### PR TITLE
Update Metalware to use Commanders new subcommands

### DIFF
--- a/src/cli.rb
+++ b/src/cli.rb
@@ -33,6 +33,12 @@ module Metalware
         '--quiet', 'Suppress any warnings from being displayed'
       )
 
+      command :'repo' do |c|
+        c.syntax = 'metal repo [options]'
+        c.summary = 'Manage template and config repository'
+        c.sub_command_help = true
+      end
+
       command :'repo use' do |c|
         c.syntax = 'metal repo use REPO_URL [options]'
         c.summary = ''
@@ -40,6 +46,7 @@ module Metalware
         #c.example 'description', 'command example'
         c.option '-f', '--force',
           'Force use of a new repo even if local changes have been made to the current repo'
+        c.hidden = true
         c.action Commands::Repo::Use
       end
 
@@ -50,6 +57,7 @@ module Metalware
         #c.example 'description', 'command example'
         c.option '-f', '--force',
           'Force update even if local changes have been made to the repo'
+        c.hidden = true
         c.action Commands::Repo::Update
       end
 

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -36,7 +36,7 @@ module Metalware
       command :'repo' do |c|
         c.syntax = 'metal repo [options]'
         c.summary = 'Manage template and config repository'
-        c.sub_command_help = true
+        c.sub_command_group = true
       end
 
       command :'repo use' do |c|
@@ -46,7 +46,7 @@ module Metalware
         #c.example 'description', 'command example'
         c.option '-f', '--force',
           'Force use of a new repo even if local changes have been made to the current repo'
-        c.hidden = true
+        c.sub_command = true
         c.action Commands::Repo::Use
       end
 
@@ -57,7 +57,7 @@ module Metalware
         #c.example 'description', 'command example'
         c.option '-f', '--force',
           'Force update even if local changes have been made to the repo'
-        c.hidden = true
+        c.sub_command = true
         c.action Commands::Repo::Update
       end
 


### PR DESCRIPTION
This PR is dependant on the new version of Commander. Please merge the following PR first:
https://github.com/alces-software/commander/pull/1

Created a `repo` command that appears in the main help. It is responsible for display the help for it's subcommands. The sub commands (`update` and `use`) have been removed from the main help as they now appear in the sub help.