### PR TITLE
Hunter each and update dhcp

### DIFF
--- a/etc/templates/dhcp
+++ b/etc/templates/dhcp
@@ -1,0 +1,7 @@
+  host %NODENAME% {
+    hardware ethernet %HWADDR%;
+    option host-name "%NODENAME%.prv.cluster.local";
+    option routers %HOSTIP%;
+    filename "/pxelinux.0";
+    fixed-address %FIXEDADDR%;
+  }

--- a/lib/actions/each
+++ b/lib/actions/each
@@ -1,0 +1,74 @@
+: '
+: NAME: each
+: SYNOPSIS: Iterator through the gender groups
+: VERSION: 1.0.0
+: '
+#==============================================================================
+# Copyright (C) 2007-2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+usage()
+{
+  echo "(c) 2008-2011 Alces Software Ltd & Stephen F Norledge"
+  echo "each command is used to iterate over the nodes within a gender groups"
+  echo "usage: metal each -g <gender> -c <command>"
+  echo "  options:"
+  echo "    -g specify gender nodes groups"
+  echo "    -c specify command to be used by the iterator"
+  echo "  parameters:"
+  echo "    <gender> node name or gender name"
+  echo "    <command> string containing the command"
+  echo "  Command Variables:"
+  echo "    %node% is replaced with the specific node name"
+  echo "    %index% is replaced with the index number of the loop"
+  echo
+}
+
+while ! [ -z "${*}" ]; do
+  case "${1}" in
+    '-g')
+      NODEGROUP="${2}"
+      shift 1
+      ;;
+    '-c')
+      CMD="${2}"
+      shift 1
+      ;;
+  esac
+  shift 1
+done
+
+if [ -z "$NODEGROUP" ]; then
+  echo "Gender group is required, -g <gender>" >&2
+  exit 1
+fi
+
+if [ -z "$CMD" ]; then
+  echo "Command is required, -c <command>" >&2
+  exit 1
+fi
+
+index=0
+nodeattr -n $NODEGROUP | while read node; do
+  ((index++))
+  echo $CMD | sed "s/%node%/${node}/g" |\
+  sed "s/%index%/${index}/g" | bash
+done

--- a/lib/actions/each
+++ b/lib/actions/each
@@ -36,7 +36,7 @@ usage()
   echo "  parameters:"
   echo "    <gender> node name or gender name"
   echo "    <command> string containing the command"
-  echo "  Command Variables:"
+  echo "  command variables:"
   echo "    %node% is replaced with the specific node name"
   echo "    %index% is replaced with the index number of the loop"
   echo
@@ -51,6 +51,10 @@ while ! [ -z "${*}" ]; do
     '-c')
       CMD="${2}"
       shift 1
+      ;;
+    '-h'|'--help')
+      usage
+      exit 0
       ;;
   esac
   shift 1
@@ -72,3 +76,4 @@ nodeattr -n $NODEGROUP | while read node; do
   echo $CMD | sed "s/%node%/${node}/g" |\
   sed "s/%index%/${index}/g" | bash
 done
+exit 0

--- a/lib/ruby/lib/alces/stack/hunter/cli.rb
+++ b/lib/ruby/lib/alces/stack/hunter/cli.rb
@@ -58,12 +58,12 @@ module Alces
                required: true
 
         flag :update_dhcp,
-               'Adds/updates the entry in dhcp.hosts while hunting for mac addresses',
+               'Adds/updates the entry in dhcpd.hosts while hunting for mac addresses',
                '--update-dhcp',
                default: false
 
         option :template,
-                'Specify which template file for updating dhcp.hosts',
+                'Specify which template file for updating dhcpd.hosts',
                 '--template',
                 default: "#{ENV['alces_BASE']}/etc/templates/dhcp"
 

--- a/lib/ruby/lib/alces/stack/hunter/cli.rb
+++ b/lib/ruby/lib/alces/stack/hunter/cli.rb
@@ -57,11 +57,15 @@ module Alces
                default: 0,
                required: true
 
-        option :cobbler_interface,
-               'Specify cobbler interface',
-               '--cobblerinterface',
-               default: 'eth0',
-               required: true
+        flag :update_dhcp,
+               'Adds/updates the entry in dhcp.hosts while hunting for mac addresses',
+               '--update-dhcp',
+               default: false
+
+        option :template,
+                'Specify which template file for updating dhcp.hosts',
+                '--template',
+                default: "#{ENV['alces_BASE']}/etc/templates/dhcp"
 
         def setup_signal_handler
           trap('INT') do
@@ -79,6 +83,8 @@ module Alces
                      name: hostname,
                      name_sequence_start: sequence_start,
                      name_sequence_length: sequence_length,
+                     update_dhcp_flag: update_dhcp,
+                     template: template
                      )
         end
       end

--- a/lib/ruby/lib/alces/stack/hunter/cli.rb
+++ b/lib/ruby/lib/alces/stack/hunter/cli.rb
@@ -69,6 +69,7 @@ module Alces
 
         def setup_signal_handler
           trap('INT') do
+            `systemctl restart dhcpd` if update_dhcp
             STDERR.puts "Exiting..." unless @exiting
             @exiting = true
             Kernel.exit(0)


### PR DESCRIPTION
Fix includes the each tool specified in #1 

It also includes the updates to hunter that log the output to /var/log/metalware/hunter.log. Hunter now has the option to update the dhcpd.hosts as mentioned in #3 