### PR TITLE
Improve magic namespace tests

### DIFF
--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -200,53 +200,49 @@ RSpec.describe Metalware::Templater do
           at: '/var/lib/metalware/cache/hunter.yaml'
       end
 
-      context 'without passed parameters' do
-        it 'is created with default values' do
-          filesystem.test do
-            templater = Metalware::Templater.new(config)
-            magic_namespace = templater.config.alces
+      it 'is created with default values when no parameters passed' do
+        filesystem.test do
+          templater = Metalware::Templater.new(config)
+          magic_namespace = templater.config.alces
 
-            expect(magic_namespace.index).to eq(0)
-            expect(magic_namespace.nodename).to eq(nil)
-            expect(magic_namespace.firstboot).to eq(nil)
-            expect(magic_namespace.files).to eq(nil)
-            expect(magic_namespace.kickstart_url).to eq(nil)
-            expect(magic_namespace.build_complete_url).to eq(nil)
-            expect_environment_dependent_parameters_present(magic_namespace)
-          end
+          expect(magic_namespace.index).to eq(0)
+          expect(magic_namespace.nodename).to eq(nil)
+          expect(magic_namespace.firstboot).to eq(nil)
+          expect(magic_namespace.files).to eq(nil)
+          expect(magic_namespace.kickstart_url).to eq(nil)
+          expect(magic_namespace.build_complete_url).to eq(nil)
+          expect_environment_dependent_parameters_present(magic_namespace)
         end
       end
 
-      context 'with passed parameters' do
-        it 'overrides defaults with parameter values, where applicable' do
-          filesystem.test do
-            build_files = SpecUtils.create_mock_build_files_hash(
-              self, config: config, node_name: 'testnode03'
-            )
+      it 'overrides defaults with applicable parameter values when parameters passed' do
+        filesystem.test do
+          build_files = SpecUtils.create_mock_build_files_hash(
+            self, config: config, node_name: 'testnode03'
+          )
 
-            templater = Metalware::Templater.new(config, {
-              nodename: 'testnode03',
-              firstboot: true,
-              files: build_files
-            })
-            magic_namespace = templater.config.alces
+          templater = Metalware::Templater.new(config, {
+            nodename: 'testnode03',
+            firstboot: true,
+            files: build_files
+          })
+          magic_namespace = templater.config.alces
 
-            expect(magic_namespace.index).to eq(2)
-            expect(magic_namespace.nodename).to eq('testnode03')
-            expect(magic_namespace.firstboot).to eq(true)
-            expect(magic_namespace.kickstart_url).to eq('http://1.2.3.4/metalware/kickstart/testnode03')
-            expect(magic_namespace.build_complete_url).to eq('http://1.2.3.4/metalware/exec/kscomplete.php?name=testnode03')
+          expect(magic_namespace.index).to eq(2)
+          expect(magic_namespace.nodename).to eq('testnode03')
+          expect(magic_namespace.firstboot).to eq(true)
+          expect(magic_namespace.kickstart_url).to eq('http://1.2.3.4/metalware/kickstart/testnode03')
+          expect(magic_namespace.build_complete_url).to eq('http://1.2.3.4/metalware/exec/kscomplete.php?name=testnode03')
 
-            # Can reach inside the passed `files` object.
-            expect(
-              magic_namespace.files.namespace01.first.raw
-            ).to eq('/some/other/path')
-            expect(
-              magic_namespace.files.namespace02.first.raw
-            ).to eq('another_file_in_repo')
+          # Can reach inside the passed `files` object.
+          expect(
+            magic_namespace.files.namespace01.first.raw
+          ).to eq('/some/other/path')
+          expect(
+            magic_namespace.files.namespace02.first.raw
+          ).to eq('another_file_in_repo')
 
-            expect_environment_dependent_parameters_present(magic_namespace)
-          end
+          expect_environment_dependent_parameters_present(magic_namespace)
         end
       end
     end

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -251,8 +251,8 @@ RSpec.describe Metalware::Templater do
       end
     end
 
-    context 'when no hunter config file present' do
-      it 'loads the hunter parameter as an empty array' do
+    context 'when no hunter cache file present' do
+      it 'loads the hunter parameter as an empty Hashie' do
         filesystem.test do
           templater = Metalware::Templater.new(config)
           magic_namespace = templater.config.alces


### PR DESCRIPTION
Based on https://github.com/alces-software/metalware/pull/106. This is just some refactoring of the Templater's magic namespace tests, to in particular use `FakeFS` and `FileSystem`. Submitting this now to keep it separate from my next PR which will also touch the `MagicNamespace`.