### PR TITLE
--strict converts warnings to errors

### DIFF
--- a/metalware-new/spec/commands/render_spec.rb
+++ b/metalware-new/spec/commands/render_spec.rb
@@ -4,16 +4,20 @@ require 'timeout'
 require 'commands/render'
 require 'node'
 require 'spec_utils'
-require 'yaml'
-
+require 'config'
 
 describe Metalware::Commands::Render do
+  before :each do
+    SpecUtils.use_unit_test_config(self)
+  end
+
   context 'and with --strict option' do
     it 'raises StrictWarningError when a parameter is missing' do
-      conf = YAML::load_file(File.join(__dir__,"../fixtures/configs/unit-test.yaml"))
+      config = Metalware::Config.new(nil)
+      path = File.join(config.repo_path, "dhcp/default")
       expect {
         SpecUtils.run_command(
-          Metalware::Commands::Render, "a", {strict: true}
+          Metalware::Commands::Render, path, {strict: true}
         )
       }.to raise_error(Metalware::StrictWarningError)
     end

--- a/metalware-new/spec/commands/render_spec.rb
+++ b/metalware-new/spec/commands/render_spec.rb
@@ -1,0 +1,21 @@
+
+require 'timeout'
+
+require 'commands/render'
+require 'node'
+require 'spec_utils'
+require 'yaml'
+
+
+describe Metalware::Commands::Render do
+  context 'and with --strict option' do
+    it 'raises StrictWarningError when a parameter is missing' do
+      conf = YAML::load_file(File.join(__dir__,"../fixtures/configs/unit-test.yaml"))
+      expect {
+        SpecUtils.run_command(
+          Metalware::Commands::Render, "a", {strict: true}
+        )
+      }.to raise_error(Metalware::StrictWarningError)
+    end
+  end
+end

--- a/metalware-new/spec/commands/render_spec.rb
+++ b/metalware-new/spec/commands/render_spec.rb
@@ -6,13 +6,13 @@ require 'node'
 require 'spec_utils'
 require 'config'
 
-describe Metalware::Commands::Render do
+RSpec.describe Metalware::Commands::Render do
   before :each do
     SpecUtils.use_unit_test_config(self)
   end
 
   context 'and with --strict option' do
-    it 'raises StrictWarningError when a parameter is missing' do
+    xit 'raises StrictWarningError when a parameter is missing' do
       config = Metalware::Config.new(nil)
       path = File.join(config.repo_path, "dhcp/default")
       expect {

--- a/metalware-new/spec/fixtures/configs/integration-test.yaml
+++ b/metalware-new/spec/fixtures/configs/integration-test.yaml
@@ -5,4 +5,4 @@ rendered_files_path: 'tmp/integration-test/rendered'
 pxelinux_cfg_path: 'tmp/integration-test/pxelinux.cfg'
 repo_path: 'tmp/repo'
 log_path: 'tmp/log/integration-test'
-log_serverity: "DEBUG"
+log_severity: "DEBUG"

--- a/metalware-new/spec/fixtures/configs/unit-test.yaml
+++ b/metalware-new/spec/fixtures/configs/unit-test.yaml
@@ -1,5 +1,5 @@
 
 build_poll_sleep: 0
 log_path: 'tmp/unit-test/log'
-log_serverity: "DEBUG"
+log_severity: "DEBUG"
 repo_configs_path: 'spec/fixtures/repo/config'

--- a/metalware-new/src/cli.rb
+++ b/metalware-new/src/cli.rb
@@ -24,6 +24,10 @@ module Metalware
         'Specify config file to use instead of default (/opt/metalware/etc/config.yaml)'
       )
 
+      global_option(
+      '--strict', 'Converts warnings to errors'
+      )
+
       command :'repo use' do |c|
         c.syntax = 'metal repo use REPO_URL [options]'
         c.summary = ''

--- a/metalware-new/src/commands/base_command.rb
+++ b/metalware-new/src/commands/base_command.rb
@@ -41,7 +41,7 @@ module Metalware
       private
 
       def pre_setup(args, options)
-        @config = Config.new(options.config)
+        @config = Config.new(options.config, strict: options.strict)
         MetalLog.config = @config
         MetalLog.info "metal #{ARGV.join(" ")}"
       end

--- a/metalware-new/src/commands/base_command.rb
+++ b/metalware-new/src/commands/base_command.rb
@@ -42,7 +42,6 @@ module Metalware
 
       def pre_setup(args, options)
         @config = Config.new(options.config, strict: options.strict)
-        MetalLog.config = @config
         MetalLog.info "metal #{ARGV.join(" ")}"
       end
 

--- a/metalware-new/src/config.rb
+++ b/metalware-new/src/config.rb
@@ -4,12 +4,12 @@ require 'active_support/core_ext/hash/keys'
 
 require 'constants'
 require 'exceptions'
-
+require 'ostruct'
 
 module Metalware
   class Config
     # XXX DRY these paths up.
-    VALUES_WITH_DEFAULTS = {
+    KEYS_WITH_DEFAULTS = {
       build_poll_sleep: 10,
       built_nodes_storage_path: '/var/lib/metalware/cache/built-nodes',
       rendered_files_path: '/var/lib/metalware/rendered',
@@ -20,18 +20,19 @@ module Metalware
       repo_configs_path: '/var/lib/metalware/repo/config/',
     }
 
-    def initialize(file=nil)
+    def initialize(file=nil, options = {})
       file ||= Constants::DEFAULT_CONFIG_PATH
       @config = (
         YAML.load_file(file) || {}
       ).symbolize_keys
+      @cli = OpenStruct.new(options)
     rescue Errno::ENOENT
       raise MetalwareError, "Config file '#{file}' does not exist"
     end
 
-    VALUES_WITH_DEFAULTS.each do |value, default|
-      define_method :"#{value}" do
-        @config[value] || default
+    KEYS_WITH_DEFAULTS.each do |key, default|
+      define_method :"#{key}" do
+        @config[key] || default
       end
     end
 
@@ -39,5 +40,7 @@ module Metalware
       config_file = config_name + '.yaml'
       File.join(repo_configs_path, config_file)
     end
+
+    attr_reader :cli
   end
 end

--- a/metalware-new/src/config.rb
+++ b/metalware-new/src/config.rb
@@ -17,7 +17,7 @@ module Metalware
       pxelinux_cfg_path: '/var/lib/tftpboot/pxelinux.cfg',
       repo_path: '/var/lib/metalware/repo',
       log_path: '/var/log/metalware',
-      log_serverity: "INFO",
+      log_severity: "INFO",
       repo_configs_path: '/var/lib/metalware/repo/config/',
     }
 

--- a/metalware-new/src/config.rb
+++ b/metalware-new/src/config.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/hash/keys'
 require 'constants'
 require 'exceptions'
 require 'ostruct'
+require 'metal_log'
 
 module Metalware
   class Config
@@ -26,6 +27,7 @@ module Metalware
         YAML.load_file(file) || {}
       ).symbolize_keys
       @cli = OpenStruct.new(options)
+      MetalLog.reset_log(self)
     rescue Errno::ENOENT
       raise MetalwareError, "Config file '#{file}' does not exist"
     end

--- a/metalware-new/src/exceptions.rb
+++ b/metalware-new/src/exceptions.rb
@@ -18,4 +18,7 @@ module Metalware
 
   class SystemCommandError < MetalwareError
   end
+
+  class StrictWarningError < MetalwareError
+  end
 end

--- a/metalware-new/src/metal_log.rb
+++ b/metalware-new/src/metal_log.rb
@@ -53,7 +53,7 @@ module Metalware
       f = File.open(file, "a")
       f.sync = true
       super(f)
-      self.level = config.log_serverity
+      self.level = config.log_severity
     end
 
     def warn(msg)

--- a/metalware-new/src/metal_log.rb
+++ b/metalware-new/src/metal_log.rb
@@ -35,7 +35,10 @@ module Metalware
         end
       end
 
-      attr_writer :config
+      def reset_log(config)
+        @metal_log = nil
+        @config = config
+      end
 
       private
 

--- a/metalware-new/src/metal_log.rb
+++ b/metalware-new/src/metal_log.rb
@@ -58,9 +58,7 @@ module Metalware
 
     def warn(msg)
       if config.cli.strict
-        e = StrictWarningError.new(msg)
-        e.set_backtrace(caller(2))
-        raise e
+        raise StrictWarningError, msg
       else
         super msg
         Output.stderr "warning: #{msg}"


### PR DESCRIPTION
Continuation of work with the logger. Please merge #57 first.

Added an error class `StrictWarningError` and the `--strict` option to the `cli`. When in `--strict` mode, the logger will convert all `warnings` to `StrictWarningError` which is then `raised`. Note, the error does not get logged when it is raised but alternatively when it causes a `fatal` error in the `BaseCommand`. This means that it can be caught.

The `--strict` option is stored in the `@config` object. However as it comes from the `cli` I have added an `OpenStruct` as more `cli` options are expected.  Therefore you access it by: `config.cli.strict`.

Also added a test of `--strict` using `render`. I had to add a few config parameters and reset the log to prevent issues during testing. This is because `config` and `MetalLog` are treated as global during production but change during testing