### PR TITLE
Make system files available on Metalware server

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -77,10 +77,15 @@ say_done $?
 title "Creating initial directory structure"
 doing 'Create'
 mkdir -p /var/log/metalware
-mkdir -p /var/lib/metalware/rendered/kickstart
+mkdir -p /var/lib/metalware/rendered/{kickstart,system}
 mkdir -p /var/lib/metalware/cache/{built-nodes,templates}
 mkdir -p /var/lib/metalware/repo
 chmod a+rw /var/lib/metalware/cache/built-nodes
+
+# Link certain files in to Metalware dir; these can then be retrieved by a
+# request to a `/metalware/system/$file` route on the Metalware deployment
+# server.
+ln -s /etc/hosts /opt/metalware/etc/genders /var/lib/metalware/rendered/system/
 
 mkdir -p "${target}"
 cp -R "${source}/"{Gemfile,Gemfile.lock,bin,etc,libexec,src} "${target}"


### PR DESCRIPTION
Link certain files in to Metalware dir; these can then be retrieved by a request to a `/metalware/system/$file` route on the Metalware deployment server.

Trello: https://trello.com/c/oFRKSD7A/29-have-required-urls-work-on-metalware-deployment-server.