### PR TITLE
Add Configurator class

### DIFF
--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -206,5 +206,27 @@ RSpec.describe Metalware::Configurator do
         'boolean_q' => false,
       )
     end
+
+    it 'fails fast for question with unknown type' do
+      define_questions({
+        test: {
+          # This question
+          string_q: {
+            question: 'String?',
+            type: 'string',
+          },
+          unknown_q: {
+            question: 'Something odd?',
+            type: 'foobar',
+          }
+        },
+      })
+
+      expect {
+        configurator
+      }.to raise_error(
+        Metalware::UnknownQuestionTypeError
+      )
+    end
   end
 end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -167,5 +167,44 @@ RSpec.describe Metalware::Configurator do
         'choice_q' => 'bar'
       })
     end
+
+    it 'asks all questions in order' do
+      define_questions({
+        test: {
+          string_q: {
+            question: 'String?',
+            type: 'string',
+          },
+          integer_q: {
+            question: 'Integer?',
+            type: 'integer',
+          },
+          boolean_q: {
+            question: 'Boolean?',
+            type: 'boolean',
+          },
+        },
+        some_other_questions: {
+          not_asked_q: {
+            question: 'Not asked?'
+          }
+        }
+      })
+
+      allow(highline).to receive(
+        :ask
+      ).and_return('Some string', 11)
+      allow(highline).to receive(
+        :agree
+      ).and_return(false)
+
+      configurator.configure
+
+      expect(answers).to eq(
+        'string_q' => 'Some string',
+        'integer_q' => 11,
+        'boolean_q' => false,
+      )
+    end
   end
 end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -141,5 +141,31 @@ RSpec.describe Metalware::Configurator do
         'boolean_q' => true
       })
     end
+
+    it "offers choices for question with type 'choice'" do
+      define_questions({
+        test: {
+          choice_q: {
+            question: 'What choice would you like?',
+            type: 'choice',
+            choices: ['foo', 'bar']
+          }
+        }
+      })
+
+      expect(highline).to receive(
+        :choose
+      ).with(
+        'foo', 'bar'
+      ).and_return(
+        'bar'
+      )
+
+      configurator.configure
+
+      expect(answers).to eq({
+        'choice_q' => 'bar'
+      })
+    end
   end
 end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -225,7 +225,8 @@ RSpec.describe Metalware::Configurator do
       expect {
         configurator
       }.to raise_error(
-        Metalware::UnknownQuestionTypeError
+        Metalware::UnknownQuestionTypeError,
+        /'foobar'.*test\.unknown_q.*#{configure_file_path}/
       )
     end
   end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -91,5 +91,30 @@ RSpec.describe Metalware::Configurator do
         'string_q' => 'My string'
       })
     end
+
+    it 'asks questions with type `integer`' do
+      define_questions({
+        test: {
+          integer_q: {
+            question: 'Can you enter an integer?',
+            type: 'integer'
+          }
+        }
+      })
+
+      expect(highline).to receive(
+        :ask
+      ).with(
+        'Can you enter an integer?', Integer
+      ).and_return(
+        7
+      )
+
+      configurator.configure
+
+      expect(answers).to eq({
+        'integer_q' => 7
+      })
+    end
   end
 end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -116,5 +116,30 @@ RSpec.describe Metalware::Configurator do
         'integer_q' => 7
       })
     end
+
+    it "uses confirmation for questions with type 'boolean'" do
+      define_questions({
+        test: {
+          boolean_q: {
+            question: 'Should this cluster be awesome?',
+            type: 'boolean'
+          }
+        }
+      })
+
+      expect(highline).to receive(
+        :agree
+      ).with(
+       'Should this cluster be awesome?'
+      ).and_return(
+        true
+      )
+
+      configurator.configure
+
+      expect(answers).to eq({
+        'boolean_q' => true
+      })
+    end
   end
 end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -1,0 +1,95 @@
+
+require 'tempfile'
+require 'yaml'
+require 'highline'
+
+require 'configurator'
+
+
+RSpec.describe Metalware::Configurator do
+  let :highline {
+    HighLine.new
+  }
+
+  let :configure_file {
+    Tempfile.new('configure.yaml')
+  }
+
+  let :configure_file_path {
+    configure_file.path
+  }
+
+  let :answers_file_path {
+    Tempfile.new('test.yaml').path
+  }
+
+  let :answers {
+    YAML.load_file(answers_file_path)
+  }
+
+  let :configurator {
+    Metalware::Configurator.new(
+      highline: highline,
+      configure_file: configure_file_path,
+      questions: 'test',
+      answers_file: answers_file_path
+    )
+  }
+
+  def define_questions(questions_hash)
+    configure_file.write(questions_hash.to_yaml)
+    configure_file.rewind
+  end
+
+  describe '#configure' do
+    it 'asks questions with type `string`' do
+      define_questions({
+        test: {
+          string_q: {
+            question: 'Can you enter a string?',
+            type: 'string'
+          }
+        }
+      })
+
+      expect(highline).to receive(
+        :ask
+      ).with(
+        'Can you enter a string?'
+      ).and_return(
+        'My string'
+      )
+
+      configurator.configure
+
+      expect(answers).to eq({
+        'string_q' => 'My string'
+      })
+    end
+
+
+    it 'asks questions with no `type` as `string`' do
+      define_questions({
+        test: {
+          string_q: {
+            question: 'Can you enter a string?'
+          }
+        }
+      })
+
+      expect(highline).to receive(
+        :ask
+      ).with(
+        'Can you enter a string?'
+      ).and_return(
+        'My string'
+      )
+
+      configurator.configure
+
+      expect(answers).to eq({
+        'string_q' => 'My string'
+      })
+    end
+  end
+end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -37,6 +37,8 @@ module Metalware
 
       def ask(highline)
         case type
+        when 'boolean'
+          highline.agree(question)
         when 'integer'
           highline.ask(question, Integer)
         else

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -27,18 +27,23 @@ module Metalware
     private
 
     class Question
-      attr_reader :identifier, :question, :type
+      attr_reader :identifier, :question, :type, :choices
 
       def initialize(identifier, properties)
         @identifier = identifier
         @question = properties[:question]
         @type = properties[:type]
+        @choices = properties[:choices]
       end
 
       def ask(highline)
         case type
         when 'boolean'
           highline.agree(question)
+        when 'choice'
+          highline.choose(*choices) do |menu|
+            menu.prompt = question
+          end
         when 'integer'
           highline.ask(question, Integer)
         else

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -10,9 +10,7 @@ module Metalware
       @questions_section = questions
       @answers_file = answers_file
 
-      @questions = YAML.load_file(configure_file).
-      with_indifferent_access[questions].
-      map{ |identifier, properties| create_question(identifier, properties) }
+      @questions = load_questions
     end
 
     def configure
@@ -27,6 +25,12 @@ module Metalware
       :questions_section,
       :answers_file,
       :questions
+
+    def load_questions
+      @questions = YAML.load_file(configure_file).
+        with_indifferent_access[questions_section].
+        map{ |identifier, properties| create_question(identifier, properties) }
+    end
 
     def ask_questions
       questions.map do |question|

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -13,18 +13,25 @@ module Metalware
     end
 
     def configure
-      identifier, properties = questions.first
-      question = Question.new(identifier, properties)
-      answer = question.ask(highline)
-      answers = {
-        identifier => answer
-      }
+      answers = ask_questions
+      save_answers(answers)
+    end
+
+    private
+
+    def ask_questions
+      questions.map do |identifier, properties|
+        question = Question.new(identifier, properties)
+        answer = question.ask(highline)
+        [identifier, answer]
+      end.to_h
+    end
+
+    def save_answers(answers)
       File.open(answers_file, 'w') do |f|
         f.write(YAML.dump(answers))
       end
     end
-
-    private
 
     class Question
       attr_reader :identifier, :question, :type, :choices

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -19,6 +19,8 @@ module Metalware
 
     private
 
+    attr_reader :highline, :questions, :answers_file
+
     def ask_questions
       questions.map do |identifier, properties|
         question = Question.new(identifier, properties)
@@ -58,7 +60,5 @@ module Metalware
         end
       end
     end
-
-    attr_reader :highline, :questions, :answers_file
   end
 end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -1,0 +1,40 @@
+
+require 'active_support/core_ext/hash'
+
+
+module Metalware
+  class Configurator
+    def initialize(highline:, configure_file:, questions:, answers_file:)
+      @highline = highline
+      @answers_file = answers_file
+      @questions = YAML.load_file(
+        configure_file
+      ).with_indifferent_access[questions]
+    end
+
+    def configure
+      identifier, properties = questions.first
+      question = Question.new(identifier, properties)
+      answer = highline.ask(question.question)
+      answers = {
+        identifier => answer
+      }
+      File.open(answers_file, 'w') do |f|
+        f.write(YAML.dump(answers))
+      end
+    end
+
+    private
+
+    class Question
+      attr_reader :identifier, :question
+
+      def initialize(identifier, properties)
+        @identifier = identifier
+        @question = properties[:question]
+      end
+    end
+
+    attr_reader :highline, :questions, :answers_file
+  end
+end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -15,7 +15,7 @@ module Metalware
     def configure
       identifier, properties = questions.first
       question = Question.new(identifier, properties)
-      answer = highline.ask(question.question)
+      answer = question.ask(highline)
       answers = {
         identifier => answer
       }
@@ -27,11 +27,21 @@ module Metalware
     private
 
     class Question
-      attr_reader :identifier, :question
+      attr_reader :identifier, :question, :type
 
       def initialize(identifier, properties)
         @identifier = identifier
         @question = properties[:question]
+        @type = properties[:type]
+      end
+
+      def ask(highline)
+        case type
+        when 'integer'
+          highline.ask(question, Integer)
+        else
+          highline.ask(question)
+        end
       end
     end
 

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -7,9 +7,10 @@ module Metalware
     def initialize(highline:, configure_file:, questions:, answers_file:)
       @highline = highline
       @answers_file = answers_file
-      @questions = YAML.load_file(
-        configure_file
-      ).with_indifferent_access[questions]
+
+      @questions = YAML.load_file(configure_file).
+      with_indifferent_access[questions].
+      map{ |identifier, properties| Question.new(identifier, properties) }
     end
 
     def configure
@@ -22,10 +23,9 @@ module Metalware
     attr_reader :highline, :questions, :answers_file
 
     def ask_questions
-      questions.map do |identifier, properties|
-        question = Question.new(identifier, properties)
+      questions.map do |question|
         answer = question.ask(highline)
-        [identifier, answer]
+        [question.identifier, answer]
       end.to_h
     end
 
@@ -36,29 +36,49 @@ module Metalware
     end
 
     class Question
+      VALID_TYPES = [:boolean, :choice, :integer, :string]
+
       attr_reader :identifier, :question, :type, :choices
 
       def initialize(identifier, properties)
         @identifier = identifier
         @question = properties[:question]
-        @type = properties[:type]
+        @type = type_for(properties[:type])
         @choices = properties[:choices]
       end
 
       def ask(highline)
         case type
-        when 'boolean'
+        when :boolean
           highline.agree(question)
-        when 'choice'
+        when :choice
           highline.choose(*choices) do |menu|
             menu.prompt = question
           end
-        when 'integer'
+        when :integer
           highline.ask(question, Integer)
         else
           highline.ask(question)
         end
       end
+
+      private
+
+      def type_for(value)
+        value = value&.to_sym
+        if value.nil?
+          :string
+        elsif valid_type?(value)
+          value
+        else
+          raise UnknownQuestionTypeError
+        end
+      end
+
+      def valid_type?(value)
+        VALID_TYPES.include?(value)
+      end
     end
+
   end
 end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -48,4 +48,7 @@ module Metalware
 
   class YAMLConfigError < MetalwareError
   end
+
+  class UnknownQuestionTypeError < MetalwareError
+  end
 end


### PR DESCRIPTION
This PR adds a `Configurator` class, which is an easily testable class to be used in our `configure` commands to perform the configuration process.

This works by loading a given `configure.yaml` file, asking the specified group of questions using appropriate `HighLine` methods based on their `type`, and then saving the answers to the specified `answers` file.

There is not a specific Trello card for this, but it will support a future PR adding the basic `configure` commands.