### PR TITLE
Define configure default answers as the previously recorded answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed bug in tests that was caused by defining repo_path and repo_config_path independently in Config.
 - The MissingParameterWrapper automatically converts Hashes to a IterableRecursiveOpenStruct.
 - Moved auxiliary Commands (e.g. BaseCommand) into the CommandHelpers module.
+- Patched HighLine to prevent errors when the default answer to questions contains an erb tag.
+- Allow Configure questions to have predefined default answers.
+- Override the Configure default answers to be that of the previous answer of the same question.
 
 ### Added
 

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -31,33 +31,44 @@ RSpec.describe Metalware::Configurator do
   }
 
   let :configurator {
+    make_configurator
+  }
+
+  def make_configurator(hl = highline)
     Metalware::Configurator.new(
-      highline: highline,
+      highline: hl,
       configure_file: configure_file_path,
       questions_section: 'test',
       answers_file: answers_file_path
     )
-  }
+  end
 
   def define_questions(questions_hash)
     configure_file.write(questions_hash.to_yaml)
     configure_file.rewind
   end
 
-  def configure_with_input(input_string)
-    $stdout = Tempfile.open
-
-    input.write(input_string)
-    input.rewind
-
-    configurator.configure
-    $stdout.close
+  def redirect_stdout(&block)
+    $stdout = tmp = Tempfile.new
+    block.call
+    tmp.close
   rescue => e
-    $stdout.rewind
-    STDERR.puts $stdout.read
+    begin
+      $stdout.rewind
+      STDERR.puts $stdout.read
+    rescue
+    end
     raise e
   ensure
     $stdout = STDOUT
+  end
+
+  def configure_with_input(input_string)
+    redirect_stdout do
+      input.write(input_string)
+      input.rewind
+      configurator.configure
+    end
   end
 
   describe '#configure' do
@@ -251,7 +262,6 @@ RSpec.describe Metalware::Configurator do
 
     it 'loads default values' do
 
-
       str_ans = "I am a little teapot!!"
       erb_ans = '<%= I_am_an_erb_tag %>'
 
@@ -281,6 +291,39 @@ RSpec.describe Metalware::Configurator do
         'string_erb' => erb_ans,
         'integer_q' => 10
       })
+    end
+
+    it 'loads the old answers as defaults' do
+      define_questions({
+        test: {
+          string_q: {
+            question: "String?",
+            default: "This is the wrong string"
+          },
+          integer_q: {
+            question: 'Integer?',
+            type: 'integer',
+            default: 10
+          }
+        }
+      })
+
+      old_answers = {
+        "string_q" => "CORRECT",
+        "integer_q" => -100,
+        "should_not_see_me" => "OHHH SNAP"
+      }
+      new_answers = old_answers.dup.tap { |h| h.delete("should_not_see_me") }
+
+      first_run_configure = nil
+      redirect_stdout do
+        first_run_configure = make_configurator(HighLine.new)
+        first_run_configure.send(:save_answers, old_answers)
+      end
+      expect(first_run_configure.send(:old_answers)).to eq(old_answers)
+
+      configure_with_input("\n\n\n\n\n\n")
+      expect(answers).to eq(new_answers)
     end
   end
 end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -85,7 +85,12 @@ module Metalware
     class Question
       VALID_TYPES = [:boolean, :choice, :integer, :string]
 
-      attr_reader :identifier, :question, :type, :choices
+      attr_reader :identifier,
+        :question,
+        :type,
+        :choices,
+        :default,
+        :old_answer
 
       def initialize(identifier:, properties:, configure_file:,
                      questions_section:, old_answer: nil)
@@ -121,7 +126,7 @@ module Metalware
 
       def add_default(question, type = :string)
         new_default = \
-          (@old_answer && !@old_answer.to_s.empty?) ? @old_answer : @default
+          (old_answer && !old_answer.to_s.empty?) ? old_answer : default
 
         unless new_default.nil?
           parsed_default = nil

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -55,12 +55,7 @@ module Metalware
     end
 
     def old_answers
-      @old_answers ||= if File.exists?(@answers_file)
-        data = YAML.load_file(@answers_file)
-        data ? data : {}
-      else
-        {}
-      end
+      @old_answers ||= Utils.safely_load_yaml(answers_file)
     end
 
     def ask_questions

--- a/src/utils.rb
+++ b/src/utils.rb
@@ -3,10 +3,11 @@ module Metalware
   module Utils
 
     class << self
-      # Load YAML from `file`, or empty hash if file does not exist.
+      # Load YAML from `file`, or empty hash if file does not exist or does not
+      # contain YAML.
       def safely_load_yaml(file)
         if File.file? file
-          YAML.load_file(file)
+          YAML.load_file(file) || {}
         else
           {}
         end


### PR DESCRIPTION
Continuation of Typology questions. Please merge #91 first

When loading the default answer, the answer file is checked first. If an old answer is found, then that is used as the default. Otherwise the default in `configure.yaml` is used.