### PR TITLE
Refactoring templater

### DIFF
--- a/metalware-new/spec/commands/build_spec.rb
+++ b/metalware-new/spec/commands/build_spec.rb
@@ -48,12 +48,12 @@ describe Metalware::Commands::Build do
 
   context 'when called without group argument' do
     it 'renders default templates for given node' do
-      expect(Metalware::Templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/kickstart/default',
         '/var/lib/metalware/rendered/kickstart/testnode01',
         hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(Metalware::Templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/pxelinux/default',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         hash_including(nodename: 'testnode01', index: 0)
@@ -63,12 +63,12 @@ describe Metalware::Commands::Build do
     end
 
     it 'uses different templates if template options passed' do
-      expect(Metalware::Templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/kickstart/my_kickstart',
         '/var/lib/metalware/rendered/kickstart/testnode01',
         hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(Metalware::Templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         hash_including(nodename: 'testnode01', index: 0)
@@ -85,8 +85,8 @@ describe Metalware::Commands::Build do
       time_to_wait = 0.2
       use_mock_nodes(not_built_nodes: 'testnode01')
 
-      allow(Metalware::Templater).to receive(:save)
-      expect(Metalware::Templater).to receive(:save).with(
+      allow(Metalware::Templater).to receive(:render_to_file)
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/pxelinux/default',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         hash_including(nodename: 'testnode01', firstboot: true)
@@ -96,13 +96,13 @@ describe Metalware::Commands::Build do
     end
 
     it 'renders pxelinux twice with firstboot switched if node builds' do
-      allow(Metalware::Templater).to receive(:save)
-      expect(Metalware::Templater).to receive(:save).with(
+      allow(Metalware::Templater).to receive(:render_to_file)
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/pxelinux/default',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         hash_including(nodename: 'testnode01', firstboot: true)
       ).once.ordered
-      expect(Metalware::Templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/pxelinux/default',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         hash_including(nodename: 'testnode01', firstboot: false)
@@ -119,23 +119,23 @@ describe Metalware::Commands::Build do
     end
 
     it 'renders templates for each node' do
-      allow(Metalware::Templater).to receive(:save)
-      expect(Metalware::Templater).to receive(:save).with(
+      allow(Metalware::Templater).to receive(:render_to_file)
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/kickstart/my_kickstart',
         '/var/lib/metalware/rendered/kickstart/testnode01',
         hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(Metalware::Templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(Metalware::Templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/kickstart/my_kickstart',
         '/var/lib/metalware/rendered/kickstart/testnode02',
         hash_including(nodename: 'testnode02', index: 1)
       )
-      expect(Metalware::Templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:render_to_file).with(
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
         '/var/lib/tftpboot/pxelinux.cfg/testnode02_HEX_IP',
         hash_including(nodename: 'testnode02', index: 1)

--- a/metalware-new/spec/commands/build_spec.rb
+++ b/metalware-new/spec/commands/build_spec.rb
@@ -86,7 +86,7 @@ describe Metalware::Commands::Build do
       use_mock_nodes(not_built_nodes: 'testnode01')
 
       expect(
-        Metalware::Templater::Combiner
+        Metalware::Templater
       ).to receive(:new).once.ordered.with(
         hash_including(firstboot: true)
       ).and_return(@templater)
@@ -100,7 +100,7 @@ describe Metalware::Commands::Build do
 
     it 'renders pxelinux twice with firstboot switched if node builds' do
       expect(
-        Metalware::Templater::Combiner
+        Metalware::Templater
       ).to receive(:new).once.ordered.with(
         hash_including(firstboot: true)
       ).and_return(@templater)
@@ -109,7 +109,7 @@ describe Metalware::Commands::Build do
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP'
       ).once.ordered
       expect(
-        Metalware::Templater::Combiner
+        Metalware::Templater
       ).to receive(:new).once.ordered.with(
         hash_including(firstboot: false)
       ).and_return(@templater)

--- a/metalware-new/spec/commands/build_spec.rb
+++ b/metalware-new/spec/commands/build_spec.rb
@@ -42,37 +42,37 @@ describe Metalware::Commands::Build do
   end
 
   before :each do
-    SpecUtils.use_mock_templater(self)
-    allow(@templater).to receive(:save)
     use_mock_nodes
     SpecUtils.use_unit_test_config(self)
   end
 
   context 'when called without group argument' do
     it 'renders default templates for given node' do
-      SpecUtils.expect_it_templates_for_single_node(self)
-      expect(@templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/kickstart/default',
-        '/var/lib/metalware/rendered/kickstart/testnode01'
+        '/var/lib/metalware/rendered/kickstart/testnode01',
+        hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(@templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/pxelinux/default',
-        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP'
-      )
+        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
+        hash_including(nodename: 'testnode01', index: 0)
+      ).at_least(:once)
 
       run_build('testnode01')
     end
 
     it 'uses different templates if template options passed' do
-      SpecUtils.expect_it_templates_for_single_node(self)
-      expect(@templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/kickstart/my_kickstart',
-        '/var/lib/metalware/rendered/kickstart/testnode01'
+        '/var/lib/metalware/rendered/kickstart/testnode01',
+        hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(@templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
-        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP'
-      )
+        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
+        hash_including(nodename: 'testnode01', index: 0)
+      ).at_least(:once)
 
       run_build(
         'testnode01',
@@ -85,37 +85,27 @@ describe Metalware::Commands::Build do
       time_to_wait = 0.2
       use_mock_nodes(not_built_nodes: 'testnode01')
 
-      expect(
-        Metalware::Templater
-      ).to receive(:new).once.ordered.with(
-        hash_including(firstboot: true)
-      ).and_return(@templater)
-      expect(@templater).to receive(:save).with(
+      allow(Metalware::Templater).to receive(:save)
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/pxelinux/default',
-        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP'
-      ).once.ordered
+        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
+        hash_including(nodename: 'testnode01', firstboot: true)
+      ).once
 
       expect_runs_longer_than(time_to_wait) { run_build('testnode01') }
     end
 
     it 'renders pxelinux twice with firstboot switched if node builds' do
-      expect(
-        Metalware::Templater
-      ).to receive(:new).once.ordered.with(
-        hash_including(firstboot: true)
-      ).and_return(@templater)
-      expect(@templater).to receive(:save).with(
+      allow(Metalware::Templater).to receive(:save)
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/pxelinux/default',
-        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP'
+        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
+        hash_including(nodename: 'testnode01', firstboot: true)
       ).once.ordered
-      expect(
-        Metalware::Templater
-      ).to receive(:new).once.ordered.with(
-        hash_including(firstboot: false)
-      ).and_return(@templater)
-      expect(@templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/pxelinux/default',
-        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP'
+        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
+        hash_including(nodename: 'testnode01', firstboot: false)
       ).once.ordered
 
        run_build('testnode01')
@@ -129,22 +119,26 @@ describe Metalware::Commands::Build do
     end
 
     it 'renders templates for each node' do
-      SpecUtils.expect_it_templates_for_each_node(self)
-      expect(@templater).to receive(:save).with(
+      allow(Metalware::Templater).to receive(:save)
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/kickstart/my_kickstart',
-        '/var/lib/metalware/rendered/kickstart/testnode01'
+        '/var/lib/metalware/rendered/kickstart/testnode01',
+        hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(@templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
-        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP'
+        '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
+        hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(@templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/kickstart/my_kickstart',
-        '/var/lib/metalware/rendered/kickstart/testnode02'
+        '/var/lib/metalware/rendered/kickstart/testnode02',
+        hash_including(nodename: 'testnode02', index: 1)
       )
-      expect(@templater).to receive(:save).with(
+      expect(Metalware::Templater).to receive(:save).with(
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
-        '/var/lib/tftpboot/pxelinux.cfg/testnode02_HEX_IP'
+        '/var/lib/tftpboot/pxelinux.cfg/testnode02_HEX_IP',
+        hash_including(nodename: 'testnode02', index: 1)
       )
 
       run_build(

--- a/metalware-new/spec/commands/hosts_spec.rb
+++ b/metalware-new/spec/commands/hosts_spec.rb
@@ -20,7 +20,7 @@ describe Metalware::Commands::Hosts do
 
   context 'when called without group argument' do
     it 'appends to hosts file by default' do
-      expect(Metalware::Templater).to receive(:append).with(
+      expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
         hash_including(nodename: 'testnode01', index: 0)
@@ -30,7 +30,7 @@ describe Metalware::Commands::Hosts do
     end
 
     it 'uses a different template if template option passed' do
-      expect(Metalware::Templater).to receive(:append).with(
+      expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
         '/var/lib/metalware/repo/hosts/my_template',
         '/etc/hosts',
         hash_including(nodename: 'testnode01', index: 0)
@@ -41,7 +41,7 @@ describe Metalware::Commands::Hosts do
 
     context 'when dry-run' do
       it 'outputs what would be appended' do
-        expect(Metalware::Templater).to receive(:file).with(
+        expect(Metalware::Templater).to receive(:render).with(
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode01')
         )
@@ -54,17 +54,17 @@ describe Metalware::Commands::Hosts do
   context 'when called for group' do
     it 'appends to hosts file by default' do
       # XXX Dedupe these very similar assertions
-      expect(Metalware::Templater).to receive(:append).with(
+      expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
         hash_including(nodename: 'testnode01', index: 0)
       )
-      expect(Metalware::Templater).to receive(:append).with(
+      expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
         hash_including(nodename: 'testnode02', index: 1)
       )
-      expect(Metalware::Templater).to receive(:append).with(
+      expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
         hash_including(nodename: 'testnode03', index: 2)
@@ -76,15 +76,15 @@ describe Metalware::Commands::Hosts do
     context 'when dry-run' do
       it 'outputs what would be appended' do
         # XXX Dedupe these too
-        expect(Metalware::Templater).to receive(:file).with(
+        expect(Metalware::Templater).to receive(:render).with(
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode01', index: 0)
         )
-        expect(Metalware::Templater).to receive(:file).with(
+        expect(Metalware::Templater).to receive(:render).with(
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode02', index: 1)
         )
-        expect(Metalware::Templater).to receive(:file).with(
+        expect(Metalware::Templater).to receive(:render).with(
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode03', index: 2)
         )

--- a/metalware-new/spec/commands/hosts_spec.rb
+++ b/metalware-new/spec/commands/hosts_spec.rb
@@ -41,7 +41,7 @@ describe Metalware::Commands::Hosts do
 
     context 'when dry-run' do
       it 'outputs what would be appended' do
-        expect(Metalware::Templater).to receive(:render).with(
+        expect(Metalware::Templater).to receive(:render_to_stdout).with(
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode01')
         )
@@ -76,15 +76,15 @@ describe Metalware::Commands::Hosts do
     context 'when dry-run' do
       it 'outputs what would be appended' do
         # XXX Dedupe these too
-        expect(Metalware::Templater).to receive(:render).with(
+        expect(Metalware::Templater).to receive(:render_to_stdout).with(
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode01', index: 0)
         )
-        expect(Metalware::Templater).to receive(:render).with(
+        expect(Metalware::Templater).to receive(:render_to_stdout).with(
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode02', index: 1)
         )
-        expect(Metalware::Templater).to receive(:render).with(
+        expect(Metalware::Templater).to receive(:render_to_stdout).with(
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode03', index: 2)
         )

--- a/metalware-new/spec/commands/hosts_spec.rb
+++ b/metalware-new/spec/commands/hosts_spec.rb
@@ -14,27 +14,26 @@ describe Metalware::Commands::Hosts do
   end
 
   before :each do
-    SpecUtils.use_mock_templater(self)
     SpecUtils.use_mock_genders(self)
     SpecUtils.use_unit_test_config(self)
   end
 
   context 'when called without group argument' do
     it 'appends to hosts file by default' do
-      SpecUtils.expect_it_templates_for_single_node(self)
-      expect(@templater).to receive(:append).with(
+      expect(Metalware::Templater).to receive(:append).with(
         '/var/lib/metalware/repo/hosts/default',
-        '/etc/hosts'
+        '/etc/hosts',
+        hash_including(nodename: 'testnode01', index: 0)
       )
 
       run_hosts('testnode01')
     end
 
     it 'uses a different template if template option passed' do
-      SpecUtils.expect_it_templates_for_single_node(self)
-      expect(@templater).to receive(:append).with(
+      expect(Metalware::Templater).to receive(:append).with(
         '/var/lib/metalware/repo/hosts/my_template',
-        '/etc/hosts'
+        '/etc/hosts',
+        hash_including(nodename: 'testnode01', index: 0)
       )
 
       run_hosts('testnode01', template: 'my_template')
@@ -42,9 +41,9 @@ describe Metalware::Commands::Hosts do
 
     context 'when dry-run' do
       it 'outputs what would be appended' do
-        SpecUtils.expect_it_templates_for_single_node(self)
-        expect(@templater).to receive(:file).with(
-          '/var/lib/metalware/repo/hosts/default'
+        expect(Metalware::Templater).to receive(:file).with(
+          '/var/lib/metalware/repo/hosts/default',
+          hash_including(nodename: 'testnode01')
         )
 
         run_hosts('testnode01', dry_run: true)
@@ -54,11 +53,21 @@ describe Metalware::Commands::Hosts do
 
   context 'when called for group' do
     it 'appends to hosts file by default' do
-      SpecUtils.expect_it_templates_for_each_node(self)
-
-      expect(@templater).to receive(:append).thrice.with(
+      # XXX Dedupe these very similar assertions
+      expect(Metalware::Templater).to receive(:append).with(
         '/var/lib/metalware/repo/hosts/default',
-        '/etc/hosts'
+        '/etc/hosts',
+        hash_including(nodename: 'testnode01', index: 0)
+      )
+      expect(Metalware::Templater).to receive(:append).with(
+        '/var/lib/metalware/repo/hosts/default',
+        '/etc/hosts',
+        hash_including(nodename: 'testnode02', index: 1)
+      )
+      expect(Metalware::Templater).to receive(:append).with(
+        '/var/lib/metalware/repo/hosts/default',
+        '/etc/hosts',
+        hash_including(nodename: 'testnode03', index: 2)
       )
 
       run_hosts('testnodes', group: true)
@@ -66,10 +75,18 @@ describe Metalware::Commands::Hosts do
 
     context 'when dry-run' do
       it 'outputs what would be appended' do
-        SpecUtils.expect_it_templates_for_each_node(self)
-
-        expect(@templater).to receive(:file).thrice.with(
-          '/var/lib/metalware/repo/hosts/default'
+        # XXX Dedupe these too
+        expect(Metalware::Templater).to receive(:file).with(
+          '/var/lib/metalware/repo/hosts/default',
+          hash_including(nodename: 'testnode01', index: 0)
+        )
+        expect(Metalware::Templater).to receive(:file).with(
+          '/var/lib/metalware/repo/hosts/default',
+          hash_including(nodename: 'testnode02', index: 1)
+        )
+        expect(Metalware::Templater).to receive(:file).with(
+          '/var/lib/metalware/repo/hosts/default',
+          hash_including(nodename: 'testnode03', index: 2)
         )
 
         run_hosts('testnodes', group: true, dry_run: true)

--- a/metalware-new/spec/integration/build_spec.rb
+++ b/metalware-new/spec/integration/build_spec.rb
@@ -126,7 +126,7 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode01_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater::Combiner.new({
+          Metalware::Templater.new({
             nodename: 'testnode01', index: 0, firstboot: false
           }).file(PXELINUX_TEMPLATE)
         )
@@ -137,7 +137,7 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode02_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater::Combiner.new({
+          Metalware::Templater.new({
             nodename: 'testnode02', index: 1, firstboot: false
           }).file(PXELINUX_TEMPLATE)
         )
@@ -148,7 +148,7 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode02_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater::Combiner.new({
+          Metalware::Templater.new({
             nodename: 'testnode02', index: 1, firstboot: true
           }).file(PXELINUX_TEMPLATE)
         )

--- a/metalware-new/spec/integration/build_spec.rb
+++ b/metalware-new/spec/integration/build_spec.rb
@@ -126,7 +126,7 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode01_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.file(PXELINUX_TEMPLATE, {
+          Metalware::Templater.render(PXELINUX_TEMPLATE, {
             nodename: 'testnode01', index: 0, firstboot: false
           })
         )
@@ -137,7 +137,7 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode02_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.file(PXELINUX_TEMPLATE, {
+          Metalware::Templater.render(PXELINUX_TEMPLATE, {
             nodename: 'testnode02', index: 1, firstboot: false
           })
         )
@@ -148,7 +148,7 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode02_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.file(PXELINUX_TEMPLATE, {
+          Metalware::Templater.render(PXELINUX_TEMPLATE, {
             nodename: 'testnode02', index: 1, firstboot: true
           })
         )

--- a/metalware-new/spec/integration/build_spec.rb
+++ b/metalware-new/spec/integration/build_spec.rb
@@ -126,9 +126,9 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode01_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.new({
+          Metalware::Templater.file(PXELINUX_TEMPLATE, {
             nodename: 'testnode01', index: 0, firstboot: false
-          }).file(PXELINUX_TEMPLATE)
+          })
         )
       end
 
@@ -137,9 +137,9 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode02_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.new({
+          Metalware::Templater.file(PXELINUX_TEMPLATE, {
             nodename: 'testnode02', index: 1, firstboot: false
-          }).file(PXELINUX_TEMPLATE)
+          })
         )
       end
 
@@ -148,9 +148,9 @@ describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode02_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.new({
+          Metalware::Templater.file(PXELINUX_TEMPLATE, {
             nodename: 'testnode02', index: 1, firstboot: true
-          }).file(PXELINUX_TEMPLATE)
+          })
         )
       end
 

--- a/metalware-new/spec/spec_utils.rb
+++ b/metalware-new/spec/spec_utils.rb
@@ -16,9 +16,9 @@ module SpecUtils
 
     def use_mock_templater(example_group)
       example_group.instance_exec do
-        @templater = object_double(Metalware::Templater::Combiner.new)
+        @templater = object_double(Metalware::Templater.new)
         allow(
-          Metalware::Templater::Combiner
+          Metalware::Templater
         ).to receive(:new).and_return(
           @templater
         )
@@ -39,7 +39,7 @@ module SpecUtils
     def expect_it_templates_for_each_node(example_group)
       example_group.instance_exec do
         expect(
-          Metalware::Templater::Combiner
+          Metalware::Templater
         ).to receive(:new).with(
           hash_including(
             nodename: 'testnode01',
@@ -47,7 +47,7 @@ module SpecUtils
           )
         ).ordered
         expect(
-          Metalware::Templater::Combiner
+          Metalware::Templater
         ).to receive(:new).with(
           hash_including(
             nodename: 'testnode02',
@@ -59,7 +59,7 @@ module SpecUtils
 
     def expect_it_templates_for_single_node(example_group)
       example_group.instance_exec do
-        expect(Metalware::Templater::Combiner).to receive(:new).with(
+        expect(Metalware::Templater).to receive(:new).with(
           hash_including(nodename: 'testnode01')
         )
       end

--- a/metalware-new/spec/spec_utils.rb
+++ b/metalware-new/spec/spec_utils.rb
@@ -14,53 +14,11 @@ module SpecUtils
       end
     end
 
-    def use_mock_templater(example_group)
-      example_group.instance_exec do
-        @templater = object_double(Metalware::Templater.new)
-        allow(
-          Metalware::Templater
-        ).to receive(:new).and_return(
-          @templater
-        )
-      end
-    end
-
     def use_unit_test_config(example_group)
       example_group.instance_exec do
         stub_const(
           'Metalware::Constants::DEFAULT_CONFIG_PATH',
           SpecUtils.fixtures_config('unit-test.yaml')
-        )
-      end
-    end
-
-    # Expectations.
-
-    def expect_it_templates_for_each_node(example_group)
-      example_group.instance_exec do
-        expect(
-          Metalware::Templater
-        ).to receive(:new).with(
-          hash_including(
-            nodename: 'testnode01',
-            index: 0
-          )
-        ).ordered
-        expect(
-          Metalware::Templater
-        ).to receive(:new).with(
-          hash_including(
-            nodename: 'testnode02',
-            index: 1
-          )
-        ).ordered
-      end
-    end
-
-    def expect_it_templates_for_single_node(example_group)
-      example_group.instance_exec do
-        expect(Metalware::Templater).to receive(:new).with(
-          hash_including(nodename: 'testnode01')
         )
       end
     end

--- a/metalware-new/spec/templater_spec.rb
+++ b/metalware-new/spec/templater_spec.rb
@@ -13,7 +13,7 @@ describe Metalware::Templater do
   def expect_renders(template_parameters, expected)
     # Strip trailing spaces from rendered output to make comparisons less
     # brittle.
-    rendered = Metalware::Templater.file(
+    rendered = Metalware::Templater.render(
       TEST_TEMPLATE_PATH, template_parameters
     ).gsub(/\s+\n/, "\n")
 

--- a/metalware-new/spec/templater_spec.rb
+++ b/metalware-new/spec/templater_spec.rb
@@ -9,7 +9,7 @@ TEST_REPO_PATH = File.join(FIXTURES_PATH, 'repo')
 TEST_HUNTER_PATH = File.join(FIXTURES_PATH, 'cache/hunter.yaml')
 
 
-describe Metalware::Templater::Combiner do
+describe Metalware::Templater do
   def expect_renders(templater, expected)
     # Strip trailing spaces from rendered output to make comparisons less
     # brittle.
@@ -21,7 +21,7 @@ describe Metalware::Templater::Combiner do
   describe '#file' do
     context 'when templater passed no parameters' do
       it 'renders template with no extra parameters' do
-        templater = Metalware::Templater::Combiner.new
+        templater = Metalware::Templater.new
         expected = <<-EOF
         This is a test template
         some_passed_value:
@@ -38,7 +38,7 @@ describe Metalware::Templater::Combiner do
 
     context 'when templater passed parameters' do
       it 'renders template with extra passed parameters' do
-        templater = Metalware::Templater::Combiner.new({
+        templater = Metalware::Templater.new({
           some_passed_value: 'my_value'
         })
         expected = <<-EOF
@@ -61,7 +61,7 @@ describe Metalware::Templater::Combiner do
       end
 
       it 'renders template with repo parameters' do
-        templater = Metalware::Templater::Combiner.new
+        templater = Metalware::Templater.new
         expected = <<-EOF
         This is a test template
         some_passed_value:
@@ -79,8 +79,8 @@ describe Metalware::Templater::Combiner do
         stub_const('Metalware::Constants::MAXIMUM_RECURSIVE_CONFIG_DEPTH', 3)
 
         expect{
-          Metalware::Templater::Combiner.new
-        }.to raise_error(Metalware::Templater::Combiner::LoopErbError)
+          Metalware::Templater.new
+        }.to raise_error(Metalware::Templater::LoopErbError)
       end
     end
   end
@@ -115,7 +115,7 @@ describe Metalware::Templater::Combiner do
 
     context 'without passed parameters' do
       it 'is created with default values' do
-        templater = Metalware::Templater::Combiner.new
+        templater = Metalware::Templater.new
         magic_namespace = templater.config.alces
 
         expect(magic_namespace.index).to eq(0)
@@ -128,7 +128,7 @@ describe Metalware::Templater::Combiner do
 
     context 'with passed parameters' do
       it 'overrides defaults with parameter values, where applicable' do
-        templater = Metalware::Templater::Combiner.new({
+        templater = Metalware::Templater.new({
           nodename: 'testnode04',
           index: 3,
           firstboot: true,
@@ -149,7 +149,7 @@ describe Metalware::Templater::Combiner do
       end
 
       it 'loads the hunter parameter as an empty array' do
-        templater = Metalware::Templater::Combiner.new
+        templater = Metalware::Templater.new
         magic_namespace = templater.config.alces
         expect(magic_namespace.hunter).to eq(Hashie::Mash.new)
       end

--- a/metalware-new/spec/templater_spec.rb
+++ b/metalware-new/spec/templater_spec.rb
@@ -10,10 +10,12 @@ TEST_HUNTER_PATH = File.join(FIXTURES_PATH, 'cache/hunter.yaml')
 
 
 describe Metalware::Templater do
-  def expect_renders(templater, expected)
+  def expect_renders(template_parameters, expected)
     # Strip trailing spaces from rendered output to make comparisons less
     # brittle.
-    rendered = templater.file(TEST_TEMPLATE_PATH).gsub(/\s+\n/, "\n")
+    rendered = Metalware::Templater.file(
+      TEST_TEMPLATE_PATH, template_parameters
+    ).gsub(/\s+\n/, "\n")
 
     expect(rendered).to eq(expected.strip_heredoc)
   end
@@ -21,7 +23,6 @@ describe Metalware::Templater do
   describe '#file' do
     context 'when templater passed no parameters' do
       it 'renders template with no extra parameters' do
-        templater = Metalware::Templater.new
         expected = <<-EOF
         This is a test template
         some_passed_value:
@@ -32,13 +33,13 @@ describe Metalware::Templater do
         alces.index: 0
         EOF
 
-        expect_renders(templater, expected)
+        expect_renders({}, expected)
       end
     end
 
     context 'when templater passed parameters' do
       it 'renders template with extra passed parameters' do
-        templater = Metalware::Templater.new({
+        template_parameters = ({
           some_passed_value: 'my_value'
         })
         expected = <<-EOF
@@ -51,7 +52,7 @@ describe Metalware::Templater do
         alces.index: 0
         EOF
 
-        expect_renders(templater, expected)
+        expect_renders(template_parameters, expected)
       end
     end
 
@@ -61,7 +62,6 @@ describe Metalware::Templater do
       end
 
       it 'renders template with repo parameters' do
-        templater = Metalware::Templater.new
         expected = <<-EOF
         This is a test template
         some_passed_value:
@@ -72,7 +72,7 @@ describe Metalware::Templater do
         alces.index: 0
         EOF
 
-        expect_renders(templater, expected)
+        expect_renders({}, expected)
       end
 
       it 'raises if maximum recursive config depth exceeded' do

--- a/metalware-new/src/commands/build.rb
+++ b/metalware-new/src/commands/build.rb
@@ -35,29 +35,29 @@ module Metalware
       end
 
       def render_build_templates
-        @nodes.template_each firstboot: true do |templater, node|
-          render_kickstart(templater, node)
-          render_pxelinux(templater, node)
+        @nodes.template_each firstboot: true do |parameters, node|
+          render_kickstart(parameters, node)
+          render_pxelinux(parameters, node)
         end
       end
 
-      def render_kickstart(templater, node)
+      def render_kickstart(parameters, node)
         kickstart_template_path = template_path :kickstart
         # XXX Ensure this path has been created
         kickstart_save_path = File.join(
           @config.rendered_files_path, 'kickstart', node.name
         )
-        templater.save(kickstart_template_path, kickstart_save_path)
+        Templater.save(kickstart_template_path, kickstart_save_path, parameters)
       end
 
-      def render_pxelinux(templater, node)
+      def render_pxelinux(parameters, node)
         # XXX handle nodes without hexadecimal IP, i.e. nodes not in `hosts`
         # file yet - best place to do this may be when creating `Node` objects?
         pxelinux_template_path = template_path :pxelinux
         pxelinux_save_path = File.join(
           @config.pxelinux_cfg_path, node.hexadecimal_ip
         )
-        templater.save(pxelinux_template_path, pxelinux_save_path)
+        Templater.save(pxelinux_template_path, pxelinux_save_path, parameters)
       end
 
       def template_path(template_type)
@@ -97,8 +97,8 @@ module Metalware
       end
 
       def render_permanent_pxelinux_configs(nodes)
-        nodes.template_each firstboot: false do |templater, node|
-          render_pxelinux(templater, node)
+        nodes.template_each firstboot: false do |parameters, node|
+          render_pxelinux(parameters, node)
         end
       end
 

--- a/metalware-new/src/commands/build.rb
+++ b/metalware-new/src/commands/build.rb
@@ -47,7 +47,7 @@ module Metalware
         kickstart_save_path = File.join(
           @config.rendered_files_path, 'kickstart', node.name
         )
-        Templater.save(kickstart_template_path, kickstart_save_path, parameters)
+        Templater.render_to_file(kickstart_template_path, kickstart_save_path, parameters)
       end
 
       def render_pxelinux(parameters, node)
@@ -57,7 +57,7 @@ module Metalware
         pxelinux_save_path = File.join(
           @config.pxelinux_cfg_path, node.hexadecimal_ip
         )
-        Templater.save(pxelinux_template_path, pxelinux_save_path, parameters)
+        Templater.render_to_file(pxelinux_template_path, pxelinux_save_path, parameters)
       end
 
       def template_path(template_type)

--- a/metalware-new/src/commands/dhcp.rb
+++ b/metalware-new/src/commands/dhcp.rb
@@ -29,7 +29,7 @@ module Metalware
       end
 
       def render_template
-        Templater.save(
+        Templater.render_to_file(
           template_path, RENDERED_DHCPD_HOSTS_STAGING_FILE
         )
       end

--- a/metalware-new/src/commands/dhcp.rb
+++ b/metalware-new/src/commands/dhcp.rb
@@ -29,7 +29,7 @@ module Metalware
       end
 
       def render_template
-        Templater.new.save(
+        Templater.save(
           template_path, RENDERED_DHCPD_HOSTS_STAGING_FILE
         )
       end

--- a/metalware-new/src/commands/dhcp.rb
+++ b/metalware-new/src/commands/dhcp.rb
@@ -29,7 +29,7 @@ module Metalware
       end
 
       def render_template
-        Templater::Combiner.new.save(
+        Templater.new.save(
           template_path, RENDERED_DHCPD_HOSTS_STAGING_FILE
         )
       end

--- a/metalware-new/src/commands/hosts.rb
+++ b/metalware-new/src/commands/hosts.rb
@@ -28,9 +28,9 @@ module Metalware
       def add_nodes_to_hosts
         @nodes.template_each do |parameters|
           if @options.dry_run
-            puts Templater.file(template_path, parameters)
+            puts Templater.render(template_path, parameters)
           else
-            Templater.append(template_path, HOSTS_FILE, parameters)
+            Templater.render_and_append_to_file(template_path, HOSTS_FILE, parameters)
           end
         end
       end

--- a/metalware-new/src/commands/hosts.rb
+++ b/metalware-new/src/commands/hosts.rb
@@ -26,11 +26,11 @@ module Metalware
       end
 
       def add_nodes_to_hosts
-        @nodes.template_each do |templater|
+        @nodes.template_each do |parameters|
           if @options.dry_run
-            puts templater.file(template_path)
+            puts Templater.file(template_path, parameters)
           else
-            templater.append(template_path, HOSTS_FILE)
+            Templater.append(template_path, HOSTS_FILE, parameters)
           end
         end
       end

--- a/metalware-new/src/commands/hosts.rb
+++ b/metalware-new/src/commands/hosts.rb
@@ -28,7 +28,7 @@ module Metalware
       def add_nodes_to_hosts
         @nodes.template_each do |parameters|
           if @options.dry_run
-            puts Templater.render(template_path, parameters)
+            Templater.render_to_stdout(template_path, parameters)
           else
             Templater.render_and_append_to_file(template_path, HOSTS_FILE, parameters)
           end

--- a/metalware-new/src/commands/render.rb
+++ b/metalware-new/src/commands/render.rb
@@ -11,7 +11,7 @@ module Metalware
           nodename: maybe_node,
         }.reject { |param, value| value.nil? }
 
-        rendered = Templater.file(template_path, template_parameters)
+        rendered = Templater.render(template_path, template_parameters)
         puts rendered
       end
     end

--- a/metalware-new/src/commands/render.rb
+++ b/metalware-new/src/commands/render.rb
@@ -11,8 +11,7 @@ module Metalware
           nodename: maybe_node,
         }.reject { |param, value| value.nil? }
 
-        rendered = Templater.render(template_path, template_parameters)
-        puts rendered
+        Templater.render_to_stdout(template_path, template_parameters)
       end
     end
   end

--- a/metalware-new/src/commands/render.rb
+++ b/metalware-new/src/commands/render.rb
@@ -10,9 +10,8 @@ module Metalware
         template_parameters = {
           nodename: maybe_node,
         }.reject { |param, value| value.nil? }
-        templater = Templater.new(template_parameters)
 
-        rendered = templater.file(template_path)
+        rendered = Templater.file(template_path, template_parameters)
         puts rendered
       end
     end

--- a/metalware-new/src/commands/render.rb
+++ b/metalware-new/src/commands/render.rb
@@ -10,7 +10,7 @@ module Metalware
         template_parameters = {
           nodename: maybe_node,
         }.reject { |param, value| value.nil? }
-        templater = Templater::Combiner.new(template_parameters)
+        templater = Templater.new(template_parameters)
 
         rendered = templater.file(template_path)
         puts rendered

--- a/metalware-new/src/nodes.rb
+++ b/metalware-new/src/nodes.rb
@@ -33,15 +33,15 @@ module Metalware
       self.class.send(:new, nodes)
     end
 
+    # XXX Is this method still worthwhile with new Templater?
     def template_each(**additional_template_parameters, &block)
       @nodes.each_with_index do |node, index|
         template_parameters = {
           nodename: node.name,
           index: index,
         }.merge(additional_template_parameters)
-        templater = Templater.new(template_parameters)
 
-        block.call(templater, node)
+        block.call(template_parameters, node)
       end
     end
 

--- a/metalware-new/src/nodes.rb
+++ b/metalware-new/src/nodes.rb
@@ -39,7 +39,7 @@ module Metalware
           nodename: node.name,
           index: index,
         }.merge(additional_template_parameters)
-        templater = Templater::Combiner.new(template_parameters)
+        templater = Templater.new(template_parameters)
 
         block.call(templater, node)
       end

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -71,7 +71,7 @@ module Metalware
       @config = parse_config
     end
 
-    def render(filename, template_parameters={})
+    def render(filename)
       File.open(filename.chomp, 'r') do |f|
         replace_erb(f.read, @config)
       end

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -32,6 +32,31 @@ require 'nodeattr_interface'
 
 module Metalware
   class Templater
+    class << self
+      # XXX Have method to print template here, and do not expose access to
+      # `file` method directly, so can cleanly stub this for testing.
+      # XXX rename to `render`; rename other methods here appropriately too.
+      # XXX rename args in these methods - use `**parameters` for passing
+      # template parameters?
+      def file(filename, template_parameters={})
+        Templater.new(template_parameters).file(filename)
+      end
+
+      def save(template_file, save_file, template_parameters={})
+        File.open(save_file.chomp, "w") do |f|
+          f.puts file(template_file, template_parameters)
+        end
+        # Alces::Stack::Log.info "Template Saved: #{save_file}"
+      end
+
+      def append(template_file, append_file, template_parameters={})
+        File.open(append_file.chomp, 'a') do |f|
+          f.puts file(template_file, template_parameters)
+        end
+        # Alces::Stack::Log.info "Template Appended: #{append_file}"
+      end
+    end
+
     attr_reader :config
 
     # XXX Have this just take allowed keyword parameters:
@@ -47,30 +72,11 @@ module Metalware
       @config = parse_config
     end
 
-    # XXX Have method to print template here, and do not expose access to
-    # `file` method directly, so can cleanly stub this for testing.
-    # XXX need `template_parameters` param? Child class, which is only one
-    # used (outside of tests), forbids this.
     # XXX rename to `render`; rename other methods here appropriately too.
-    # XXX `template_parameters` now unused here
     def file(filename, template_parameters={})
       File.open(filename.chomp, 'r') do |f|
         replace_erb(f.read, @config)
       end
-    end
-
-    def save(template_file, save_file, template_parameters={})
-      File.open(save_file.chomp, "w") do |f|
-        f.puts file(template_file, template_parameters)
-      end
-      # Alces::Stack::Log.info "Template Saved: #{save_file}"
-    end
-
-    def append(template_file, append_file, template_parameters={})
-      File.open(append_file.chomp, 'a') do |f|
-        f.puts file(template_file, template_parameters)
-      end
-      # Alces::Stack::Log.info "Template Appended: #{append_file}"
     end
 
     # XXX Make this not a nested class, also possibly should use common error

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -37,20 +37,20 @@ module Metalware
       # `file` method directly, so can cleanly stub this for testing.
       # XXX rename args in these methods - use `**parameters` for passing
       # template parameters?
-      def render(filename, template_parameters={})
-        Templater.new(template_parameters).render(filename)
+      def render(template, template_parameters={})
+        Templater.new(template_parameters).render(template)
       end
 
-      def render_to_file(template_file, save_file, template_parameters={})
+      def render_to_file(template, save_file, template_parameters={})
         File.open(save_file.chomp, "w") do |f|
-          f.puts render(template_file, template_parameters)
+          f.puts render(template, template_parameters)
         end
         # Alces::Stack::Log.info "Template Saved: #{save_file}"
       end
 
-      def render_and_append_to_file(template_file, append_file, template_parameters={})
+      def render_and_append_to_file(template, append_file, template_parameters={})
         File.open(append_file.chomp, 'a') do |f|
-          f.puts render(template_file, template_parameters)
+          f.puts render(template, template_parameters)
         end
         # Alces::Stack::Log.info "Template Appended: #{append_file}"
       end
@@ -62,17 +62,17 @@ module Metalware
     # - nodename
     # - index
     # - what else?
-    def initialize(hash={})
-      passed_magic_parameters = hash.select do |k,v|
+    def initialize(parameters={})
+      passed_magic_parameters = parameters.select do |k,v|
         [:index, :nodename, :firstboot].include?(k) && !v.nil?
       end
       @magic_namespace = MagicNamespace.new(passed_magic_parameters)
-      @passed_hash = hash
+      @passed_hash = parameters
       @config = parse_config
     end
 
-    def render(filename)
-      File.open(filename.chomp, 'r') do |f|
+    def render(template)
+      File.open(template.chomp, 'r') do |f|
         replace_erb(f.read, @config)
       end
     end

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -31,248 +31,232 @@ require 'nodeattr_interface'
 # require "alces/stack/log"
 
 module Metalware
-  module Templater
-    class Handler
-      # XXX Make this use the Combiner rather than be a superclass of it, to
-      # better separate these.
-      # XXX Have method to print template here, and do not expose access to
-      # `file` method directly, so can cleanly stub this for testing.
-      # XXX need `template_parameters` param? Child class, which is only one
-      # used (outside of tests), forbids this.
-      # XXX rename to `render`; rename other methods here appropriately too.
-      def file(filename, template_parameters={})
-        File.open(filename.chomp, 'r') do |f|
-          replace_erb(f.read, template_parameters)
-        end
-      end
+  class Templater
+    attr_reader :config
 
-      def save(template_file, save_file, template_parameters={})
-        File.open(save_file.chomp, "w") do |f|
-          f.puts file(template_file, template_parameters)
-        end
-        # Alces::Stack::Log.info "Template Saved: #{save_file}"
+    # XXX Have this just take allowed keyword parameters:
+    # - nodename
+    # - index
+    # - what else?
+    def initialize(hash={})
+      passed_magic_parameters = hash.select do |k,v|
+        [:index, :nodename, :firstboot].include?(k) && !v.nil?
       end
+      @magic_namespace = MagicNamespace.new(passed_magic_parameters)
+      @passed_hash = hash
+      @config = parse_config
+    end
 
-      def append(template_file, append_file, template_parameters={})
-        File.open(append_file.chomp, 'a') do |f|
-          f.puts file(template_file, template_parameters)
-        end
-        # Alces::Stack::Log.info "Template Appended: #{append_file}"
-      end
-
-      def replace_erb(template, template_parameters)
-        parameters_binding = template_parameters.instance_eval {binding}
-        ERB.new(template).result(parameters_binding)
-      rescue StandardError => e
-        $stderr.puts "Could not parse ERB"
-        $stderr.puts template.to_s
-        $stderr.puts template_parameters.to_s
-        raise e
+    # XXX Have method to print template here, and do not expose access to
+    # `file` method directly, so can cleanly stub this for testing.
+    # XXX need `template_parameters` param? Child class, which is only one
+    # used (outside of tests), forbids this.
+    # XXX rename to `render`; rename other methods here appropriately too.
+    # XXX `template_parameters` now unused here
+    def file(filename, template_parameters={})
+      File.open(filename.chomp, 'r') do |f|
+        replace_erb(f.read, @config)
       end
     end
 
-    class Combiner < Handler
-      attr_reader :config
-
-      # XXX Have this just take allowed keyword parameters:
-      # - nodename
-      # - index
-      # - what else?
-      def initialize(hash={})
-        passed_magic_parameters = hash.select do |k,v|
-          [:index, :nodename, :firstboot].include?(k) && !v.nil?
-        end
-        @magic_namespace = MagicNamespace.new(passed_magic_parameters)
-        @passed_hash = hash
-        @config = parse_config
+    def save(template_file, save_file, template_parameters={})
+      File.open(save_file.chomp, "w") do |f|
+        f.puts file(template_file, template_parameters)
       end
+      # Alces::Stack::Log.info "Template Saved: #{save_file}"
+    end
 
-      def file(filename, template={})
-        raise HashInputError if !template.empty?
-        super(filename, @config)
+    def append(template_file, append_file, template_parameters={})
+      File.open(append_file.chomp, 'a') do |f|
+        f.puts file(template_file, template_parameters)
       end
+      # Alces::Stack::Log.info "Template Appended: #{append_file}"
+    end
 
-      # XXX Make these not nested classes, also possibly should use common
-      # error class or superclass for these.
-      class HashInputError < StandardError
-        def initialize(msg="Hash included through file method. Must be included in Combiner initializer")
-          super
-        end
+    # XXX Make this not a nested class, also possibly should use common error
+    # class or superclass.
+    class LoopErbError < StandardError
+      def initialize(msg="Input hash may contain infinitely recursive ERB")
+        super
       end
+    end
 
-      class LoopErbError < StandardError
-        def initialize(msg="Input hash may contain infinitely recursive ERB")
-          super
-        end
-      end
+    private
 
-      private
+    def replace_erb(template, template_parameters)
+      parameters_binding = template_parameters.instance_eval {binding}
+      ERB.new(template).result(parameters_binding)
+    rescue StandardError => e
+      $stderr.puts "Could not parse ERB"
+      $stderr.puts template.to_s
+      $stderr.puts template_parameters.to_s
+      raise e
+    end
 
-      def nodename
-        @magic_namespace.nodename
-      end
+    def nodename
+      @magic_namespace.nodename
+    end
 
-      # The merging of the raw combined config files, any additional passed
-      # values, and the magic `alces` namespace; this is the config prior to
-      # parsing any nested ERB values.
-      def base_config
-        @base_config ||= raw_config
-          .merge(@passed_hash)
-          .merge(alces: @magic_namespace)
-      end
+    # The merging of the raw combined config files, any additional passed
+    # values, and the magic `alces` namespace; this is the config prior to
+    # parsing any nested ERB values.
+    def base_config
+      @base_config ||= raw_config
+        .merge(@passed_hash)
+        .merge(alces: @magic_namespace)
+    end
 
-      def raw_config
-        combined_configs = {}
-        ordered_node_config_files.each do |config_name|
-          begin
-            config_path = "#{Constants::REPO_PATH}/config/#{config_name}.yaml"
-            config = YAML.load_file(config_path)
-          rescue Errno::ENOENT # Skips missing files
-          rescue StandardError => e
-            $stderr.puts "Could not parse YAML config file"
-            raise e
+    def raw_config
+      combined_configs = {}
+      ordered_node_config_files.each do |config_name|
+        begin
+          config_path = "#{Constants::REPO_PATH}/config/#{config_name}.yaml"
+          config = YAML.load_file(config_path)
+        rescue Errno::ENOENT # Skips missing files
+        rescue StandardError => e
+          $stderr.puts "Could not parse YAML config file"
+          raise e
+        else
+          if !config.is_a? Hash
+            raise "Expected YAML config file to contain a hash"
           else
-            if !config.is_a? Hash
-              raise "Expected YAML config file to contain a hash"
-            else
-              combined_configs.merge!(config)
-            end
+            combined_configs.merge!(config)
           end
         end
-        # XXX only symbolizes top-level keys, but not those in nested hashes =>
-        # confusing.
-        combined_configs.symbolize_keys
       end
+      # XXX only symbolizes top-level keys, but not those in nested hashes =>
+      # confusing.
+      combined_configs.symbolize_keys
+    end
 
-      def ordered_node_config_files
-        list = [ "all" ]
-        return list if !nodename
-        # XXX Move this to `NodeattrInterface` and use `SystemCommand.run`.
-        list_str = `nodeattr -l #{nodename} 2>/dev/null`.chomp
-        if list_str.empty? then return list end
-        list.concat(list_str.split(/\n/).reverse)
-        list.push(nodename)
-        list.uniq
-      end
+    def ordered_node_config_files
+      list = [ "all" ]
+      return list if !nodename
+      # XXX Move this to `NodeattrInterface` and use `SystemCommand.run`.
+      list_str = `nodeattr -l #{nodename} 2>/dev/null`.chomp
+      if list_str.empty? then return list end
+      list.concat(list_str.split(/\n/).reverse)
+      list.push(nodename)
+      list.uniq
+    end
 
-      def parse_config
-        current_parsed_config = base_config
+    def parse_config
+      current_parsed_config = base_config
+      current_config_string = current_parsed_config.to_s
+      previous_config_string = nil
+      count = 0
+
+      # Loop through the config and recursively parse any config values which
+      # contain ERB, until the parsed config is not changing or we have
+      # exceeded the maximum number of passes to make.
+      while previous_config_string != current_config_string
+        count += 1
+        raise LoopErbError if count > Constants::MAXIMUM_RECURSIVE_CONFIG_DEPTH
+
+        previous_config_string = current_config_string
+        current_parsed_config = perform_config_parsing_pass(current_parsed_config)
         current_config_string = current_parsed_config.to_s
-        previous_config_string = nil
-        count = 0
-
-        # Loop through the config and recursively parse any config values which
-        # contain ERB, until the parsed config is not changing or we have
-        # exceeded the maximum number of passes to make.
-        while previous_config_string != current_config_string
-          count += 1
-          raise LoopErbError if count > Constants::MAXIMUM_RECURSIVE_CONFIG_DEPTH
-
-          previous_config_string = current_config_string
-          current_parsed_config = perform_config_parsing_pass(current_parsed_config)
-          current_config_string = current_parsed_config.to_s
-        end
-
-        RecursiveOpenStruct.new(current_parsed_config)
       end
 
-      def perform_config_parsing_pass(current_parsed_config)
-        current_parsed_config.map do |k,v|
+      RecursiveOpenStruct.new(current_parsed_config)
+    end
+
+    def perform_config_parsing_pass(current_parsed_config)
+      current_parsed_config.map do |k,v|
+        [k, parse_config_value(v, current_parsed_config)]
+      end.to_h
+    end
+
+    def parse_config_value(value, current_parsed_config)
+      case value
+      when String
+        replace_erb(value, RecursiveOpenStruct.new(current_parsed_config))
+      when Hash
+        value.map do |k,v|
           [k, parse_config_value(v, current_parsed_config)]
         end.to_h
+      else
+        value
       end
+    end
+  end
 
-      def parse_config_value(value, current_parsed_config)
-        case value
-        when String
-          replace_erb(value, RecursiveOpenStruct.new(current_parsed_config))
-        when Hash
-          value.map do |k,v|
-            [k, parse_config_value(v, current_parsed_config)]
-          end.to_h
-        else
-          value
-        end
+  module GenderGroupProxy
+    class << self
+      def method_missing(group_symbol)
+        NodeattrInterface.nodes_in_group(group_symbol)
+      rescue NoGenderGroupError
+        # XXX Should warn/log that resorting to this? Here or in
+        # `MagicNamespace`?
+        []
+      end
+    end
+  end
+
+  MagicNamespace = Struct.new(:index, :nodename, :firstboot) do
+    def initialize(index: 0, nodename: nil, firstboot: nil)
+      super(index, nodename, firstboot)
+    end
+
+    def genders
+      # XXX Do we want to make genders available as a `Hashie::Mash` too?
+      # Depends if we want to be able to iterate through genders or just get
+      # list of nodes in a specified gender
+      GenderGroupProxy
+    end
+
+    def hunter
+      if File.exists? Constants::HUNTER_PATH
+        Hashie::Mash.load(Constants::HUNTER_PATH)
+      else
+        # XXX Should warn/log that resorting to this?
+        Hashie::Mash.new
       end
     end
 
-    module GenderGroupProxy
-      class << self
-        def method_missing(group_symbol)
-          NodeattrInterface.nodes_in_group(group_symbol)
-        rescue NoGenderGroupError
-          # XXX Should warn/log that resorting to this? Here or in
-          # `MagicNamespace`?
-          []
-        end
+    def hosts_url
+      system_file_url 'hosts'
+    end
+
+    def genders_url
+      system_file_url 'genders'
+    end
+
+    def build_complete_url
+      if nodename
+        deployment_server_url "exec/kscomplete.php?name=#{nodename}"
       end
     end
 
-    MagicNamespace = Struct.new(:index, :nodename, :firstboot) do
-      def initialize(index: 0, nodename: nil, firstboot: nil)
-        super(index, nodename, firstboot)
-      end
+    def hostip
+      SystemCommand.run(determine_hostip_script).chomp
+    rescue SystemCommandError
+      # If script failed for any reason fall back to using `hostname -i`,
+      # which may or may not give the IP on the interface we actually want
+      # to use (note: the dance with pipes is so we only get the last word
+      # in the output, as I've had the IPv6 IP included first before, which
+      # breaks all the things).
+      # XXX Warn about falling back to this?
+      SystemCommand.run(
+        "hostname -i | xargs -d' ' -n1 | tail -n 2 | head -n 1"
+      ).chomp
+    end
 
-      def genders
-        # XXX Do we want to make genders available as a `Hashie::Mash` too?
-        # Depends if we want to be able to iterate through genders or just get
-        # list of nodes in a specified gender
-        GenderGroupProxy
-      end
+    private
 
-      def hunter
-        if File.exists? Constants::HUNTER_PATH
-          Hashie::Mash.load(Constants::HUNTER_PATH)
-        else
-          # XXX Should warn/log that resorting to this?
-          Hashie::Mash.new
-        end
-      end
+    def system_file_url(system_file)
+      deployment_server_url "system/#{system_file}"
+    end
 
-      def hosts_url
-        system_file_url 'hosts'
-      end
+    def deployment_server_url(url_path)
+      "http://#{hostip}/#{url_path}"
+    end
 
-      def genders_url
-        system_file_url 'genders'
-      end
-
-      def build_complete_url
-        if nodename
-          deployment_server_url "exec/kscomplete.php?name=#{nodename}"
-        end
-      end
-
-      def hostip
-        SystemCommand.run(determine_hostip_script).chomp
-      rescue SystemCommandError
-        # If script failed for any reason fall back to using `hostname -i`,
-        # which may or may not give the IP on the interface we actually want
-        # to use (note: the dance with pipes is so we only get the last word
-        # in the output, as I've had the IPv6 IP included first before, which
-        # breaks all the things).
-        # XXX Warn about falling back to this?
-        SystemCommand.run(
-          "hostname -i | xargs -d' ' -n1 | tail -n 2 | head -n 1"
-        ).chomp
-      end
-
-      private
-
-      def system_file_url(system_file)
-        deployment_server_url "system/#{system_file}"
-      end
-
-      def deployment_server_url(url_path)
-        "http://#{hostip}/#{url_path}"
-      end
-
-      def determine_hostip_script
-        File.join(
-          Constants::METALWARE_INSTALL_PATH,
-          'libexec/determine-hostip'
-        )
-      end
+    def determine_hostip_script
+      File.join(
+        Constants::METALWARE_INSTALL_PATH,
+        'libexec/determine-hostip'
+      )
     end
   end
 end

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -33,12 +33,14 @@ require 'nodeattr_interface'
 module Metalware
   class Templater
     class << self
-      # XXX Have method to print template here, and do not expose access to
-      # `file` method directly, so can cleanly stub this for testing.
       # XXX rename args in these methods - use `**parameters` for passing
       # template parameters?
       def render(template, template_parameters={})
         Templater.new(template_parameters).render(template)
+      end
+
+      def render_to_stdout(template, template_parameters={})
+          puts render(template, template_parameters)
       end
 
       def render_to_file(template, save_file, template_parameters={})

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -35,23 +35,22 @@ module Metalware
     class << self
       # XXX Have method to print template here, and do not expose access to
       # `file` method directly, so can cleanly stub this for testing.
-      # XXX rename to `render`; rename other methods here appropriately too.
       # XXX rename args in these methods - use `**parameters` for passing
       # template parameters?
-      def file(filename, template_parameters={})
-        Templater.new(template_parameters).file(filename)
+      def render(filename, template_parameters={})
+        Templater.new(template_parameters).render(filename)
       end
 
-      def save(template_file, save_file, template_parameters={})
+      def render_to_file(template_file, save_file, template_parameters={})
         File.open(save_file.chomp, "w") do |f|
-          f.puts file(template_file, template_parameters)
+          f.puts render(template_file, template_parameters)
         end
         # Alces::Stack::Log.info "Template Saved: #{save_file}"
       end
 
-      def append(template_file, append_file, template_parameters={})
+      def render_and_append_to_file(template_file, append_file, template_parameters={})
         File.open(append_file.chomp, 'a') do |f|
-          f.puts file(template_file, template_parameters)
+          f.puts render(template_file, template_parameters)
         end
         # Alces::Stack::Log.info "Template Appended: #{append_file}"
       end
@@ -72,8 +71,7 @@ module Metalware
       @config = parse_config
     end
 
-    # XXX rename to `render`; rename other methods here appropriately too.
-    def file(filename, template_parameters={})
+    def render(filename, template_parameters={})
       File.open(filename.chomp, 'r') do |f|
         replace_erb(f.read, @config)
       end


### PR DESCRIPTION
This PR contains a few changes to how the `Templater` interface works to support what I'm working on and to try and make the templating simpler/clearer/easier to test. See commit messages for the details of the changes.

There's quite a lot of additions/deletions here but it's mostly just churn in the tests and other files due to the interface when using the `Templater` changing; the important changes are in `metalware-new/src/templater.rb`. @WilliamMcCumstie: No need to look at this in great detail but if you want to take a quick look to see if you have any thoughts then that would be useful :slightly_smiling_face:.