### PR TITLE
Update the CLI to include summaries and descriptions

### DIFF
--- a/src/cli.rb
+++ b/src/cli.rb
@@ -35,8 +35,11 @@ module Metalware
 
       command :'repo use' do |c|
         c.syntax = 'metal repo use REPO_URL [options]'
-        c.summary = ''
-        c.description = ''
+        c.summary = 'Clone a new template git repo'
+        c.description = 'Clones a new git repo from a URL. The repo should ' \
+          'contain the default templates used by the other commands. It may ' \
+          'also include a config directory containing template parameter YAML '\
+          'files.'
         #c.example 'description', 'command example'
         c.option '-f', '--force',
           'Force use of a new repo even if local changes have been made to the current repo'
@@ -45,8 +48,11 @@ module Metalware
 
       command :'repo update' do |c|
         c.syntax = 'metal repo update [options]'
-        c.summary = ''
-        c.description = ''
+        c.summary = 'Updates the git repository'
+        c.description = 'Updates the local git repository to match the remote.'\
+          ' The update command does not support local changes. The force '\
+          'will trigger a hard reset and will delete local changes. All other '\
+          'git commands can be preformed manually on the repo.'
         #c.example 'description', 'command example'
         c.option '-f', '--force',
           'Force update even if local changes have been made to the repo'
@@ -55,17 +61,21 @@ module Metalware
 
       command :render do |c|
         c.syntax = 'metal render TEMPLATE [NODE] [options]'
-        c.summary = ''
-        c.description = ''
+        c.summary = 'Render a given template'
+        c.description = 'Renders the file specified by TEMPLATE and sends the '\
+          'output to standard out. The template can be rendered for a specific '\
+          'node using the optional NODE input.'
         #c.example 'description', 'command example'
         c.action Commands::Render
       end
 
       command :hosts do |c|
         c.syntax = 'metal hosts NODE_IDENTIFIER [options]'
-        c.summary = ''
-        #c.description = ''
-        c.example 'description', 'command example'
+        c.summary = 'Adds a node(s) to the hosts file'
+        c.description = 'Renders the hosts template for the node (or group) ' \
+          'and appends it to /etc/hosts. Note that it does not check if the ' \
+          'node already exists in the file.'
+        #c.example 'description', 'command example'
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
         c.option '-t TEMPLATE', '--template TEMPLATE', String,
@@ -77,8 +87,15 @@ module Metalware
 
       command :hunter do |c|
         c.syntax = 'metal hunter [options]'
-        c.summary = ''
-        c.description = ''
+        c.summary = 'Detects and caches DHCP discover messages'
+        c.description = 'Hunter is used in conjunction with the dhcp command ' \
+        'to update dhcp server. Hunter listens out for dhcp discovery ' \
+        'messages from the booting nodes. Hunter assigns the nodes a node ' \
+        'name based of PREFIX or user input. The node\'s name and ' \
+        "MAC address is then cached.\n\nHunter will continue listening " \
+        'for nodes until it is interrupted. A single MAC address will only be '\
+        'cached once per run even if the compute node reboots. Refer to dhcp ' \
+        'command to updated the dhcp server.'
         #c.example 'description', 'command example'
         c.option '-i INTERFACE', '--interface INTERFACE', String,
           "Local interface to hunt on (default: #{Defaults.hunter.interface})"
@@ -93,8 +110,12 @@ module Metalware
 
       command :dhcp do |c|
         c.syntax = 'metal dhcp [options]'
-        c.summary = ''
-        c.description = ''
+        c.summary = 'Renders and reboots dhcp from the hunter cache'
+        c.description = 'Dhcp renders a template which is used to update the ' \
+          'dhcp server. Dhcp is designed  to run after hunter and read from ' \
+          'its cache. Hunter cache can be iterated over in the template with ' \
+          '"alces.hunter.each". The rendered dhcp template is validated ' \
+          'before the dhcp server is reset.'
         #c.example 'description', 'command example'
         c.option '-t TEMPLATE', '--template TEMPLATE', String,
           "Specify dhcp template to use (default: #{Defaults.dhcp.template})"
@@ -103,8 +124,17 @@ module Metalware
 
       command :build do |c|
         c.syntax = 'metal build NODE_IDENTIFIER [options]'
-        c.summary = ''
-        c.description = ''
+        c.summary = 'Renders the templates used to build the nodes'
+        c.description = 'Build is used to rendered template files before ' \
+          'waiting for the compute nodes to pxe-boot and build. Build by ' \
+          'default will render the pxelinux and kickstart templates. In ' \
+          'additional, build renders the "files" list in [config].yaml for ' \
+          "the gender group and node.\n\nBuild will then wait for the nodes " \
+          'to build. Once a node has finished building, it needs to curl ' \
+          '"alces.build_complete_url" which notifies build that the node is ' \
+          'complete. This will trigger the pxelinux file to be re-rendered ' \
+          'with "firstboot" set to false. Build will exit once all the nodes ' \
+          'have finished building.'
         #c.example 'description', 'command example'
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
@@ -117,8 +147,16 @@ module Metalware
 
       command :power do |c|
         c.syntax = 'metal power NODE_IDENTIFIER [COMMAND] [options]'
-        c.summary = 'Volatile'
-        c.description = ''
+        c.summary = 'Volatile. Run power commands on a node.'
+        c.description = 'Allows ipmi power commands to be ran on a node(s)' \
+          "\n\nThe following commands are supported: " \
+          "\non        - Turns the node on" \
+          "\noff       - Turns the node off" \
+          "\nstatus    - Display the power status" \
+          "\nlocate    - Turns the node locater light on" \
+          "\nlocateoff - Turns the node locater light off" \
+          "\ncycle     - Power cycle the node" \
+          "\nreset     - Warm reset the node"
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
         #c.example 'description', 'command example'
@@ -127,8 +165,10 @@ module Metalware
 
       command :console do |c|
         c.syntax = 'metal console NODE_IDENTIFIER [options]'
-        c.summary = 'Volatile'
-        c.description = ''
+        c.summary = 'Volatile. Display a node\'s console in the terminal'
+        c.description = 'Displays the console of a node in the terminal. The ' \
+          'console command operates over the BMC network and can be used as ' \
+          'node is booting.'
         #c.example 'description', 'command example'
         c.action BashCommand
       end
@@ -136,8 +176,8 @@ module Metalware
       command :status do |c|
         c.syntax = 'metal status NODE_IDENTIFIER [options]'
         c.summary = 'Display the current network status of the nodes'
-        c.description = "The status tool will attempt to determine the power and" \
-                        " ping status of the node(s)."
+        c.description = "The status tool will attempt to determine the power " \
+                        "and ping status of the node(s)."
         c.option '-g', '--group', String,
           'Switch NODE_IDENTIFIER to specify a gender group rather than a single node'
         c.option '--wait-limit WAIT_LIMIT', Integer,


### PR DESCRIPTION
Added descriptions and summaries for the commands. Feel free to edit as you please.

Should we add some general information about metal itself? I was thinking having a description section that comes up when you run `metal --help`. This section can go into how the templater/ magicnamespace + config files work.