### PR TITLE
Add Metalware design docs, in particular for topologies

### DIFF
--- a/docs/design/01-metalware-improvements.md
+++ b/docs/design/01-metalware-improvements.md
@@ -1,0 +1,502 @@
+
+This document describes the planned/suggested improvements to the Metalware CLI
+for building clusters, with the aims of making it simpler, more flexible, and
+more consistent, both for internal use and as a base for use by higher-level
+tools. Once we have this improved Metalware CLI we plan to use it as the base
+for developing one or more 'wizard-like' CLI or GUI tools, which will be
+provided to customers for building bare metal and/or Flight clusters with
+reasonably standard configurations.
+
+This base Metalware tool is mostly intended for us/Steve to use, therefore it
+is not worth attempting to bring absolutely everything needed to build any
+cluster into one tool which will never need to be left. This tool needs to be
+very flexible to handle building clusters with any odd requirements, and this
+will always require a certain amount of manual tweaking - from our perspective
+Metalware is a way to save time and avoid mistakes while doing this, while
+retaining flexibility.
+
+Note that this document only concerns the tools directly related to building
+clusters, which are currently as follows:
+
+- `repo`
+- `hosts`
+- `hunter`
+- `scripts`
+- `kickstart`
+- `boot`
+
+Metalware also currently also contains the following other tools:
+
+- `console`
+- `each`
+- `ipmi`
+- `power`
+- `status`
+
+These are utilities for working with bare metal clusters; these are not
+discussed here however they will probably be folded into the updated CLI at
+some point, possibly with some tweaks to their current form.
+
+
+# New CLI library
+
+It makes sense to use a new CLI library for Metalware when making these
+changes, rather than the custom Alces tools we use at the moment. Benefits of
+doing this:
+
+- make things more consistent between different commands
+
+- simpler to add subcommands (which we may want to do in some cases to make the
+  interface a bit easier to use)
+
+- easier to use, and more flexible for the various common things we want to do
+
+[Commander](https://github.com/commander-rb/commander) seems the obvious choice
+for this since it seems like the Ruby CLI library which provides the most, and
+we also use it already for other tools (e.g. Gridware).
+
+
+# Multiple clusters
+
+For now we are not doing any special handling for building multiple clusters
+with Metalware. If you want to do this you can always manually reset or adjust
+things as needed to stop things intended for different clusters interfering, as
+well as namespace things intended for different clusters as needed (e.g. name
+nodes like `cluster1.node01` etc).
+
+
+# Repo adjustments
+
+Metalware will now only have a single repo active at a time. Repos will contain
+a bit less than they do currently, but further files will be able to be used
+from arbitrary other locations (see
+[below](#metalware-config-files-parameter)).
+
+There will be no default repo; when using Metalware on a new machine you must
+initially specify a repo to be used.
+
+Adjusted repo layout:
+
+- There will be directories for each of the special templates, each of these
+  will contain a `default` file which is used as the default template for that
+  template type, as well as any other additional templates. These directories
+  are:
+
+  - `pxelinux` (formerly `boot`)
+  - `hosts`
+  - `dhcp` (formerly `hunter`)
+  - `kickstart`
+
+- There is also a `files` directory for holding arbitrary templates, which is
+  pretty much what the `scripts` directory is currently but more generally
+  named to reflect the fact that these templates can be anything (scripts,
+  config files, snippets of larger files etc).
+
+
+# Metalware config `files` parameter
+
+Within Metalware config files a user will be able to specify a `files`
+parameter. Although we will leave the `files` parameter untouched when passing
+this to the templater, we will pick up this information and use it in a special
+way.
+
+The `files` parameter in a config file takes the following format:
+
+
+```yaml
+- files: 
+  namespace1:
+    - file1
+    - /path/to/some/file/file2
+  namespace2:
+    - file1
+    - http://example.com/path/to/file
+```
+
+Each `files` parameter contains some arbitrary namespaces; these can be
+anything. Within each of these will be a list of files. These files can be
+specified as any of:
+
+- a file within the files directory of the Metalware repo
+
+- an absolute path to a file on the deployment server
+
+- the URL to get the file from; we don't care what this is, it can be a file in
+  another Git repo, a file on S3 etc.
+
+When running the [new `metal build` command](#build-command), for
+each node to be built we will load all the applicable `files` from
+its applicable configs.  This will then be merged into an overall
+files object for that node. For each file specified we then:
+
+- obtain the file from the specified location
+
+- render this file for the node in the usual way
+
+- then when rendering the main files for this node (the `pxelinux` config,
+  `kickstart` file etc.) information about the rendered files will be made
+  available within the templates (see [below](#templating-adjustments))
+
+
+# Templating adjustments
+
+## Magic namespace
+
+In addition to the current magic parameters provided in templates by the
+Metalware templater (and with the exception of some of these which are no
+longer needed or provided in a different way), we also want to provide access
+to the following magic parameters within templates:
+
+- URLs on the Metalware deployment server that the `hosts` file, `genders`
+  file, and potentially other similar system files can be obtained from
+
+- a URL on the deployment server that is used to inform Metalware that the node
+  being templated has finished building (this will be for the `kscomplete.php`
+  script, or equivalent new version of this)
+
+- the information gathered by `hunter` (see [splitting `hunter`
+  section](#splitting-hunter))
+
+- when running the `build` command, information on the rendered files for that
+  node
+
+To avoid a profusion of magic parameters available within templates leading to
+confusion, we have decided to namespace all magic parameters to be made
+available within templates within an `alces` object. This will be the only
+variable which it will be an error to set in config files. All information in
+this namespace will be generated based on the current node, information on the
+deployment server, user input etc. 
+
+A possible layout for this namespace is as follows:
+
+- `variables` = values which vary based on the current node
+  - `nodename`
+  - `index`
+  - `build_complete_url`
+
+- `constants` = values based on details of the deployment server, which will
+  not vary by current node
+  - `hostip`
+  - `hosts_url`
+  - `genders_url`
+
+- `hunter` = array of nodename/MAC address pairs, as found by the adjusted
+  hunter command
+
+- `files` = only available when running the `build` command; contains an array
+  of objects for each of the rendered files for the current node, as discussed
+  above. Each entry in this array will have the following format:
+
+  - `raw` = the raw value entered in the config to specify this file, i.e. a
+    file path within the repo, an absolute path on the deployment server, or a
+    URL
+
+  - either:
+    - `error` = info on the error if we couldn't find the file, specific to the
+      type of file to be found; when this occurs we will by default also output
+      the error as a warning to inform the user
+
+    - the following values with info about the file:
+      - `name` = the rendered file name
+      - `url` = a URL to obtain the rendered file from the deployment server
+
+Alternatively, maybe we don't need the distinction between `variables` and
+`constants`? We could just have all these values in the main `alces` namespace.
+
+Note some current magic parameters are not present in the above, this is
+because we have decided they are no longer needed with the Metalware
+refactoring; these are:
+
+- for `boot`:
+
+  - `kickstart` - `boot` is being merged into the new `build` command (see
+    [here](#build-command)), which always renders kickstart files.
+
+  - `permanent` - the distinction between permanent and temporary booting is
+    leftover from when the Metalware templating didn't exist; we no longer need
+    this and can just adjust templates as needed.
+
+  - `kernelappendoptions` - leftover from before the full templating was
+    implemented, there is no longer a need for special handling of this, we can
+    just set this in config files as needed.
+
+- for `hunter`:
+  - `fixedaddr` and `hwaddr` no longer need special handling, due to the
+    `hunter` split (see [splitting `hunter` section](#splitting-hunter)) all
+    values found by hunter will be available when rendering all templates
+
+Note also that this means there are no longer differing magic values between
+the different commands which render templates, simplifying these (aside from
+the new `files` parameter, which although it could always be generated and
+provided it only makes sense/is simpler to provide for just the `build`
+command).
+
+
+## Adjusting templating options
+
+Currently it is possible to specify JSON overrides when templating using the
+`--json` parameter for various commands.
+
+Compared to specifying values within the config file hierarchy this has the
+disadvantage of making it harder to reproduce building nodes. For example, if
+one user builds a cluster using some JSON overrides, and then later another
+user wants to modify some templated files for some nodes of this cluster, even
+if the latter user changes the templates and configs, without knowing the exact
+JSON overrides used earlier they may get a different result.
+
+Given this disadvantage and the lack of an advantage to using this parameter
+(any such changes can always be made in a config file) we will be removing this
+parameter, which should make building nodes generally more likely to be
+reproducible.
+
+Additionally we want to remove the `--template-options` parameter provided for
+various Metalware commands; the information given by this parameter would be
+better suited to being in documentation.
+
+
+## Warning about unset values
+
+We also want to make a warning be output when templating files if an attempt is
+made to use an unset value in the ERB; this will only be a warning by default
+as sometimes it is desirable to have parameters be optionally set, or insert
+nothing when they are unset.
+
+
+## Providing access to raw templater
+
+To support arbitrary access to templating in any way while building a cluster,
+we will now also have a command providing direct access to the templater. This
+new `render` command will simply take a (absolute, or relative to the working
+directory) path and optionally a node name, load the config in the usual way
+for this node, and output the rendered template to stdout. The output can then
+be piped or redirected as needed.
+
+
+# Splitting `hunter`
+
+Currently the `hunter` command performs two related, intertwined functions:
+
+- watching for nodes coming up on the network and displaying their MAC
+  addresses
+
+- writing a dhcp config file given the found MAC addresses and chosen node
+  names as these come up
+
+To increase the flexibility of Metalware and make it simpler to recover from
+mistakes using `hunter` we have decided to split this command in two based on
+these functions:
+
+- a cut-down `hunter` command:
+  - looks for MAC addresses as the current `hunter` does, and accepts node
+    names to associate with these when found
+  - performs no validation that the given node name is defined in the `hosts`
+    file or is not duplicated in `dhcp.hosts`; does not restart `dhcpd`
+  - writes output to new cache file in `/var/lib/metalware/cache/hunter.yaml`;
+    the data from this file will then be made available in any future
+    templating within the `alces.hunter` object (described above)
+
+- a new `dhcp` command:
+  - a simple wrapper command around running new `render` command with a `dhcp`
+    config template and outputting this to `/etc/dhcp/dhcp.hosts`, along with
+    some associated validation and restarting of `dhcpd`. The best way to
+    validate this may be to make a backup before making the changes, restart
+    `dhcpd`, and if this fails rollback the config and output the error;
+    alternatively there may be some other way to validate `dhcp` configs.
+  - this command will happen to use information found by `hunter` command,
+    however it will not have any special info available to it compared to in
+    other templates, and can also use any other template data if needed; other
+    commands run after `hunter` can also use the `alces.hunter` info if needed
+
+Note that this change means within Metalware repos the `dhcp` template will now
+be for the entire `dhcp.hosts` file, rather than just for individual nodes
+within this.
+
+# Splitting `hosts`
+
+Similarly to `hunter`, we would like to split `hosts` in to two commands as
+well:
+
+- a stage to build up a config file in `/var/lib/metalware/cache` specifying
+  the association of node names with IPs on various networks, or possibly to
+  just associate indices with nodes on particular networks (which can then be
+  used to generate IPs)
+
+- another similar wrapper around `render` for rendering `hosts`, which will
+  entirely rerender the `hosts` file based on the built up config (as well as
+  any other template parameters needed)
+
+Given these commands we could incrementally build up the `hosts` config and
+rerender the file as needed, without risking duplicate or obsolete entries.
+
+However given that the current way of rendering `hosts` is mostly sufficient,
+and that this split would be more work than the `hunter` split (as we will need
+to handle multiple IPs and names for nodes), we will keep the current
+functionality for the moment. We may investigate this split further at some
+point but it is not key for the initial improvements.
+
+
+# `build` command
+
+We plan to combine the `scripts`, `kickstart`, and `boot` commands into a new
+`build` command. These commands currently serve one purpose, of rendering the
+scripts needed when building a node, so it makes sense to combine them; this
+also means the rendered scripts will always be consistent and will be the
+scripts last used when building that node.
+
+This command will function as follows:
+
+- given a node name or group, for each specified node:
+
+  - the config files are loaded in the standard way, including the
+    `alces.files` object as described above
+
+  - each specified file is obtained and rendered for the current node; the
+    result of this is saved in the `files` object, as also described above
+
+  - the `kickstart` and `pxelinux` files are rendered for the current node.
+    Note that:
+    - The `pxelinux` files will be rendered the same as for `boot` currently,
+      to `/var/lib/tftpboot/pxelinux.cfg/`; the `kickstart` files will now
+      always be rendered to `/var/lib/metalware/rendered` (we now only need the
+      'permanent' boot behaviour)
+    - As with the other special templates, the `kickstart/default` and
+      `pxelinux/default` templates will be used by default in this command;
+      `--kickstart` and `--pxelinux` options will be available to override this
+      if necessary.
+
+  - the 'boot' process will execute and watch for built nodes, similarly to the
+    current `boot` behaviour; this will always function with the current
+    'permanent' boot behaviour
+
+  - if the 'boot' process is interrupted, before exiting options will be given
+    to either act as if all nodes reported as built, and rewrite the configs
+    appropriately, or to just exit without cleanup. The former will be the
+    default behaviour, as this is usually what we want to happen if e.g. a
+    build is started and a while later we realize some needed file is missing.
+ 
+
+# Summary
+
+## Adjusted commands layout
+
+Following from the various points above, the new suggested new layout of
+Metalware build commands will be as follows:
+
+- `repo`
+
+    - `use REPO_URL` = performs the current behaviour of `repo --clone` for the
+      given repo, installing it as Metalware's (only) repo. Options:
+      - `--force`/`-f` = to force the use of a new repo even if local changes
+        have been made
+
+    - `update` = performs the current behaviour of `repo --update`, except
+      always for the single repo. Options:
+      - `--force`/`-f` = to force the update even if local changes have been
+        made
+
+- `render TEMPLATE_PATH [NODE_NAME]` = load config and render given ERB
+  template for given node (if given) to stdout. Notes:
+  - for one-off templating it may still be useful to provide a JSON overrides
+    option for just this command - thoughts?
+
+- `hosts` = perform the current behaviour of `hosts --add` (for the moment at
+  least, until we investigate changing the way rendering `hosts` works, as
+  described above). Options:
+  - one of the following is required to specify the nodes to add:
+    - `--node`/`-n`
+    - `--group`/`-g`
+  - `--template`/`-t` = specify template in `/var/lib/metalware/rendered/hosts`
+    to use (instead of `default`)
+  - `--dry-run`/`-x`
+
+- `hunter` = look for nodes on the network and then associate names with each
+  found MAC address; results are saved to
+  `/var/lib/metalware/cache/hunter.yaml`. Options:
+    - `--interface`/`-i`
+    - `--prefix`/`-p` = same as current `--identifier`, but more descriptive
+      name for purpose
+    - `--length`/`-l`
+    - `--start`/`-s`
+
+- `dhcp` = simple wrapper around `render` for `dhcp` templates and outputting
+  result to `/etc/dhcp/dhcp.hosts`; validates the resulting config file and
+  restarts `dhcpd`
+  - `--template`/`-t` = specify template in `/var/lib/metalware/rendered/dhcp`
+    to use (instead of `default`)
+
+- `build` = combination of rendering needed files for each specified node
+  (specified `files`, `kickstart`, and `pxelinux` config) and then waiting for
+  `boot` process to complete
+  - one of the following is required to specify the nodes to build:
+    - `--node`/`-n`
+    - `--group`/`-g`
+  - `--kickstart`/`-t` = specify Kickstart template in
+    `/var/lib/metalware/rendered/kickstart` to use (instead of `default`)
+  - `--pxelinux`/`-p` = specify Pxelinux template in
+    `/var/lib/metalware/rendered/pxelinux` to use (instead of `default`)
+
+Note that:
+  - various options are no longer needed in the new CLI
+  - of those options mentioned above, these should function in the same way as
+    the existing option unless stated otherwise
+  - the node name or group options, where present, are just called `--node` or
+    `--group`
+  - only `hosts` and `build` still need to be passed either a `node` or `group`
+    option, no other commands need to operate on the level of individual nodes.
+    If/when `hosts` is changed to function more like the split `hunter` then it
+    will also not need to operate at this level (as the config will be built up
+    distinct from the rendering, and the rendering will use the full config)
+
+
+### Shared options
+
+Additionally, all commands will have the following options available:
+
+- `--help`/`-h`
+
+- `--verbose`/`-v`
+
+- `--quiet`/`-q` = in several places in this document warnings are mentioned; this
+  will suppress these and other errors from being output (not essential for MVP
+  Metalware improvements)
+
+- `--strict`/`-s` = converts these warnings in to errors, and causes commands
+  to fail fast when these are encountered (also not essential for MVP)
+
+
+## Metalware directories
+
+Where possible we want to confine Metalware's data to `/var/lib/metalware/`;
+this directory will have the following layout:
+
+- `repo` = the current Metalware `repo`
+
+- `rendered` = the location for all rendered files aside from those which need
+  to be output to `/var/lib/tftpboot/pxelinux.cfg/` or `/etc/`
+
+- `cache` = the location for any `config`-type files generated using Metalware,
+  which will be made available when templating; currently will just contain
+  `hunter.yaml` but more files may later be written here
+
+- `system` = links to system files which will be made available by the
+  Metalware deployment server; currently will just contain `hosts` and
+  `genders`
+
+- `exec` = scripts on the deployment server which will be made available to be
+  triggered by requests from nodes; currently will just contain the
+  `kscomplete.php` script for reporting nodes are built.
+
+  Aside: it may be worth removing this PHP script at some point and replacing
+  it with using `alces-flight-trigger` for this purpose. This would mean we no
+  longer need to have Apache for this purpose, proxied to by Nginx. I made an
+  initial look at doing this in
+  https://github.com/alces-software/imageware/commit/ada3e817f7f369c8db4ee2a52419dcc12228c74d
+  but have left it for now as the current way works OK. If we were to do this
+  we could probably make the `alces-flight-trigger` credentials available as a
+  magic parameter when templating; nodes would then need to use these when
+  reporting that they have built.
+
+Given this directory structure, the `rendered`, `system`, and `exec`
+directories will currently be made available on the deployment server to nodes.
+These will normally be accessed using parameters from the `alces` namespace
+when templating files for nodes.

--- a/docs/design/02-topologies.md
+++ b/docs/design/02-topologies.md
@@ -1,0 +1,288 @@
+
+# Overview
+
+- Will have new `metal configure` command group for configuring values to be
+  used within config files for all nodes, a group of nodes, or an individual
+  node:
+  - `metal configure all`
+  - `metal configure group GROUP`
+  - `metal configure node NODE`
+
+- These commands may also perform other behaviour specific to the type of
+  resource being configured.
+
+- Note that these commands will be just one interface for configuring the
+  'topology' of a cluster; it should be possible for alternative interfaces,
+  such as a future web interface or manual editing, to modify the same files,
+  and the loading of these files for use when templating will be independent of
+  the `configure` commands.
+
+- There will be a `configure.yaml` file in the repo root, specifying
+  configuration questions to be used within these commands or alternative
+  interfaces.
+
+- The `configure` commands will save the entered answers to a file in
+  `/var/lib/metalware/config`, specific to the resource being configured.
+
+- Repo configs will be able to use a new object in the magic `alces` namespace,
+  `alces.config.$question_identifier`, where `$question_identifier` is the
+  identifier for a particular question specified in `configure.yaml`; when
+  templating the corresponding question answer will then be used in these
+  places.
+
+
+# `configure.yaml` format
+
+There will also be a `configure.yaml` in the repo root, which specifies
+configuration questions for the different categories, with the following
+suggested format:
+
+```yaml
+questions:
+  example_question_identifier: &example_question_identifier
+    question: 'What value should this take?' # Required.
+    choices: # Optional; limit choices to one of these options.
+      - 7
+      - 11
+    default: 11 # Optional; default value to use when no input entered, if any.
+    type: 'integer' # Optional/default `'string'`. For validation and converting; see below for details.
+    required: true # Optional/default `true`
+
+  another_example: &another_example
+    question: 'Enter anything?'
+
+all:
+  # Both these questions will be asked for `metal configure all`.
+  example_question_identifier: *example_question_identifier
+  another_example: *another_example
+
+group:
+  # Just ask this question for `metal configure group`.
+  another_example: *another_example
+
+node:
+  # Similarly, just ask this for `metal configure node`. Note: the answer will
+  # be saved under `different_name` in the resulting config this time however.
+  different_name: *example_question_identifier
+```
+
+## Notes regarding above format
+
+- By defining all the questions within a `questions` object we can then share
+  questions between different categories without duplication using YAML's
+  ability to refer to other parts of the document.
+
+- Any name key can be used when specifying a question for a particular
+  category. Often the same identifier will be used for the question definition
+  and when specifying a question for a category, e.g. a `cluster_name` question
+  may be defined in `questions` and then used as `cluster_name` under `all`,
+  however this will not necessarily always need to be the case.
+
+## Notes on `type`
+
+The `type` for a question will serve the dual purpose of validating input and
+then converting this before saving.
+
+For the minimal version of this feature possible type values will probably just
+include `string`, `integer`, and `boolean`. These will be necessary as since we
+are accepting user input we won't know what type we should save a given answer
+as, and we will need non-string types when templating.
+
+Later we can add types with more validation here, e.g. we can have an `ip` type
+which will save the value as a string but validate that it is a valid IP first.
+While these more complicated validations could be specified separately by
+adding an optional regular expression field to question configs, I think
+building these in to Metalware would be better since:
+
+- there will only be a limited number of these more advanced types, and I don't
+  think we need the flexibility of allowing more validations to be specified in
+  the repo;
+
+- having these built in to Metalware means we won't need to duplicate
+  validations between repos or places within repos;
+
+- we may later want to do non-regex validation, e.g. a `dns` type could
+  validate that a particular IP entered gives the expected DNS response (though
+  this particular example sounds like overkill).
+
+
+# `metal configure` commands
+
+The `metal configure` commands each take their specified questions and ask
+them, save the results to a particular file within a new
+`/var/lib/metalware/config/` directory, and perform any other actions
+appropriate to the resource being configured.
+
+## `metal configure all`
+
+Asks the `all` questions; the validated, converted answers will be saved to
+`/var/lib/metalware/config/all.yaml` in the following format:
+
+```yaml
+answers:
+  example_question_identifier: 7
+  another_example: 'foo'
+```
+
+## `metal configure group $GROUP`
+
+Asks for a genders line to be entered first, then similarly to `all` asks the
+`group` questions; the results will then be saved to
+`/var/lib/metalware/config/groups/$GROUP.yaml`
+
+```yaml
+genders: 'somenodes[01-03] somenodes,cluster,all'
+answers:
+  another_example: 'foo'
+```
+
+Note that initially the genders line will just take a line of text, later we
+can add more validation and potentially generate this based on e.g. entering a
+number of nodes in the group and a group name.
+
+Every time `metal configure group` is run we should regenerate
+`/opt/metalware/etc/genders` by (for now at least) simply concatenating all the
+group gender lines together; this way it should always be in sync with the
+configured groups. Aside: it may be worth including a line in the generated
+genders indicating this and that any changes to it directly may not persist.
+
+## `metal configure node $NODE`
+
+Similarly asks the questions configured for `node`, and saves these to
+`/var/lib/metalware/config/nodes/$NODE.yaml`. Note that unlike `configure all`,
+required before any nodes/group can be built, or `configure group`, required
+before a particular group can be built, it will not be required to `configure
+node` before building a particular node; `configure node` just provides a way
+to further specialize a particular node's configuration.
+
+## Re-running `configure` commands
+
+If any `configure` command is re-run we will also want to pre-fill the answer
+to each question with the saved answer.
+
+When saving the answers after re-running `configure`, we will want to make sure
+just the new answers are saved. For instance:
+
+- `metal configure all` run, an answer `'foo'` is given for the `some_question`
+  question;
+
+- the question `some_question` for `all` is removed from
+  `/var/lib/metalware/repo/configure.yaml`;
+
+- `metal configure all` is run again; `some_question` won't be asked and we
+  should make sure the previous answer is not still included in the resulting
+  config file.
+
+
+# `hosts` generation
+
+With the addition of groups being defined separately from the genders file, it
+should now be possible to have the whole `hosts` file generated in one pass
+from a single template. To do this we will need a way when templating to get
+all the defined groups, along with the nodes within each group and the config
+for each node (to get each node's IP and hostname etc).
+
+A possible way to do this would be to have an `alces.groups` method, which
+takes a block with 2 arguments, `group_index` and `group`. `group_index` will
+simply be a unique index for each configured group; `group` will have a `nodes`
+method which takes a block with a `node` argument; `node` will provide access
+to the loaded config for the given node, the same as would be available at the
+top level if the templater was run with the `nodename` for this node and an
+appropriate `index`.
+
+This could then be used to generate a `hosts` file in some way, possibly like
+this:
+
+```erb
+<%# Note: may not actually need to provide group_index here, just make it
+available in configs. %>
+<% alces.groups do |group_index, group| %>
+
+  <% group.nodes do |node| %>
+
+    <% node.networks.each do |name, network| %>
+      <%# Note: `network.ip` could be either hard-coded or generated
+      dynamically using `group_index` and `index` etc, will depend on config.
+      %>
+      <%= network.ip %> <%= network.hostname %> <%= network.short_hostname %>
+    <% end %>
+
+  <% end %>
+
+<% end %>
+```
+
+The `alces.groups` parameter in this situation is going to load the config for
+every possible node in every configured group for the Cluster. There is the
+potential that this will be noticeably slow; if this is the case we may want to
+have this only available in certain situations, for example when a
+`load_groups`, or similar, argument is passed to the templater.
+
+When this feature is implemented the `hosts` file will be able to be rendered
+in full in a single pass; since the information used in the rendering can
+change with any `configure` command it seems sensible to automatically
+re-render the `hosts` file after every `configure` command, similarly to the
+plan for `genders` after any `configure group` command. If we add this it will
+largely make the `hosts` command obsolete, although we may want to retain it
+for re-rendering after manually changing the template or a config file.
+
+We will also need to consider if we this how a `hosts` template other than the
+default will be selected for automatic re-rendering, or alternatively if we
+still need the ability to have multiple `hosts` templates within a single repo
+now - it should now be possible to have the `hosts` template handle any
+situations where we want to treat groups or nodes differently.
+
+
+## Command ordering
+
+With this new functionality certain commands will now require that other
+commands have been run first:
+
+- All `metal configure` commands will require the repo be set up (`repo use`
+  has been run) before running.
+
+- `metal build` will require that `metal configure all` has been run first,
+  i.e. that `/var/lib/metalware/config/all.yaml` has been generated, so any
+  necessary config has been set up before templating.
+
+- Additionally, `metal build -g $GROUP` will require that `metal configure
+  group $GROUP` has been run first, i.e. that
+  `/var/lib/metalware/config/groups/$GROUP.yaml` has been generated.
+
+- Note that a node config is not required, so a
+  `/var/lib/metalware/config/nodes/$NODE.yaml` file is not required to build
+  `$NODE`.
+
+
+## Templating
+
+When loading `alces.config` values from files in `/var/lib/metalware/config/`
+for use in templates, the same procedure will be followed as for loading the
+repo configs, i.e.
+
+- first `all.yaml` will be loaded;
+
+- if no `nodename` is passed, then nothing else will be loaded;
+
+- if a `nodename` is passed, all/any gender groups will be found for the node,
+  and any `groups/$GROUP.yaml` configs will be loaded for these in order of
+  precedence;
+
+- any `nodes/$NODE.yaml` file for the specific node will be loaded.
+
+When templating, attempting to use an `alces.config` value which is not set in
+the config should be a fatal error. All config values should be set up, as even
+if a particular config question is optional and nothing has been entered a
+value of `nil` should still be saved, in which case `nil` will be used when
+templating - however if the specified identifier is not present at all then
+this indicates the repo has an inconsistent `config` directory and
+`configure.yaml` file, which should be addressed.
+
+
+## Questions
+
+- May want to change `all` to `cluster` everywhere?
+
+- Change either `/var/lib/metalware/config` or `/var/lib/metalware/repo/config`
+  to something else, as they are related but the naming may be confusing? Maybe
+  also name `/var/lib/metalware/repo/configure.yaml` something else?

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,3 @@
+
+This directory contains design documents for future reference; these are not
+intended or expected to stay up-to-date with the current state of Metalware.


### PR DESCRIPTION
The important doc related to topologies is https://github.com/alces-software/metalware/compare/dev/docs?expand=1#diff-7633f31d52d6afaac7f6adf486a7e485.