### PR TITLE
Templater logs warnings when it tries to use missing parameters

### DIFF
--- a/metalware-new/spec/fixtures/configs/integration-test.yaml
+++ b/metalware-new/spec/fixtures/configs/integration-test.yaml
@@ -4,4 +4,5 @@ built_nodes_storage_path: 'tmp/integration-test/built-nodes'
 rendered_files_path: 'tmp/integration-test/rendered'
 pxelinux_cfg_path: 'tmp/integration-test/pxelinux.cfg'
 repo_path: 'tmp/repo'
-log_path: 'tmp/integration-test/log'
+log_path: 'tmp/log/integration-test'
+log_serverity: "DEBUG"

--- a/metalware-new/spec/fixtures/configs/unit-test.yaml
+++ b/metalware-new/spec/fixtures/configs/unit-test.yaml
@@ -1,3 +1,4 @@
 
 build_poll_sleep: 0
-log_path: 'tmp/unit-test/log'
+log_path: 'tmp/log/unit-test'
+log_serverity: "DEBUG"

--- a/metalware-new/src/config.rb
+++ b/metalware-new/src/config.rb
@@ -14,7 +14,8 @@ module Metalware
       rendered_files_path: '/var/lib/metalware/rendered',
       pxelinux_cfg_path: '/var/lib/tftpboot/pxelinux.cfg',
       repo_path: '/var/lib/metalware/repo',
-      log_path: '/var/log/metalware'
+      log_path: '/var/log/metalware',
+      log_serverity: "INFO"
     }
 
     def initialize(file)

--- a/metalware-new/src/metal_log.rb
+++ b/metalware-new/src/metal_log.rb
@@ -23,6 +23,7 @@ require 'logger'
 require 'config'
 require 'exceptions'
 require 'fileutils'
+require 'output'
 
 module Metalware
   class MetalLog < Logger
@@ -53,11 +54,9 @@ module Metalware
       super(f)
     end
 
-# POSSIBLE USE TO IMPLEMENT --strict
-=begin
-      def warn(*args, &block)
-        super(*args, &block)
-      end
-=end
+    def warn(msg)
+      Output.stderr "warning: #{msg}"
+      super msg
+    end
   end
 end

--- a/metalware-new/src/metal_log.rb
+++ b/metalware-new/src/metal_log.rb
@@ -52,6 +52,7 @@ module Metalware
       f = File.open(file, "a")
       f.sync = true
       super(f)
+      level = self.class.config.log_serverity
     end
 
     def warn(msg)

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -39,17 +39,18 @@ module Metalware
     end
 
     def method_missing(s, *a, &b)
-      if s == :[]
-        value = a.map { |v| @wrapped_obj[v] }
-        value = value[0] if value.length == 1
-      else
-        value = @wrapped_obj.send(s)
-      end
+      value = @wrapped_obj.send(s)
       if value.nil? && ! @missing_tags.include?(s)
         @missing_tags.push s
         MetalLog.warn "Missing template parameter: #{s}"
       end
       value
+    end
+
+    def [](a)
+      # ERB expects to be able to index in to the binding passed; this should
+      # function the same as a method call.
+      send(a)
     end
   end
 

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -183,8 +183,7 @@ module Metalware
         current_config_string = current_parsed_config.to_s
       end
 
-      struct = RecursiveOpenStruct.new(current_parsed_config)
-      MissingParameterWrapper.new(struct)
+      create_template_parameters(current_parsed_config)
     end
 
     def perform_config_parsing_pass(current_parsed_config)
@@ -196,8 +195,8 @@ module Metalware
     def parse_config_value(value, current_parsed_config)
       case value
       when String
-        struct = RecursiveOpenStruct.new(current_parsed_config)
-        replace_erb(value, MissingParameterWrapper.new(struct))
+        parameters = create_template_parameters(current_parsed_config)
+        replace_erb(value, parameters)
       when Hash
         value.map do |k,v|
           [k, parse_config_value(v, current_parsed_config)]
@@ -205,6 +204,10 @@ module Metalware
       else
         value
       end
+    end
+
+    def create_template_parameters(config)
+      MissingParameterWrapper.new(RecursiveOpenStruct.new(config))
     end
   end
 

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -33,13 +33,18 @@ require 'exceptions'
 
 module Metalware
   class MissingParameterWrapper
-    def initialize(wrapped_object)
+    def initialize(wrapped_obj)
       @missing_tags = []
-      @wrapped_object = wrapped_object
+      @wrapped_obj = wrapped_obj
     end
 
     def method_missing(s, *a, &b)
-      value = @wrapped_object.send s
+      if s == :[]
+        value = a.map { |v| @wrapped_obj[v] }
+        value = value[0] if value.length == 1
+      else
+        value = @wrapped_obj.send(s)
+      end
       if value.nil? && ! @missing_tags.include?(s)
         @missing_tags.push s
         MetalLog.warn "Missing template parameter: #{s}"

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -49,8 +49,8 @@ module Metalware
         @missing_tags.push s
         MetalLog.warn "Missing template parameter: #{s}"
       end
-      value   
-    end  
+      value
+    end
   end
 
   class Templater

--- a/metalware-new/src/templater.rb
+++ b/metalware-new/src/templater.rb
@@ -217,13 +217,20 @@ module Metalware
       @struct = MagicNamespaceStruct.new(*a)
     end
 
-    def method_missing(s)
-      value = @struct.send(s)
+    def method_missing(s, *a, &b)
+      if s == :[]
+        value = (a.length == 1 ? @struct[a[0]] : a.map { |v| @struct[v] })
+      else
+        value = @struct.send(s)
+      end
       if value.nil? && ! @missing_tags.include?(s)
         @missing_tags.push s
         MetalLog.warn "Missing template parameter: alces.#{s}"
       end
       value
+    rescue => e
+      MetalLog.debug "#{e.inspect}"
+      raise e
     end
 
     MagicNamespaceStruct = Struct.new(:index, :nodename, :firstboot) do


### PR DESCRIPTION
Carry on from the work on the logger. Please merge #55 before this one.

Modified `MetalLog` to override the base `warn` method. Now `MetalLog.warn` will take a message and log it to both `stderr` and the log file. 

`Templater` uses the `warn` when it tries to use a parameter in the `erb` template that is not defined. This is done by creating a wrapper around both `RecursiveOpenStruct` and `MagicNamespace`. 

ERB now receives a `binding` from `TemplaterRecursiveOpenStruct` which is a wrapper around `RecursiveOpenStruct`. If `RecursiveOpenStruct` return a nil value to the templater, the wrapper log it as a `warning`.

However ERB first quires `TemplaterRecursiveOpenStruct` for the `MagicNamespace` object. Then it quires `MagicNamespace` separately for the exact value (e.g. index). Therefore `MagicNamespace` needs a similar wrapper.