### PR TITLE
Display the usage if not command input

### DIFF
--- a/src/cli.rb
+++ b/src/cli.rb
@@ -126,6 +126,11 @@ module Metalware
         c.action Commands::Bash
       end
 
+      def run!
+        ARGV.push "--help" if ARGV.empty?
+        super
+      end
+
       run!
     end
   end


### PR DESCRIPTION
Simple fix to display help when you run `metal`. 

Was looking to do the same for `repo` but that's much harder as `repo use` and `repo update` are defined separately 