### PR TITLE
Migrated ipmi to metalware version 2

### DIFF
--- a/libexec/ipmi
+++ b/libexec/ipmi
@@ -78,10 +78,10 @@ usage()
 {
   echo "(c) 2008-2011 Alces Software Ltd & Stephen F Norledge"
   echo "alces-ipmi command, perform ipmi commands on single or multiple machines"
-  echo "usage: alces ipmi [-g] <name> -c <command>"
+  echo "usage: alces ipmi [-g] <name> -k <command>"
   echo "  options:"
   echo "    -g specify genders node group"
-  echo "    -c specify ipmi command"
+  echo "    -k specify ipmi command"
   echo "  parameters:"
   echo "    <name> node name or genders group name"
   echo
@@ -93,7 +93,7 @@ while ! [ -z "${*}" ]; do
       NODEGROUP="${2}"
       shift 1
       ;;
-    '-c')
+    '-k')
       CMD="${2}"
       shift 1
       ;;

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -37,7 +37,7 @@ module Metalware
         c.syntax = 'metal repo use REPO_URL [options]'
         c.summary = ''
         c.description = ''
-        c.example 'description', 'command example'
+        #c.example 'description', 'command example'
         c.option '-f', '--force',
           'Force use of a new repo even if local changes have been made to the current repo'
         c.action Commands::Repo::Use
@@ -47,7 +47,7 @@ module Metalware
         c.syntax = 'metal repo update [options]'
         c.summary = ''
         c.description = ''
-        c.example 'description', 'command example'
+        #c.example 'description', 'command example'
         c.option '-f', '--force',
           'Force update even if local changes have been made to the repo'
         c.action Commands::Repo::Update
@@ -57,14 +57,14 @@ module Metalware
         c.syntax = 'metal render TEMPLATE [NODE] [options]'
         c.summary = ''
         c.description = ''
-        c.example 'description', 'command example'
+        #c.example 'description', 'command example'
         c.action Commands::Render
       end
 
       command :hosts do |c|
         c.syntax = 'metal hosts NODE_IDENTIFIER [options]'
         c.summary = ''
-        c.description = ''
+        #c.description = ''
         c.example 'description', 'command example'
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
@@ -79,7 +79,7 @@ module Metalware
         c.syntax = 'metal hunter [options]'
         c.summary = ''
         c.description = ''
-        c.example 'description', 'command example'
+        #c.example 'description', 'command example'
         c.option '-i INTERFACE', '--interface INTERFACE', String,
           "Local interface to hunt on (default: #{Defaults.hunter.interface})"
         c.option '-p PREFIX', '--prefix PREFIX', String,
@@ -95,7 +95,7 @@ module Metalware
         c.syntax = 'metal dhcp [options]'
         c.summary = ''
         c.description = ''
-        c.example 'description', 'command example'
+        #c.example 'description', 'command example'
         c.option '-t TEMPLATE', '--template TEMPLATE', String,
           "Specify dhcp template to use (default: #{Defaults.dhcp.template})"
         c.action Commands::Dhcp
@@ -105,7 +105,7 @@ module Metalware
         c.syntax = 'metal build NODE_IDENTIFIER [options]'
         c.summary = ''
         c.description = ''
-        c.example 'description', 'command example'
+        #c.example 'description', 'command example'
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
         c.option '-k KICKSTART_TEMPLATE', '--kickstart KICKSTART_TEMPLATE',
@@ -121,7 +121,7 @@ module Metalware
         c.description = ''
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
-        c.example 'description', 'command example'
+        #c.example 'description', 'command example'
         c.action BashCommand
       end
 
@@ -129,7 +129,7 @@ module Metalware
         c.syntax = 'metal console NODE_IDENTIFIER [options]'
         c.summary = 'Volatile'
         c.description = ''
-        c.example 'description', 'command example'
+        #c.example 'description', 'command example'
         c.action BashCommand
       end
 
@@ -148,6 +148,19 @@ module Metalware
           'Sets the maximum number of network operations' \
           "(default: #{Defaults.status.thread_limit})"
         c.action Commands::Status
+      end
+
+      command :ipmi do |c|
+        c.syntax = 'metal ipmi NODE_IDENTIFIER [options]'
+        c.summary = 'Volatile. Perform ipmi commands on single or multiple machines'
+        c.description = "***VOLATILE***\n\n" \
+                    'Perform ipmi commands on single or multiple machines'
+        #c.example 'description', 'command example'
+        c.option '-g',
+          'Specifies that NODE_IDENTIFIER is the group. MUST be before NODE_IDENTIFIER'
+        c.option '-k COMMAND',
+          'Specifies the ipmi command'
+        c.action BashCommand
       end
 
       def run!


### PR DESCRIPTION
Based on #72 as I needed the new name of BashCommand

The ipmi script has been moved into libexec is being called through the
BashCommand. However there is a clash between Metalware CLI and ipmi's.
It might be worth while rewriting ipmi so that it is ran through ruby
instead of exec.

Also we should consider only using long option tag (e.g. `--opt-tag`)
and removing `-c <config>` tag. This is to prevent conflicts as ruby
will assume you are referring to both simultaneously with a undefined
result. In the meantime, I have resolved a conflict by changing the
ipmi command tag from `-c` to `-k`.

Also commented out the dummy examples in the CLI so they don't get
rendered.