### PR TITLE
Added options parser class

### DIFF
--- a/lib/ruby/lib/alces/stack/options.rb
+++ b/lib/ruby/lib/alces/stack/options.rb
@@ -1,0 +1,40 @@
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+module Alces
+  module Stack
+    class Options
+      def initialize(options = {})
+        @options = options
+      end
+
+      def method_missing(s, *a, &b)
+        if @options.key?(s)
+          @options[s]
+        elsif s[-1] == "?"
+          !!@options[s[0...-1].to_sym]
+        else
+          super
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Created the `Options` parser which converts the hash input from the `cli` to a object that can be queried  form the `action`.

I believe is will be removed in the updated version of metalware but is required for `status1.2` to work