### PR TITLE
Suppress output with `--quiet`

### DIFF
--- a/metalware-old/lib/ruby/lib/alces/stack/boot/run.rb
+++ b/metalware-old/lib/ruby/lib/alces/stack/boot/run.rb
@@ -141,9 +141,9 @@ module Alces
         rescue StandardError => @e
         ensure
           @e ||= Interrupt
-          STDERR.print "Exiting...."
+          $stderr.print "Exiting...."
           e = teardown(@e)
-          STDERR.puts "Done"
+          $stderr.puts "Done"
           raise e unless e == Interrupt
           Alces::Stack::Log.info "clean exit"
           Kernel.exit(0)
@@ -299,8 +299,8 @@ module Alces
           tear_down_flag_dry = true if @opt.dry_run? && !@to_delete.empty?
           tear_down_flag = true if !@opt.dry_run? && !@to_delete_dry_run.empty?
           unless @opt.permanent_boot?
-            STDERR.puts "DRY RUN: Files that would be deleted:" unless @to_delete_dry_run.empty?
-            @to_delete_dry_run.each { |file| STDERR.puts "  #{file}" }
+            $stderr.puts "DRY RUN: Files that would be deleted:" unless @to_delete_dry_run.empty?
+            @to_delete_dry_run.each { |file| $stderr.puts "  #{file}" }
             @to_delete.each { |file| delete_file_log file }
           end
 

--- a/metalware-old/lib/ruby/lib/alces/stack/hosts/cli.rb
+++ b/metalware-old/lib/ruby/lib/alces/stack/hosts/cli.rb
@@ -72,7 +72,7 @@ module Alces
 
         def setup_signal_handler
           trap('INT') do
-            STDERR.puts "\nExiting..." unless @exiting
+            $stderr.puts "\nExiting..." unless @exiting
             @exiting = true
             Kernel.exit(0)
           end

--- a/metalware-old/lib/ruby/lib/alces/stack/hunter/cli.rb
+++ b/metalware-old/lib/ruby/lib/alces/stack/hunter/cli.rb
@@ -82,7 +82,7 @@ module Alces
         def setup_signal_handler
           trap('INT') do
             `systemctl restart dhcpd` if update_dhcp
-            STDERR.puts "Exiting..." unless @exiting
+            $stderr.puts "Exiting..." unless @exiting
             @exiting = true
             Kernel.exit(0)
           end

--- a/metalware-old/lib/ruby/lib/alces/stack/hunter/listener.rb
+++ b/metalware-old/lib/ruby/lib/alces/stack/hunter/listener.rb
@@ -47,7 +47,7 @@ module Alces
         end
 
         def listen!
-          STDERR.puts "WAITING FOR NEW NODES TO APPEAR ON THE NETWORK, PLEASE NETWORK BOOT THEM NOW... (CTRL+C TO TERMINATE)"
+          $stderr.puts "WAITING FOR NEW NODES TO APPEAR ON THE NETWORK, PLEASE NETWORK BOOT THEM NOW... (CTRL+C TO TERMINATE)"
           Thread.new do
             begin
               network.each do |p|
@@ -107,19 +107,19 @@ module Alces
           @detection_count += 1
 
           begin
-            STDERR.print "Detected a machine on the network (#{hwaddr}). Please enter the hostname [#{default_name}]: "
-            STDERR.flush
+            $stderr.print "Detected a machine on the network (#{hwaddr}). Please enter the hostname [#{default_name}]: "
+            $stderr.flush
             input = gets.chomp
             name = input.empty? ? default_name : input
             update_dhcp(name, hwaddr) if @update_dhcp_flag
             Alces::Stack::Log.info("#{name}-#{hwaddr}")
             @hunter_logger.info("#{name}-#{hwaddr}")
-            STDERR.puts "Logged node"
+            $stderr.puts "Logged node"
 
           rescue Exception => e
             warn e
-            STDERR.puts "FAIL: #{e.message}"; STDERR.flush
-            STDERR.print "Retry? (Y/N): "; STDERR.flush
+            $stderr.puts "FAIL: #{e.message}"; $stderr.flush
+            $stderr.print "Retry? (Y/N): "; $stderr.flush
             input=gets.chomp
             retry if input.to_s.downcase == 'y'
           end

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -25,7 +25,11 @@ module Metalware
       )
 
       global_option(
-      '--strict', 'Converts warnings to errors'
+        '--strict', 'Converts warnings to errors'
+      )
+
+      global_option(
+        '--quiet', 'Suppresses standard output'
       )
 
       command :'repo use' do |c|

--- a/src/commands/base_command.rb
+++ b/src/commands/base_command.rb
@@ -41,7 +41,11 @@ module Metalware
       private
 
       def pre_setup(args, options)
-        @config = Config.new(options.config, strict: options.strict)
+        cli_options = {
+          strict: !!options.strict,
+          quiet: !!options.quiet
+        }
+        @config = Config.new(options.config, cli_options)
         MetalLog.info "metal #{ARGV.join(" ")}"
       end
 

--- a/src/metal_log.rb
+++ b/src/metal_log.rb
@@ -59,7 +59,7 @@ module Metalware
     def warn(msg)
       if config.cli.strict
         raise StrictWarningError, msg
-      else
+      elsif ! config.cli.quiet
         super msg
         Output.stderr "warning: #{msg}"
       end

--- a/src/metal_log.rb
+++ b/src/metal_log.rb
@@ -57,12 +57,8 @@ module Metalware
     end
 
     def warn(msg)
-      if config.cli.strict
-        raise StrictWarningError, msg
-      elsif ! config.cli.quiet
-        super msg
-        Output.stderr "warning: #{msg}"
-      end
+      config.cli.strict ? raise(StrictWarningError, msg) : super(msg)
+      Output.stderr "warning: #{msg}" unless config.cli.quiet
     end
 
     private

--- a/src/output.rb
+++ b/src/output.rb
@@ -6,7 +6,7 @@ module Metalware
       def stderr(*lines)
         # Don't output anything in unit tests to prevent noise.
         if $0 !~ /rspec$/
-          STDERR.puts(*lines)
+          $stderr.puts(*lines)
         end
       end
 


### PR DESCRIPTION
The CLI now has a global option, `--quiet` which causes standard error to  be redirected to /dev/null. This does not affect standard error and thus we will still get the warnings. 

Also I have included it as part of the `CLI` itself. This means it will not be available if we want to run the ruby tools directly in the future. 

However this looks to meet the requirements at this point in time. 