### PR TITLE
Allow iterating through template parameters

### DIFF
--- a/spec/iterable_recursive_open_struct_spec.rb
+++ b/spec/iterable_recursive_open_struct_spec.rb
@@ -1,0 +1,51 @@
+
+require 'iterable_recursive_open_struct'
+
+RSpec.describe Metalware::IterableRecursiveOpenStruct do
+  subject {
+    Metalware::IterableRecursiveOpenStruct.new({
+      prop: 'value',
+      nested: {
+        prop: 'nested_value',
+      }
+    })
+  }
+
+  describe 'property setting and access' do
+    it 'works as for RecursiveOpenStruct' do
+      expect(subject.prop).to eq('value')
+      expect(subject.nested.prop).to eq('nested_value')
+
+      subject.new_prop = 'new_value'
+      expect(subject.new_prop).to eq('new_value')
+    end
+  end
+
+  describe '#each' do
+    it 'iterates through the entries' do
+      keys = []
+      values = []
+
+      subject.each do |k,v|
+        keys << k
+        values << v
+      end
+
+      expect(keys).to eq([:prop, :nested])
+      expect(values.first).to eq('value')
+
+      # Converts any hash values to same class before iterating.
+      expect(values.last).to eq(
+        Metalware::IterableRecursiveOpenStruct.new({prop: 'nested_value'})
+      )
+    end
+  end
+
+  describe '#each=' do
+    it 'raises to prevent setting value for each' do
+      expect {
+        subject.each = 'some_value'
+      }.to raise_error Metalware::IterableRecursiveOpenStructPropertyError
+    end
+  end
+end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -42,4 +42,7 @@ module Metalware
 
   class InvalidInput < MetalwareError
   end
+
+  class IterableRecursiveOpenStructPropertyError < MetalwareError
+  end
 end

--- a/src/iterable_recursive_open_struct.rb
+++ b/src/iterable_recursive_open_struct.rb
@@ -1,0 +1,26 @@
+
+module Metalware
+  class IterableRecursiveOpenStruct < RecursiveOpenStruct
+    def each(&block)
+      convert_hash_values_to_own_class.each(&block)
+    end
+
+    def each=(*args)
+      raise IterableRecursiveOpenStructPropertyError,
+        "Cannot set property 'each', reserved to use for iteration"
+    end
+
+    private
+
+    def convert_hash_values_to_own_class
+      to_h.map do |k, v|
+        case v
+        when Hash
+          [k, IterableRecursiveOpenStruct.new(v)]
+        else
+          [k, v]
+        end
+      end.to_h
+    end
+  end
+end

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -22,7 +22,6 @@
 require "erb"
 require "ostruct"
 require "yaml"
-require 'recursive-open-struct'
 require 'active_support/core_ext/hash/keys'
 require 'hashie'
 
@@ -31,6 +30,7 @@ require 'nodeattr_interface'
 require 'metal_log'
 require 'deployment_server'
 require 'exceptions'
+require 'iterable_recursive_open_struct'
 
 module Metalware
   class MissingParameterWrapper
@@ -216,7 +216,7 @@ module Metalware
     end
 
     def create_template_parameters(config)
-      MissingParameterWrapper.new(RecursiveOpenStruct.new(config))
+      MissingParameterWrapper.new(IterableRecursiveOpenStruct.new(config))
     end
   end
 


### PR DESCRIPTION
When writing Metalware templates it is sometimes desirable to be able to iterate through a set of key-value pairs, rather than needing to access parameters individually; previously this was not possible (without
writing a convoluted template).

This commit allows this by adding a new class to be used for the template parameters loaded from the repo config, which functions the same as `RecursiveOpenStruct` but with an additional `each` method.

This seemed the simplest way to add this functionality without making future issues and confusion likely; we do not want to make this class have all `Enumerable` methods otherwise issues would occur when setting any properties with the same names in the config.