### PR TITLE
Changes to CLI

### DIFF
--- a/lib/ruby/lib/alces/stack/kickstart/cli.rb
+++ b/lib/ruby/lib/alces/stack/kickstart/cli.rb
@@ -33,8 +33,7 @@ module Alces
         root_only
         name 'metal kickstart'
         description "Renders kickstart templates"
-        log_to File.join(Alces::Stack.config.log_root,'alces-node-ho.log')
-
+        
         option  :nodename,
                 'Node name to be modified',
                 '-n', '--node-name',

--- a/lib/ruby/lib/alces/stack/status/cli.rb
+++ b/lib/ruby/lib/alces/stack/status/cli.rb
@@ -45,18 +45,20 @@ module Alces
                 '-g', '--node-group',
                 default: false
 
-        option  :wait,
+        option  :time_limit,
                 'How long to wait in seconds. Minimum 5s',
                 '-w', '--wait',
                 default: "5"
 
+        option  :thread_limit,
+                'Limit on number of tasks to run in parallel',
+                '-t', '--thread-limit',
+                default: 10
+
         def assert_preconditions!
           msg = "metal status #{ARGV.to_s.gsub(/[\[\],\"]/, "")}"
-          @status_log = Alces::Stack::Log.create_log("/var/log/metalware/status.log")
           Alces::Stack::Log.progname = "status"
-          @status_log.progname = "status"
           Alces::Stack::Log.info msg
-          @status_log.info "#{msg} , #{Process.pid}"
           self.class.assert_preconditions!
         end
 
@@ -64,7 +66,8 @@ module Alces
           Alces::Stack::Status.run!(
               nodename: nodename,
               group: group,
-              wait: wait.to_i < 5 ? 5 : wait.to_i
+              thread_limit: thread_limit,
+              time_limit: time_limit.to_i < 5 ? 5 : time_limit.to_i
             )
         rescue => e
           Alces::Stack::Log.fatal e.inspect


### PR DESCRIPTION
Required changes the CLI to match the new `status` tool. Also removes references to some logs that no longer exist in both `kickstart` and `status`