### PR TITLE
Better handle accessing unset parameters

### DIFF
--- a/spec/fixtures/unset_parameter_template.erb
+++ b/spec/fixtures/unset_parameter_template.erb
@@ -1,0 +1,1 @@
+unset.parameter: <%= unset.parameter %>

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -6,6 +6,7 @@ require 'spec_utils'
 
 TEST_TEMPLATE_PATH = File.join(FIXTURES_PATH, 'template.erb')
 REPO_TEST_CONFIG_PATH = File.join(FIXTURES_PATH, 'configs/repo-unit-test.yaml')
+UNSET_PARAMETER_TEMPLATE_PATH = File.join(FIXTURES_PATH, 'unset_parameter_template.erb')
 TEST_HUNTER_PATH = File.join(FIXTURES_PATH, 'cache/hunter.yaml')
 
 
@@ -85,6 +86,12 @@ RSpec.describe Metalware::Templater do
         expect{
           Metalware::Templater.new(@config)
         }.to raise_error(Metalware::Templater::LoopErbError)
+      end
+
+      it 'raises if attempt to access a property of an unset parameter' do
+        expect {
+          Metalware::Templater.render(@config, UNSET_PARAMETER_TEMPLATE_PATH, {})
+        }.to raise_error Metalware::UnsetParameterAccessError
       end
     end
   end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -24,4 +24,7 @@ module Metalware
 
   class NoRepoError < MetalwareError
   end
+
+  class UnsetParameterAccessError < MetalwareError
+  end
 end

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -64,7 +64,7 @@ module Metalware
       end
 
       def render_to_stdout(config, template, template_parameters={})
-          puts render(config, template, template_parameters)
+        puts render(config, template, template_parameters)
       end
 
       def render_to_file(config, template, save_file, template_parameters={})

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -119,6 +119,12 @@ module Metalware
     def replace_erb(template, template_parameters)
       parameters_binding = template_parameters.instance_eval {binding}
       ERB.new(template).result(parameters_binding)
+    rescue NoMethodError => e
+      # May be useful to include the name of the unset parameter in this error,
+      # however this is tricky as by the time we attempt to access a method on
+      # it the unset parameter is just `nil` as far as we can see here.
+      raise UnsetParameterAccessError,
+        "Attempted to call method `#{e.name}` of unset template parameter"
     end
 
     def nodename

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -43,7 +43,7 @@ module Metalware
       value = @wrapped_obj.send(s)
       if value.nil? && ! @missing_tags.include?(s)
         @missing_tags.push s
-        MetalLog.warn "Missing template parameter: #{s}"
+        MetalLog.warn "Unset template parameter: #{s}"
       end
       value
     end


### PR DESCRIPTION
This PR improves the error shown when an attempt is made to access a property on an unset template parameter; see https://github.com/alces-software/metalware/commit/17fade5c2b2090b657c618589e0283ef2e15ff29 for details.

This PR is a fix for https://trello.com/c/lJuWATLd/51-error-when-running-bin-metal-render-var-lib-metalware-repo-kickstart-default-testnode01---trace; it also addresses https://trello.com/c/5DrQ5WUr/52-make-clear-when-errors-are-template-errors-rather-than-metalware and should resolve that unless we can think of other ways we should make this clear to users.

This PR is based on https://github.com/alces-software/metalware/pull/69. 