### PR TITLE
Get repo from config always

### DIFF
--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -62,11 +62,13 @@ RSpec.describe Metalware::Commands::Build do
 
     it 'renders default standard templates for given node' do
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/kickstart/default',
         '/var/lib/metalware/rendered/kickstart/testnode01',
         expected_template_parameters,
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/default',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         expected_template_parameters,
@@ -77,11 +79,13 @@ RSpec.describe Metalware::Commands::Build do
 
     it 'uses different standard templates if template options passed' do
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/kickstart/my_kickstart',
         '/var/lib/metalware/rendered/kickstart/testnode01',
         expected_template_parameters,
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         expected_template_parameters,
@@ -99,6 +103,7 @@ RSpec.describe Metalware::Commands::Build do
       use_mock_nodes(not_built_nodes: 'testnode01')
 
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/default',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         expected_template_parameters,
@@ -109,11 +114,13 @@ RSpec.describe Metalware::Commands::Build do
 
     it 'renders pxelinux twice with firstboot switched if node builds' do
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/default',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         expected_template_parameters,
       ).once.ordered
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/default',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         expected_template_parameters.merge(firstboot: false),
@@ -144,6 +151,7 @@ RSpec.describe Metalware::Commands::Build do
           FileUtils.touch('/var/lib/metalware/repo/files/testnodes/some_file_in_repo')
 
           expect(Metalware::Templater).to receive(:render_to_file).with(
+            instance_of(Metalware::Config),
             '/var/lib/metalware/repo/files/testnodes/some_file_in_repo',
             '/var/lib/metalware/rendered/testnode01/namespace01/some_file_in_repo',
             expected_template_parameters
@@ -164,21 +172,25 @@ RSpec.describe Metalware::Commands::Build do
   context 'when called for group' do
     it 'renders standard templates for each node' do
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/kickstart/my_kickstart',
         '/var/lib/metalware/rendered/kickstart/testnode01',
         hash_including(nodename: 'testnode01', index: 0)
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         hash_including(nodename: 'testnode01', index: 0)
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/kickstart/my_kickstart',
         '/var/lib/metalware/rendered/kickstart/testnode02',
         hash_including(nodename: 'testnode02', index: 1)
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
         '/var/lib/tftpboot/pxelinux.cfg/testnode02_HEX_IP',
         hash_including(nodename: 'testnode02', index: 1)

--- a/spec/commands/hosts_spec.rb
+++ b/spec/commands/hosts_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Metalware::Commands::Hosts do
   context 'when called without group argument' do
     it 'appends to hosts file by default' do
       expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
         hash_including(nodename: 'testnode01', index: 0)
@@ -31,6 +32,7 @@ RSpec.describe Metalware::Commands::Hosts do
 
     it 'uses a different template if template option passed' do
       expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/hosts/my_template',
         '/etc/hosts',
         hash_including(nodename: 'testnode01', index: 0)
@@ -42,6 +44,7 @@ RSpec.describe Metalware::Commands::Hosts do
     context 'when dry-run' do
       it 'outputs what would be appended' do
         expect(Metalware::Templater).to receive(:render_to_stdout).with(
+          instance_of(Metalware::Config),
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode01')
         )
@@ -55,16 +58,19 @@ RSpec.describe Metalware::Commands::Hosts do
     it 'appends to hosts file by default' do
       # XXX Dedupe these very similar assertions
       expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
         hash_including(nodename: 'testnode01', index: 0)
       )
       expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
         hash_including(nodename: 'testnode02', index: 1)
       )
       expect(Metalware::Templater).to receive(:render_and_append_to_file).with(
+        instance_of(Metalware::Config),
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
         hash_including(nodename: 'testnode03', index: 2)
@@ -77,14 +83,17 @@ RSpec.describe Metalware::Commands::Hosts do
       it 'outputs what would be appended' do
         # XXX Dedupe these too
         expect(Metalware::Templater).to receive(:render_to_stdout).with(
+          instance_of(Metalware::Config),
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode01', index: 0)
         )
         expect(Metalware::Templater).to receive(:render_to_stdout).with(
+          instance_of(Metalware::Config),
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode02', index: 1)
         )
         expect(Metalware::Templater).to receive(:render_to_stdout).with(
+          instance_of(Metalware::Config),
           '/var/lib/metalware/repo/hosts/default',
           hash_including(nodename: 'testnode03', index: 2)
         )

--- a/spec/fixtures/configs/repo-unit-test.yaml
+++ b/spec/fixtures/configs/repo-unit-test.yaml
@@ -1,0 +1,2 @@
+
+repo_path: spec/fixtures/repo

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode01_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.render(PXELINUX_TEMPLATE, {
+          Metalware::Templater.render(TEST_CONFIG, PXELINUX_TEMPLATE, {
             nodename: 'testnode01', index: 0, firstboot: false
           })
         )
@@ -159,7 +159,7 @@ RSpec.describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode02_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.render(PXELINUX_TEMPLATE, {
+          Metalware::Templater.render(TEST_CONFIG, PXELINUX_TEMPLATE, {
             nodename: 'testnode02', index: 1, firstboot: false
           })
         )
@@ -170,7 +170,7 @@ RSpec.describe '`metal build`' do
           File.join(TEST_PXELINUX_DIR, 'testnode02_HEX_IP')
         )
         expect(testnode01_pxelinux).to eq(
-          Metalware::Templater.render(PXELINUX_TEMPLATE, {
+          Metalware::Templater.render(TEST_CONFIG, PXELINUX_TEMPLATE, {
             nodename: 'testnode02', index: 1, firstboot: true
           })
         )

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Metalware::Templater do
     SpecUtils.use_unit_test_config(self)
   end
 
-  describe '#file' do
+  describe '#render' do
     context 'when templater passed no parameters' do
       it 'renders template with no extra parameters' do
         expected = <<-EOF

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -58,7 +58,7 @@ module Metalware
             unless file[:error]
               render_path = node.rendered_build_file_path(namespace, file[:name])
               FileUtils.mkdir_p(File.dirname render_path)
-              Templater.render_to_file(file[:template_path], render_path, parameters)
+              Templater.render_to_file(config, file[:template_path], render_path, parameters)
             end
           end
         end
@@ -72,7 +72,7 @@ module Metalware
           files.each do |file|
             unless file[:error]
               render_path = node.rendered_build_file_path(namespace, file[:name])
-              Templater.render_to_file(file[:template_path], render_path, parameters)
+              Templater.render_to_file(config, file[:template_path], render_path, parameters)
             end
           end
         end
@@ -84,7 +84,7 @@ module Metalware
         kickstart_save_path = File.join(
           @config.rendered_files_path, 'kickstart', node.name
         )
-        Templater.render_to_file(kickstart_template_path, kickstart_save_path, parameters)
+        Templater.render_to_file(config, kickstart_template_path, kickstart_save_path, parameters)
       end
 
       def render_pxelinux(parameters, node)
@@ -94,7 +94,7 @@ module Metalware
         pxelinux_save_path = File.join(
           @config.pxelinux_cfg_path, node.hexadecimal_ip
         )
-        Templater.render_to_file(pxelinux_template_path, pxelinux_save_path, parameters)
+        Templater.render_to_file(config, pxelinux_template_path, pxelinux_save_path, parameters)
       end
 
       def template_path(template_type)

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -21,7 +21,7 @@ module Metalware
       def setup(args, options)
         @options = options
         node_identifier = args.first
-        @nodes = Nodes.create(@config, node_identifier, options.group)
+        @nodes = Nodes.create(config, node_identifier, options.group)
       end
 
       def run
@@ -48,7 +48,7 @@ module Metalware
       end
 
       def retrieve_build_files(node)
-        retriever = BuildFilesRetriever.new(node.name, @config)
+        retriever = BuildFilesRetriever.new(node.name, config)
         retriever.retrieve(node.build_files)
       end
 
@@ -65,7 +65,7 @@ module Metalware
       end
 
       def retrieve_and_render_files(parameters, node)
-        retriever = BuildFilesRetriever.new(node.name, @config)
+        retriever = BuildFilesRetriever.new(node.name, config)
         build_files_hash = retriever.retrieve(node.build_files)
 
         build_files_hash.each do |namespace, files|
@@ -82,7 +82,7 @@ module Metalware
         kickstart_template_path = template_path :kickstart
         # XXX Ensure this path has been created
         kickstart_save_path = File.join(
-          @config.rendered_files_path, 'kickstart', node.name
+          config.rendered_files_path, 'kickstart', node.name
         )
         Templater.render_to_file(config, kickstart_template_path, kickstart_save_path, parameters)
       end
@@ -92,14 +92,14 @@ module Metalware
         # file yet - best place to do this may be when creating `Node` objects?
         pxelinux_template_path = template_path :pxelinux
         pxelinux_save_path = File.join(
-          @config.pxelinux_cfg_path, node.hexadecimal_ip
+          config.pxelinux_cfg_path, node.hexadecimal_ip
         )
         Templater.render_to_file(config, pxelinux_template_path, pxelinux_save_path, parameters)
       end
 
       def template_path(template_type)
         File.join(
-          @config.repo_path,
+          config.repo_path,
           template_type.to_s,
           @options.__send__(template_type)
         )
@@ -125,7 +125,7 @@ module Metalware
           all_nodes_reported_built = rerendered_nodes.length == @nodes.length
           break if all_nodes_reported_built
 
-          sleep @config.build_poll_sleep
+          sleep config.build_poll_sleep
         end
       end
 
@@ -146,7 +146,7 @@ module Metalware
       end
 
       def clear_up_built_node_marker_files
-        glob = File.join(@config.built_nodes_storage_path, '*')
+        glob = File.join(config.built_nodes_storage_path, '*')
         files = Dir.glob(glob)
         FileUtils.rm_rf(files)
       end

--- a/src/commands/dhcp.rb
+++ b/src/commands/dhcp.rb
@@ -29,12 +29,12 @@ module Metalware
 
       def render_template
         Templater.render_to_file(
-          template_path, RENDERED_DHCPD_HOSTS_STAGING_FILE
+          config, template_path, RENDERED_DHCPD_HOSTS_STAGING_FILE
         )
       end
 
       def template_path
-        File.join(Constants::REPO_PATH, 'dhcp', @options.template)
+        File.join(config.repo_path, 'dhcp', @options.template)
       end
 
       def validate_rendered_template!

--- a/src/commands/hosts.rb
+++ b/src/commands/hosts.rb
@@ -26,15 +26,15 @@ module Metalware
       def add_nodes_to_hosts
         @nodes.template_each do |parameters|
           if @options.dry_run
-            Templater.render_to_stdout(template_path, parameters)
+            Templater.render_to_stdout(config, template_path, parameters)
           else
-            Templater.render_and_append_to_file(template_path, HOSTS_FILE, parameters)
+            Templater.render_and_append_to_file(config, template_path, HOSTS_FILE, parameters)
           end
         end
       end
 
       def template_path
-        File.join(Constants::REPO_PATH, 'hosts', @options.template)
+        File.join(config.repo_path, 'hosts', @options.template)
       end
     end
   end

--- a/src/commands/hosts.rb
+++ b/src/commands/hosts.rb
@@ -16,7 +16,7 @@ module Metalware
         @options = options
 
         node_identifier = args.first
-        @nodes = Nodes.create(@config, node_identifier, options.group)
+        @nodes = Nodes.create(config, node_identifier, options.group)
       end
 
       def run

--- a/src/commands/render.rb
+++ b/src/commands/render.rb
@@ -16,7 +16,7 @@ module Metalware
           nodename: maybe_node,
         }.reject { |param, value| value.nil? }
 
-        Templater.render_to_stdout(template_path, template_parameters)
+        Templater.render_to_stdout(config, template_path, template_parameters)
       end
     end
   end

--- a/src/commands/repo/update.rb
+++ b/src/commands/repo/update.rb
@@ -14,7 +14,7 @@ module Metalware
         end
 
         def run
-          repo = Rugged::Repository.init_at(Constants::REPO_PATH)
+          repo = Rugged::Repository.init_at(config.repo_path)
           repo.fetch("origin")
 
           local_commit = repo.branches["master"].target

--- a/src/commands/repo/use.rb
+++ b/src/commands/repo/use.rb
@@ -16,11 +16,11 @@ module Metalware
 
         def run
           if @options.force
-            FileUtils::rm_rf Constants::REPO_PATH
+            FileUtils::rm_rf config.repo_path
             MetalLog.info "Force deleted old repo"
           end
 
-          Rugged::Repository.clone_at(@repo_url, Constants::REPO_PATH)
+          Rugged::Repository.clone_at(@repo_url, config.repo_path)
           MetalLog.info "Cloned repo from #{@options.url}"
         rescue Rugged::InvalidError
           raise $!, "Repository already exists. Use -f to force clone a new one"

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -6,9 +6,6 @@ module Metalware
     DEFAULT_CONFIG_PATH = File.join(METALWARE_INSTALL_PATH, 'etc/config.yaml')
 
     METALWARE_DATA_PATH = '/var/lib/metalware'
-    # XXX Sometimes this is used and sometimes value from config (which
-    # defaults to the same) is used.
-    REPO_PATH = File.join(METALWARE_DATA_PATH, 'repo')
     # XXX Ensure created on Metalware install.
     CACHE_PATH = File.join(METALWARE_DATA_PATH, 'cache')
     HUNTER_PATH = File.join(CACHE_PATH, 'hunter.yaml')

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -59,24 +59,24 @@ module Metalware
     class << self
       # XXX rename args in these methods - use `**parameters` for passing
       # template parameters?
-      def render(template, template_parameters={})
-        Templater.new(template_parameters).render(template)
+      def render(config, template, template_parameters={})
+        Templater.new(config, template_parameters).render(template)
       end
 
-      def render_to_stdout(template, template_parameters={})
-          puts render(template, template_parameters)
+      def render_to_stdout(config, template, template_parameters={})
+          puts render(config, template, template_parameters)
       end
 
-      def render_to_file(template, save_file, template_parameters={})
+      def render_to_file(config, template, save_file, template_parameters={})
         File.open(save_file.chomp, "w") do |f|
-          f.puts render(template, template_parameters)
+          f.puts render(config, template, template_parameters)
         end
         MetalLog.info "Template Saved: #{save_file}"
       end
 
-      def render_and_append_to_file(template, append_file, template_parameters={})
-        File.open(append_file.chomp, 'a') do |f|
-          f.puts render(template, template_parameters)
+      def render_and_append_to_file(config, template, append_file, template_parameters={})
+        File.open(config, append_file.chomp, 'a') do |f|
+          f.puts render(config, template, template_parameters)
         end
         MetalLog.info "Template Appended: #{append_file}"
       end
@@ -88,7 +88,9 @@ module Metalware
     # - nodename
     # - index
     # - what else?
-    def initialize(parameters={})
+    def initialize(metalware_config, parameters={})
+      @metalware_config = metalware_config
+
       passed_magic_parameters = parameters.select do |k,v|
         [:index, :nodename, :firstboot, :files].include?(k) && !v.nil?
       end
@@ -136,7 +138,7 @@ module Metalware
       combined_configs = {}
       ordered_node_config_files.each do |config_name|
         begin
-          config_path = "#{Constants::REPO_PATH}/config/#{config_name}.yaml"
+          config_path = "#{@metalware_config.repo_path}/config/#{config_name}.yaml"
           config = YAML.load_file(config_path)
         rescue Errno::ENOENT # Skips missing files
         rescue StandardError => e


### PR DESCRIPTION
This PR fixes an issue where we would sometimes read the path to the repo from the config and sometimes from a hard-coded constant. The key commit with details is in https://github.com/alces-software/metalware/commit/e35bb3cb7535d9c329f0df332a282f281753026b.

This seems a good idea generally, but was particularly important for another feature I've added, the PR for which I'll base off of this.