### PR TITLE
Fix hunter bugs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,14 @@ GIT
 
 GIT
   remote: https://github.com/alces-software/ruby-pcap.git
-  revision: 42728a34e955ad00a5d033f4ef999a75a15f6f67
+  revision: 966ce3739d7c91c15032b3a85095c7400565841f
   specs:
-    pcap (0.7.7)
+    pcap (0.7.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.1)
+    activesupport (5.1.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/alces-software/commander
-  revision: d322ed15c6a12ede79e9bb8e9465738818efe0fc
+  revision: e9c34dad0d2688f4c1f8241810fcbf5e1a96cbf5
   specs:
-    commander (4.5.1)
+    commander (4.5.2)
       highline (~> 1.7.2)
 
 GIT

--- a/src/cli_helper/parser.rb
+++ b/src/cli_helper/parser.rb
@@ -49,6 +49,9 @@ module Metalware
               c.action eval(v)
             when "options"
               v.each do |opt|
+                if [:Integer, "Integer"].include? opt["type"]
+                  opt["type"] = "OptionParser::DecimalInteger"
+                end
                 c.option(*opt["tags"],
                        eval(opt["type"].to_s),
                        {default: opt["default"]},


### PR DESCRIPTION
This PR fixes two bugs that where identified in hunter:

The first bug is when `-s` is used with `hunter`, it truncates the `UDP` packets. This is because `Pcap` always passed the `ARGV` array into `OptionParser`. This has been fixed in Pcap (link below). In short, `Pcap` no longer parses the `ARGV` array unless it isn't initialised with any inputs.
https://github.com/alces-software/ruby-pcap/commit/966ce3739d7c91c15032b3a85095c7400565841f

The second bug is when an integer value is entered into the cli with a leading zero (e.g. `-s 035`). As `Integers` are converted according to their prefixed value, '035' is converted as an octal to 29. Now the `cli_helper` will automatically set all `Integers` as `DecimalIntegers`. A bug patch also needed to be included in `Commander` (link below). This patches the underling ruby function, which doesn't enforce DecimalIntegers. This meant that even `DecimalInteger 035` was being converted to 29. This bug patch fixes that. 
https://github.com/alces-software/commander/commit/e9c34dad0d2688f4c1f8241810fcbf5e1a96cbf5