### PR TITLE
Correct `configure` commands to use correct files

### DIFF
--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -15,7 +15,8 @@ module Metalware
         protected
 
         def answers_file
-          File.join(Constants::ANSWERS_PATH, 'groups', group_name)
+          file_name = "#{group_name}.yaml"
+          File.join(Constants::ANSWERS_PATH, 'groups', file_name)
         end
 
         private

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -15,7 +15,8 @@ module Metalware
         protected
 
         def answers_file
-          File.join(Constants::ANSWERS_PATH, 'nodes', node_name)
+          file_name = "#{node_name}.yaml"
+          File.join(Constants::ANSWERS_PATH, 'nodes', file_name)
         end
 
         private


### PR DESCRIPTION
`metal configure group` and `metal configure node` were not including the correct file extension when saving their answers; this corrects that.