### PR TITLE
Cache primary groups as new groups configured

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@
 ruby '2.4.1'
 source 'https://rubygems.org'
 
+# Required to fix issue with FakeFS; refer to
+# https://github.com/fakefs/fakefs#fakefs-----typeerror-superclass-mismatch-for-class-file.
+require 'pp'
+
 gem 'commander', git: 'https://github.com/alces-software/commander'
 gem 'rugged'
 gem 'activesupport'

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -1,0 +1,90 @@
+
+require 'spec_utils'
+
+
+RSpec.describe Metalware::Commands::Configure::Group do
+  def run_configure_group(group)
+    SpecUtils.run_command(
+      Metalware::Commands::Configure::Group, group
+    )
+  end
+
+  # XXX extract this
+  def create_directory_hierarchy
+    FileUtils.mkdir_p Metalware::Constants::METALWARE_CONFIGS_PATH
+    FileUtils.touch Metalware::Constants::DEFAULT_CONFIG_PATH
+
+    FileUtils.mkdir_p Metalware::Constants::CACHE_PATH
+    FileUtils.mkdir_p File.join(Metalware::Constants::ANSWERS_PATH, 'groups')
+
+    FileUtils.mkdir_p config.repo_path
+    File.write config.configure_file, YAML.dump({
+      questions: {},
+      domain: {},
+      group: {},
+      node: {},
+    })
+  end
+
+  let :config { Metalware::Config.new }
+  let :groups_file {
+    File.join(Metalware::Constants::CACHE_PATH, 'groups.yaml' )
+  }
+  let :groups_yaml { YAML.load_file(groups_file) }
+  let :primary_groups { groups_yaml[:primary_groups] }
+
+  context 'when `cache/groups.yaml` does not exist' do
+    it 'creates it and inserts new primary group' do
+      FakeFSHelper.new(config).run do
+        create_directory_hierarchy
+        run_configure_group 'testnodes'
+
+        expect(primary_groups).to eq [
+          'testnodes'
+        ]
+      end
+    end
+  end
+
+
+  context 'when `cache/groups.yaml` exists' do
+    it 'inserts primary group if new' do
+      FakeFSHelper.new(config).run do
+        create_directory_hierarchy
+        File.write groups_file, YAML.dump({
+          primary_groups: [
+            'first_group',
+          ]
+        })
+
+        run_configure_group 'second_group'
+
+        expect(primary_groups).to eq [
+          'first_group',
+          'second_group',
+        ]
+      end
+
+    end
+
+    it 'does nothing if primary group already presnt' do
+      FakeFSHelper.new(config).run do
+        create_directory_hierarchy
+        File.write groups_file, YAML.dump({
+          primary_groups: [
+            'first_group',
+            'second_group',
+          ]
+        })
+
+        run_configure_group 'second_group'
+
+        expect(primary_groups).to eq [
+          'first_group',
+          'second_group',
+        ]
+      end
+
+    end
+  end
+end

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -1,6 +1,7 @@
 
 require 'command_helpers/configure_command'
 require 'constants'
+require 'utils'
 
 
 module Metalware
@@ -44,20 +45,11 @@ module Metalware
         end
 
         def groups_cache
-          @groups_cache ||= load_yaml(groups_cache_file)
+          @groups_cache ||= Utils.safely_load_yaml(groups_cache_file)
         end
 
         def groups_cache_file
           File.join(Constants::CACHE_PATH, 'groups.yaml')
-        end
-
-        # XXX duplicated from Node; extract
-        def load_yaml(file)
-          if File.file? file
-            YAML.load_file(file)
-          else
-            {}
-          end
         end
       end
 

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -12,6 +12,11 @@ module Metalware
           @group_name = args.first
         end
 
+        def run
+          super
+          record_primary_group
+        end
+
         protected
 
         def answers_file
@@ -22,6 +27,38 @@ module Metalware
         private
 
         attr_reader :group_name
+
+        def record_primary_group
+          unless primary_group_recorded?
+            primary_groups << group_name
+            File.write(groups_cache_file, YAML.dump(groups_cache))
+          end
+        end
+
+        def primary_group_recorded?
+          primary_groups.include? group_name
+        end
+
+        def primary_groups
+          groups_cache[:primary_groups] ||= []
+        end
+
+        def groups_cache
+          @groups_cache ||= load_yaml(groups_cache_file)
+        end
+
+        def groups_cache_file
+          File.join(Constants::CACHE_PATH, 'groups.yaml')
+        end
+
+        # XXX duplicated from Node; extract
+        def load_yaml(file)
+          if File.file? file
+            YAML.load_file(file)
+          else
+            {}
+          end
+        end
       end
 
     end

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -24,7 +24,8 @@ module Metalware
   module Constants
     METALWARE_INSTALL_PATH = File.absolute_path(File.join(File.dirname(__FILE__), '..'))
 
-    DEFAULT_CONFIG_PATH = File.join(METALWARE_INSTALL_PATH, 'etc/config.yaml')
+    METALWARE_CONFIGS_PATH = File.join(METALWARE_INSTALL_PATH, 'etc')
+    DEFAULT_CONFIG_PATH = File.join(METALWARE_CONFIGS_PATH, 'config.yaml')
 
     METALWARE_DATA_PATH = '/var/lib/metalware'
     CACHE_PATH = File.join(METALWARE_DATA_PATH, 'cache')

--- a/src/node.rb
+++ b/src/node.rb
@@ -26,6 +26,7 @@ require 'constants'
 require 'system_command'
 require 'nodeattr_interface'
 require 'exceptions'
+require 'utils'
 
 module Metalware
   class Node
@@ -127,15 +128,7 @@ module Metalware
 
     def load_config(config_name)
       config_path = @metalware_config.repo_config_path(config_name)
-      load_yaml(config_path).symbolize_keys
-    end
-
-    def load_yaml(file)
-      if File.file? file
-        YAML.load_file(file)
-      else
-        {}
-      end
+      Utils.safely_load_yaml(config_path).symbolize_keys
     end
 
     def merge_in_files!(existing_files, new_files)
@@ -159,7 +152,7 @@ module Metalware
     end
 
     def combine_answers
-      config_answers = configs.map { |c| load_yaml(answers_path_for(c)) }
+      config_answers = configs.map { |c| Utils.safely_load_yaml(answers_path_for(c)) }
       combine_hashes(config_answers)
     end
 

--- a/src/utils.rb
+++ b/src/utils.rb
@@ -1,0 +1,17 @@
+
+module Metalware
+  module Utils
+
+    class << self
+      # Load YAML from `file`, or empty hash if file does not exist.
+      def safely_load_yaml(file)
+        if File.file? file
+          YAML.load_file(file)
+        else
+          {}
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Based on branch under review in https://github.com/alces-software/metalware/pull/97, and working towards resolving the same card.

This PR adds caching of primary groups as each new `metal configure group` command is run, which is a step towards adding a `group_index` for each primary group. The key commit here is https://github.com/alces-software/metalware/commit/231397059879c1e601fdd06ffe521a3d4f6523d2, so see that for more details.