### PR TITLE
Show defaults in help

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -77,10 +77,15 @@ say_done $?
 title "Creating initial directory structure"
 doing 'Create'
 mkdir -p /var/log/metalware
-mkdir -p /var/lib/metalware/rendered/kickstart
+mkdir -p /var/lib/metalware/rendered/{kickstart,system}
 mkdir -p /var/lib/metalware/cache/{built-nodes,templates}
 mkdir -p /var/lib/metalware/repo
 chmod a+rw /var/lib/metalware/cache/built-nodes
+
+# Link certain files in to Metalware dir; these can then be retrieved by a
+# request to a `/metalware/system/$file` route on the Metalware deployment
+# server.
+ln -s /etc/hosts /opt/metalware/etc/genders /var/lib/metalware/rendered/system/
 
 mkdir -p "${target}"
 cp -R "${source}/"{Gemfile,Gemfile.lock,bin,etc,libexec,src} "${target}"

--- a/spec/defaults_spec.rb
+++ b/spec/defaults_spec.rb
@@ -1,0 +1,16 @@
+
+require 'defaults'
+
+
+RSpec.describe Metalware::Defaults do
+  describe '#method_missing' do
+    it 'provides the correct default values' do
+      expect(Metalware::Defaults.hosts.template).to eq('default')
+      expect(Metalware::Defaults.build.kickstart).to eq('default')
+    end
+
+    it 'returns nil for not present option' do
+      expect(Metalware::Defaults.hosts.foo).to be(nil)
+    end
+  end
+end

--- a/spec/defaults_spec.rb
+++ b/spec/defaults_spec.rb
@@ -12,5 +12,9 @@ RSpec.describe Metalware::Defaults do
     it 'returns nil for not present option' do
       expect(Metalware::Defaults.hosts.foo).to be(nil)
     end
+
+    it 'returns an empty hash for unspecified commands' do
+      expect(Metalware::Defaults.render).to eq({})
+    end
   end
 end

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -25,11 +25,11 @@ module Metalware
       )
 
       global_option(
-        '--strict', 'Converts warnings to errors'
+        '--strict', 'Convert warnings to errors'
       )
 
       global_option(
-        '--quiet', 'Suppresses standard output'
+        '--quiet', 'Suppress any warnings from being displayed'
       )
 
       command :'repo use' do |c|

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -8,6 +8,7 @@ require 'commander'
 
 require 'commander_extensions'
 require 'commands'
+require 'defaults'
 
 module Metalware
   class Cli
@@ -67,7 +68,8 @@ module Metalware
         c.example 'description', 'command example'
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
-        c.option '-t TEMPLATE', '--template TEMPLATE', String, 'Specify hosts template to use'
+        c.option '-t TEMPLATE', '--template TEMPLATE', String,
+          "Specify hosts template to use (default: #{Defaults.hosts.template})"
         c.option '-x', '--dry-run',
           'Do not modify hosts file, just output additions that would be made'
         c.action Commands::Hosts
@@ -79,13 +81,13 @@ module Metalware
         c.description = ''
         c.example 'description', 'command example'
         c.option '-i INTERFACE', '--interface INTERFACE', String,
-          'Local interface to hunt on'
+          "Local interface to hunt on (default: #{Defaults.hunter.interface})"
         c.option '-p PREFIX', '--prefix PREFIX', String,
-          'Root to suggest for detected node names'
+          "Root to suggest for detected node names (default: #{Defaults.hunter.prefix})"
         c.option '-l LENGTH', '--length LENGTH', Integer,
-          'Numeric sequence length to use for suggested detected node names'
+          "Numeric sequence length to use for suggested detected node names (default: #{Defaults.hunter.length})"
         c.option '-s START_NUMBER', '--start  START_NUMBER', Integer,
-          'Start integer to use for suggested detected node names'
+          "Start integer to use for suggested detected node names (default: #{Defaults.hunter.start})"
         c.action Commands::Hunter
       end
 
@@ -94,7 +96,8 @@ module Metalware
         c.summary = ''
         c.description = ''
         c.example 'description', 'command example'
-        c.option '-t TEMPLATE', '--template TEMPLATE', String, 'Specify dhcp template to use'
+        c.option '-t TEMPLATE', '--template TEMPLATE', String,
+          "Specify dhcp template to use (default: #{Defaults.dhcp.template})"
         c.action Commands::Dhcp
       end
 
@@ -106,9 +109,9 @@ module Metalware
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
         c.option '-k KICKSTART_TEMPLATE', '--kickstart KICKSTART_TEMPLATE',
-          String, 'Specify kickstart template to use'
+          String, "Specify kickstart template to use (default: #{Defaults.build.kickstart})"
         c.option '-p PXELINUX_TEMPLATE', '--pxelinux  PXELINUX_TEMPLATE',
-          String, 'Specify pxelinux template to use'
+          String, "Specify pxelinux template to use (default: #{Defaults.build.pxelinux})"
         c.action Commands::Build
       end
 

--- a/src/commands/base_command.rb
+++ b/src/commands/base_command.rb
@@ -22,6 +22,7 @@
 
 require 'metal_log'
 require 'config'
+require 'defaults'
 
 module Metalware
   module Commands
@@ -42,6 +43,7 @@ module Metalware
 
       def pre_setup(args, options)
         setup_config(options)
+        setup_option_defaults(options)
         log_command
       end
 
@@ -51,6 +53,19 @@ module Metalware
           quiet: !!options.quiet
         }
         @config = Config.new(options.config, cli_options)
+      end
+
+      def setup_option_defaults(options)
+        # TODO: this won't work correctly for subcommands as we will need to
+        # specify defaults using more than just the command name; this does not
+        # matter for now though since this only applies to `repo` currently and
+        # no `repo` commands have defaults yet.
+        command_defaults = Defaults.send(command_name)
+        options.default(**command_defaults)
+      end
+
+      def command_name
+        self.class.name.split('::')[-1].downcase
       end
 
       def log_command

--- a/src/commands/base_command.rb
+++ b/src/commands/base_command.rb
@@ -41,11 +41,19 @@ module Metalware
       private
 
       def pre_setup(args, options)
+        setup_config(options)
+        log_command
+      end
+
+      def setup_config(options)
         cli_options = {
           strict: !!options.strict,
           quiet: !!options.quiet
         }
         @config = Config.new(options.config, cli_options)
+      end
+
+      def log_command
         MetalLog.info "metal #{ARGV.join(" ")}"
       end
 

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -19,9 +19,6 @@ module Metalware
       private
 
       def setup(args, options)
-        options.default \
-          kickstart: 'default',
-          pxelinux: 'default'
         @options = options
         node_identifier = args.first
         @nodes = Nodes.create(@config, node_identifier, options.group)

--- a/src/commands/dhcp.rb
+++ b/src/commands/dhcp.rb
@@ -18,7 +18,6 @@ module Metalware
       private
 
       def setup(args, options)
-        options.default template: 'default'
         @options = options
       end
 

--- a/src/commands/hosts.rb
+++ b/src/commands/hosts.rb
@@ -13,7 +13,6 @@ module Metalware
       private
 
       def setup(args, options)
-        options.default template: 'default'
         @options = options
 
         node_identifier = args.first

--- a/src/commands/hunter.rb
+++ b/src/commands/hunter.rb
@@ -20,13 +20,6 @@ module Metalware
       def setup(args, options)
         @hunter_log = MetalLog.new("hunter")
 
-        # XXX Always default interface to Metalware build interface (where
-        # possible)?
-        options.default \
-          interface: 'eth0',
-          prefix: 'node',
-          length: 2,
-          start: 1
         @options = options
 
         @detection_count = options.start

--- a/src/defaults.rb
+++ b/src/defaults.rb
@@ -1,0 +1,27 @@
+
+require 'constants'
+require 'recursive-open-struct'
+
+
+module Metalware
+  Defaults = RecursiveOpenStruct.new({
+    build: {
+      kickstart: 'default',
+      pxelinux: 'default',
+    },
+    dhcp: {
+      template: 'default',
+    },
+    hosts: {
+      template: 'default',
+    },
+    hunter: {
+      # XXX Always default interface to Metalware build interface (where
+      # possible)?
+      interface: 'eth0',
+      prefix: 'node',
+      length: 2,
+      start: 1,
+    }
+  })
+end

--- a/src/defaults.rb
+++ b/src/defaults.rb
@@ -4,6 +4,11 @@ require 'recursive-open-struct'
 
 
 module Metalware
+  # When new defaults are added here you may also want to add these to the
+  # option's help to be displayed.
+  # TODO: Could have these displayed in help automatically by overriding
+  # `Commander` method - not doing for now for simplicity of both writing the
+  # code and as this may be too much magic.
   Defaults = RecursiveOpenStruct.new({
     build: {
       kickstart: 'default',

--- a/src/defaults.rb
+++ b/src/defaults.rb
@@ -4,29 +4,37 @@ require 'recursive-open-struct'
 
 
 module Metalware
-  # When new defaults are added here you may also want to add these to the
-  # option's help to be displayed.
-  # TODO: Could have these displayed in help automatically by overriding
-  # `Commander` method - not doing for now for simplicity of both writing the
-  # code and as this may be too much magic.
-  Defaults = RecursiveOpenStruct.new({
-    build: {
-      kickstart: 'default',
-      pxelinux: 'default',
-    },
-    dhcp: {
-      template: 'default',
-    },
-    hosts: {
-      template: 'default',
-    },
-    hunter: {
-      # XXX Always default interface to Metalware build interface (where
-      # possible)?
-      interface: 'eth0',
-      prefix: 'node',
-      length: 2,
-      start: 1,
-    }
-  })
+  module Defaults
+    # When new defaults are added here you may also want to add these to the
+    # option's help to be displayed.
+    # TODO: Could have these displayed in help automatically by overriding
+    # `Commander` method - not doing for now for simplicity of both writing the
+    # code and as this may be too much magic.
+    DEFAULTS = RecursiveOpenStruct.new({
+      build: {
+        kickstart: 'default',
+        pxelinux: 'default',
+      },
+      dhcp: {
+        template: 'default',
+      },
+      hosts: {
+        template: 'default',
+      },
+      hunter: {
+        # XXX Always default interface to Metalware build interface (where
+        # possible)?
+        interface: 'eth0',
+        prefix: 'node',
+        length: 2,
+        start: 1,
+      }
+    })
+
+    class << self
+      def method_missing(name, *args, &block)
+        DEFAULTS.send(name) || {}
+      end
+    end
+  end
 end


### PR DESCRIPTION
Based on branch under review in https://github.com/alces-software/metalware/pull/63.

Trello: https://trello.com/c/M7EY4cUF/35-show-default-values-for-options-in-command-help.