### PR TITLE
Enforce required and allow optional questions

### DIFF
--- a/docs/design/02-topologies.md
+++ b/docs/design/02-topologies.md
@@ -46,7 +46,7 @@ questions:
       - 11
     default: 11 # Optional; default value to use when no input entered, if any.
     type: 'integer' # Optional/default `'string'`. For validation and converting; see below for details.
-    required: true # Optional/default `true`
+    optional: true # Makes the question optional. Default if missing:`false`
 
   another_example: &another_example
     question: 'Enter anything?'

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -340,7 +340,15 @@ RSpec.describe Metalware::Configurator do
       })
 
       expect{
-        configure_with_input("\n")
+        old_stderr = STDERR
+        begin
+          $stderr = Tempfile.new
+          STDERR = $stderr
+          configure_with_input("\n")
+        ensure
+          STDERR = old_stderr
+          $stderr = STDERR
+        end
       }.to raise_error(EOFError)
     end
 

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -344,12 +344,20 @@ RSpec.describe Metalware::Configurator do
         begin
           $stderr = Tempfile.new
           STDERR = $stderr
-          configure_with_input("\n")
+          configure_with_input("\n\n")
         ensure
           STDERR = old_stderr
           $stderr = STDERR
         end
+        # NOTE: EOFError occurs because HighLine is reading from an array of
+        # end-line-characters. However as this is not a valid input it keeps
+        # re-asking until it reaches the end and throws EOFError
       }.to raise_error(EOFError)
+
+      output.rewind
+      # Checks it was re-asked twice.
+      # The '?' is printed when the question is re-asked
+      expect(output.read.scan(/\?/).count).to eq(2)
     end
 
     it 'allows optional questions to have empty answers' do

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe Metalware::Configurator do
     Tempfile.new
   }
 
+  let :output {
+    Tempfile.new
+  }
+
   let :highline {
-    HighLine.new(input)
+    HighLine.new(input, output)
   }
 
   let :configure_file {
@@ -324,6 +328,37 @@ RSpec.describe Metalware::Configurator do
 
       configure_with_input("\n\n\n\n\n\n")
       expect(answers).to eq(new_answers)
+    end
+
+    it 're-asks the required questions if no answer is given' do
+      define_questions({
+        test: {
+          string_q: {
+            question: "I should be re-asked"
+          }
+        }
+      })
+
+      expect{
+        configure_with_input("\n")
+      }.to raise_error(EOFError)
+    end
+
+    it 'allows optional questions to have empty answers' do
+      define_questions({
+        test: {
+          string_q: {
+            question: "I should NOT be re-asked",
+            optional: true
+          }
+        }
+      })
+      expected = {
+        "string_q" => ""
+      }
+
+      configure_with_input("\n")
+      expect(answers).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
Configure questions are now required by default. This means that the
user will be prompted to renter an answer if they do not give one and
it does not have a default.

A new optional tag can be included with the questions, which means
an empty input is a valid response. The optional tag must evaluated
to a truthy value.

Note that when HighLine re-prompts for an input, it uses inspect to
generate the message. This gives crazy responses such as:
`must match <proc:/some/file/path-352random-other-stuff>`

As this isn't very useful to the user, a HighLinePrettyValidateProc
class is used. This class overrides the inspect method so that it
gives nicer prompts to the user.