### PR TITLE
Make node indexes consistent across different commands

### DIFF
--- a/docs/templating-system.md
+++ b/docs/templating-system.md
@@ -63,8 +63,12 @@ Values available within this namespace are:
 <td><code>index</code></td>
 <td>
 
-The index of the current node within the group being templated, for the current
-group of nodes being templated.
+The index of the current node within its primary group. The primary group for a
+node is the first group associated with that node in the genders file, i.e. the
+first group to appear in the output of `nodeattr -l $NODE_NAME`. The
+<code>index</code> is guaranteed to be consistent between invocations of
+different commands which template for the same node, so long as the genders
+file remains consistent.
 
 </td>
 

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Metalware::Commands::Build do
     def expected_template_parameters
       {
         nodename: 'testnode01',
-        index: 0,
         firstboot: true,
         files: SpecUtils.create_mock_build_files_hash(self, 'testnode01'),
       }
@@ -201,25 +200,25 @@ RSpec.describe Metalware::Commands::Build do
         instance_of(Metalware::Config),
         '/var/lib/metalware/repo/kickstart/my_kickstart',
         '/var/lib/metalware/rendered/kickstart/testnode01',
-        hash_including(nodename: 'testnode01', index: 0)
+        hash_including(nodename: 'testnode01')
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
         instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
-        hash_including(nodename: 'testnode01', index: 0)
+        hash_including(nodename: 'testnode01')
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
         instance_of(Metalware::Config),
         '/var/lib/metalware/repo/kickstart/my_kickstart',
         '/var/lib/metalware/rendered/kickstart/testnode02',
-        hash_including(nodename: 'testnode02', index: 1)
+        hash_including(nodename: 'testnode02')
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
         instance_of(Metalware::Config),
         '/var/lib/metalware/repo/pxelinux/my_pxelinux',
         '/var/lib/tftpboot/pxelinux.cfg/testnode02_HEX_IP',
-        hash_including(nodename: 'testnode02', index: 1)
+        hash_including(nodename: 'testnode02')
       )
 
       run_build(

--- a/spec/commands/hosts_spec.rb
+++ b/spec/commands/hosts_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Metalware::Commands::Hosts do
         instance_of(Metalware::Config),
         '/var/lib/metalware/repo/hosts/default',
         '/etc/hosts',
-        hash_including(nodename: 'testnode01', index: 0)
+        hash_including(nodename: 'testnode01')
       )
 
       run_hosts('testnode01')
@@ -59,7 +59,7 @@ RSpec.describe Metalware::Commands::Hosts do
         instance_of(Metalware::Config),
         '/var/lib/metalware/repo/hosts/my_template',
         '/etc/hosts',
-        hash_including(nodename: 'testnode01', index: 0)
+        hash_including(nodename: 'testnode01')
       )
 
       run_hosts('testnode01', template: 'my_template')
@@ -81,9 +81,9 @@ RSpec.describe Metalware::Commands::Hosts do
   context 'when called for group' do
     let :group_parameters {
       [
-        hash_including(nodename: 'testnode01', index: 0),
-        hash_including(nodename: 'testnode02', index: 1),
-        hash_including(nodename: 'testnode03', index: 2)
+        hash_including(nodename: 'testnode01'),
+        hash_including(nodename: 'testnode02'),
+        hash_including(nodename: 'testnode03')
       ]
     }
 

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe '`metal build`' do
         )
         expect(testnode01_pxelinux).to eq(
           Metalware::Templater.render(TEST_CONFIG, PXELINUX_TEMPLATE, {
-            nodename: 'testnode01', index: 0, firstboot: false
+            nodename: 'testnode01', firstboot: false
           })
         )
       end
@@ -176,7 +176,7 @@ RSpec.describe '`metal build`' do
         )
         expect(testnode01_pxelinux).to eq(
           Metalware::Templater.render(TEST_CONFIG, PXELINUX_TEMPLATE, {
-            nodename: 'testnode02', index: 1, firstboot: false
+            nodename: 'testnode02', firstboot: false
           })
         )
       end
@@ -187,7 +187,7 @@ RSpec.describe '`metal build`' do
         )
         expect(testnode01_pxelinux).to eq(
           Metalware::Templater.render(TEST_CONFIG, PXELINUX_TEMPLATE, {
-            nodename: 'testnode02', index: 1, firstboot: true
+            nodename: 'testnode02', firstboot: true
           })
         )
       end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -39,9 +39,11 @@ RSpec.describe Metalware::Node do
     Metalware::Node.new(Metalware::Config.new, name)
   end
 
+  let :testnode01 { node('testnode01') }
+  let :testnode02 { node('testnode02') }
+
   describe '#configs' do
     it 'returns possible configs for node in precedence order' do
-      testnode01 = node('testnode01')
       expect(testnode01.configs).to eq(["domain", "cluster", "nodes", "testnodes", "testnode01"])
     end
 
@@ -122,7 +124,6 @@ RSpec.describe Metalware::Node do
 
   describe '#build_files' do
     it 'returns merged hash of files' do
-      testnode01 = node('testnode01')
       expect(testnode01.build_files).to eq({
         namespace01: [
           'testnodes/some_file_in_repo',
@@ -134,7 +135,6 @@ RSpec.describe Metalware::Node do
         ].sort
       })
 
-      testnode02 = node('testnode02')
       expect(testnode02.build_files).to eq({
         namespace01: [
           'testnode02/some_file_in_repo',

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -179,5 +179,16 @@ RSpec.describe Metalware::Node do
       expect(testnode02.index).to eq(0)
       expect(testnode03.index).to eq(2)
     end
+
+    it "returns 0 for node not in genders" do
+      name = 'not_in_genders_node01'
+      node = node(name)
+      expect(node.index).to eq(0)
+    end
+
+    it "returns 0 for nil node name" do
+      node = node(nil)
+      expect(node.index).to eq(0)
+    end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -147,4 +147,19 @@ RSpec.describe Metalware::Node do
       })
     end
   end
+
+  describe '#==' do
+    it 'returns false if other object is not a Node' do
+      other_object = Struct.new(:name).new('foonode')
+      expect(node('foonode')).not_to eq(other_object)
+    end
+
+    it 'defines nodes with the same name as equal' do
+      expect(node('foonode')).to eq(node('foonode'))
+    end
+
+    it 'defines nodes with different names as not equal' do
+      expect(node('foonode')).not_to eq(node('barnode'))
+    end
+  end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Metalware::Node do
 
   let :testnode01 { node('testnode01') }
   let :testnode02 { node('testnode02') }
+  let :testnode03 { node('testnode03') }
 
   describe '#configs' do
     it 'returns possible configs for node in precedence order' do
@@ -160,6 +161,23 @@ RSpec.describe Metalware::Node do
 
     it 'defines nodes with different names as not equal' do
       expect(node('foonode')).not_to eq(node('barnode'))
+    end
+  end
+
+  describe '#index' do
+    it "returns consistent index of node within its 'primary' group" do
+      # We define the 'primary' group for a node as the first group it is
+      # associated with in the genders file. This means for `testnode01` and
+      # `testnode03` this is `testnodes`, but for `testnode02` it is
+      # `pregroup`, in which it is the first node and so has index 0.
+      #
+      # This has the potential to cause confusion but I see no better way to
+      # handle this currently, as a node can always have multiple groups and we
+      # have to choose one to be the primary group. Later we may add more
+      # structure and validation around handling this.
+      expect(testnode01.index).to eq(0)
+      expect(testnode02.index).to eq(0)
+      expect(testnode03.index).to eq(2)
     end
   end
 end

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -204,10 +204,10 @@ RSpec.describe Metalware::Templater do
 
     context 'with passed parameters' do
       it 'overrides defaults with parameter values, where applicable' do
-        build_files = SpecUtils.create_mock_build_files_hash(self, 'testnode01')
+        build_files = SpecUtils.create_mock_build_files_hash(self, 'testnode03')
 
         templater = Metalware::Templater.new(Metalware::Config.new, {
-          nodename: 'testnode01',
+          nodename: 'testnode03',
           index: 3,
           firstboot: true,
           files: build_files
@@ -215,10 +215,10 @@ RSpec.describe Metalware::Templater do
         magic_namespace = templater.config.alces
 
         expect(magic_namespace.index).to eq(3)
-        expect(magic_namespace.nodename).to eq('testnode01')
+        expect(magic_namespace.nodename).to eq('testnode03')
         expect(magic_namespace.firstboot).to eq(true)
-        expect(magic_namespace.kickstart_url).to eq('http://1.2.3.4/metalware/kickstart/testnode01')
-        expect(magic_namespace.build_complete_url).to eq('http://1.2.3.4/metalware/exec/kscomplete.php?name=testnode01')
+        expect(magic_namespace.kickstart_url).to eq('http://1.2.3.4/metalware/kickstart/testnode03')
+        expect(magic_namespace.build_complete_url).to eq('http://1.2.3.4/metalware/exec/kscomplete.php?name=testnode03')
 
         # Can reach inside the passed `files` object.
         expect(

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -208,13 +208,12 @@ RSpec.describe Metalware::Templater do
 
         templater = Metalware::Templater.new(Metalware::Config.new, {
           nodename: 'testnode03',
-          index: 3,
           firstboot: true,
           files: build_files
         })
         magic_namespace = templater.config.alces
 
-        expect(magic_namespace.index).to eq(3)
+        expect(magic_namespace.index).to eq(2)
         expect(magic_namespace.nodename).to eq('testnode03')
         expect(magic_namespace.firstboot).to eq(true)
         expect(magic_namespace.kickstart_url).to eq('http://1.2.3.4/metalware/kickstart/testnode03')

--- a/src/node.rb
+++ b/src/node.rb
@@ -99,6 +99,10 @@ module Metalware
       )
     end
 
+    def index
+      Nodes.create(@metalware_config, primary_group, true).index(self)
+    end
+
     private
 
     def build_complete_marker_file
@@ -111,6 +115,10 @@ module Metalware
       # It's OK for a node to not be in the genders file, it just means it's
       # not part of any groups.
       []
+    end
+
+    def primary_group
+      groups.first
     end
 
     def load_config(config_name)

--- a/src/node.rb
+++ b/src/node.rb
@@ -100,7 +100,11 @@ module Metalware
     end
 
     def index
-      Nodes.create(@metalware_config, primary_group, true).index(self)
+      if primary_group
+        Nodes.create(@metalware_config, primary_group, true).index(self)
+      else
+        0
+      end
     end
 
     private

--- a/src/node.rb
+++ b/src/node.rb
@@ -36,6 +36,17 @@ module Metalware
       @name = name
     end
 
+    # Two nodes are equal <=> their names are equal; everything else is derived
+    # from this. This does mean they will appear equal if they are initialized
+    # with different config files, but this is a bug if it occurs in practise.
+    def ==(other_node)
+      if other_node.is_a? Node
+        name == other_node.name
+      else
+        false
+      end
+    end
+
     def hexadecimal_ip
       SystemCommand.run "gethostip -x #{name}"
     end

--- a/src/nodes.rb
+++ b/src/nodes.rb
@@ -55,10 +55,9 @@ module Metalware
     end
 
     def template_each(**additional_template_parameters, &block)
-      @nodes.each_with_index do |node, index|
+      @nodes.each do |node|
         template_parameters = {
           nodename: node.name,
-          index: index,
         }.merge(additional_template_parameters)
 
         block.call(template_parameters, node)

--- a/src/nodes.rb
+++ b/src/nodes.rb
@@ -33,7 +33,7 @@ module Metalware
     # Private as can only get `Nodes` instance via other methods in this class.
     private_class_method :new
 
-    delegate :length, :each, to: :@nodes
+    delegate :length, :each, :index, to: :@nodes
 
     # Create instance of `Nodes` from a single node or gender group.
     def self.create(config, node_identifier, is_group)

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -122,7 +122,7 @@ module Metalware
       @metalware_config = metalware_config
       @nodename = parameters[:nodename]
       passed_magic_parameters = parameters.select { |k,v|
-          [:index, :firstboot, :files].include?(k) && !v.nil?
+          [:firstboot, :files].include?(k) && !v.nil?
       }
 
       magic_struct = MagicNamespace.new(**passed_magic_parameters, node: node)
@@ -251,12 +251,14 @@ module Metalware
     end
   end
 
-  MagicNamespace = Struct.new(:index, :firstboot, :files) do
-    def initialize(index: 0, node: nil, firstboot: nil, files: nil)
+  MagicNamespace = Struct.new(:firstboot, :files) do
+    def initialize(node: nil, firstboot: nil, files: nil)
       files = Hashie::Mash.new(files) if files
       @node = node
-      super(index, firstboot, files)
+      super(firstboot, files)
     end
+
+    delegate :index, to: :node
 
     def nodename
       node.name


### PR DESCRIPTION
This PR makes the node `index` used when templating be consistent across invocations of different commands which template for the same node. For example, given:

```
# genders
node[01-05] nodes,domain
```

then `metal build -g nodes` and `metal build node05` will both use an `index` of `4` for `node05`, whereas previously they would use `4` and `0` respectively.

This does have the limitation described [here](https://github.com/alces-software/metalware/blob/bd781fd6630350344e61c6afa332be2e6e5a95fe/spec/node_spec.rb#L168,L177); however this situation should be improved with future changes, as described in https://trello.com/c/XjtdbEHm/80-improve-how-indexes-work, which this PR is an initial step towards resolving.