### PR TITLE
Recursive templater

### DIFF
--- a/lib/ruby/lib/alces/stack/hosts/cli.rb
+++ b/lib/ruby/lib/alces/stack/hosts/cli.rb
@@ -31,17 +31,27 @@ module Alces
 
         root_only
         name 'metal hosts'
-        description "Modifies the hosts file"
+        description "Modifies the hosts file, modifier flag (e.g. --add) is required"
         log_to File.join(Alces::Stack.config.log_root,'alces-node-ho.log')
 
-        flag    :dry_run_flag,
-                'Prints the template output without modifying files',
-                '-n', '--dry-run',
+        option  :nodename,
+                'Node name to be modified',
+                '-n', '--node-name',
+                default: false
+
+        option  :nodegroup,
+                'Node group to be modified, overrides --node-name',
+                '-g', '--node-group',
                 default: false
 
         flag    :add_flag,
                 'Adds a new entry to /etc/hosts',
                 '-a', '--add',
+                default: false
+
+        option  :json,
+                'JSON file or string containing additional templating parameters',
+                '-j', '--additional-parameters',
                 default: false
 
         option  :template,
@@ -54,19 +64,9 @@ module Alces
                 '--template-options',
                 default: false
 
-        option  :nodename,
-                'Node name to be modified',
-                '--nodename',
-                default: ""
-
-        option  :nodegroup,
-                'Node group to be modified, overrides --nodename',
-                '-g', '--nodegroup',
-                default: false
-
-        option  :json,
-                'JSON file or string containing additional templating parameters',
-                '-j', '--additional-parameters',
+        flag    :dry_run_flag,
+                'Prints the template output without modifying files',
+                '-x', '--dry-run',
                 default: false
 
         def setup_signal_handler
@@ -81,7 +81,7 @@ module Alces
           options = {
             JSON: true,
             ITERATOR: true,
-            nodename: "Value specified by --nodename"
+            nodename: "Value specified by --node-name"
           }
           Alces::Stack::Templater.show_options(options)
           exit 0

--- a/lib/ruby/lib/alces/stack/hosts/run.rb
+++ b/lib/ruby/lib/alces/stack/hosts/run.rb
@@ -21,6 +21,7 @@
 #==============================================================================
 require 'alces/tools/logging'
 require 'alces/tools/execution'
+require 'alces/tools/cli'
 require "alces/stack/templater"
 require 'alces/stack/iterator'
 
@@ -43,11 +44,15 @@ module Alces
         end
 
         def run!
+          raise "Requires a node name or node group" if !@template_parameters[:nodename] and !@nodegroup
+
           case
           when @dry_run_flag
             lambda = dry_run
           when @add_flag
             lambda = -> (json) {add(json)}
+          else
+            raise "Could not modify hosts, see 'metal hosts -h'"
           end
 
           Alces::Stack::Iterator.new(@nodegroup, lambda, @json) if !lambda.nil?
@@ -57,6 +62,8 @@ module Alces
           case
           when @add_flag
             lambda = -> (json) {puts_template(json)}
+          else
+            raise "Could not modify hosts, see 'metal hosts -h'"
           end
           return lambda
         end

--- a/lib/ruby/lib/alces/stack/hunter/cli.rb
+++ b/lib/ruby/lib/alces/stack/hunter/cli.rb
@@ -66,7 +66,7 @@ module Alces
         option :template,
                 'Specify which template file for updating dhcpd.hosts',
                 '--template',
-                default: "#{ENV['alces_BASE']}/etc/templates/hunter/dhcp"
+                default: "#{ENV['alces_BASE']}/etc/templates/hunter/dhcp.erb"
 
         flag    :template_options,
                 'Display the templating parameters',


### PR DESCRIPTION
Fixed some bugs in metal hosts if no inputs where given and fixed the default template in hunter.

Updated the templater so it recursively replaces the parameters. It is now possible to reference a parameter tag within another parameter. The recursion limit is 100.