### PR TITLE
Add `group_index`

### DIFF
--- a/docs/templating-system.md
+++ b/docs/templating-system.md
@@ -77,7 +77,27 @@ file remains consistent.
 href='https://github.com/alces-software/metalware-default/blob/226cf530d4ce6bdc09a6c65ba3f4bfc553032752/config/domain.yaml#L3'>
 metalware-default
 </a>
-</td> </tr>
+</td>
+</tr>
+
+<tr>
+<td><code>group_index</code></td>
+<td>
+
+The unique index of the current node's primary group. This is guaranteed to
+remain consistent for a particular primary group; it may change for a node if
+that node's primary group is changed.
+
+</td>
+
+<td>
+<pre lang="yaml">
+
+ip: "10.10.<%= alces.group_index %>.<%= alces.index %>"
+
+</pre>
+</td>
+</tr>
 
 
 <tr>

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -93,6 +93,20 @@ class FileSystem
     with_fixtures(answer_fixtures_dir, at: '/var/lib/metalware/answers')
   end
 
+  def with_groups_cache_fixture(groups_cache_file)
+    with_fixtures(
+      groups_cache_file,
+      at: Metalware::Constants::GROUPS_CACHE_PATH
+    )
+  end
+
+  def with_hunter_cache_fixture(hunter_cache_file)
+    with_fixtures(
+      hunter_cache_file,
+      at: Metalware::Constants::HUNTER_PATH
+    )
+  end
+
   # Create same directory hierarchy that would be created by a Metalware
   # install.
   def create_initial_directory_hierarchy

--- a/spec/fixtures/cache/groups.yaml
+++ b/spec/fixtures/cache/groups.yaml
@@ -1,0 +1,4 @@
+
+primary_groups:
+  - some_group
+  - testnodes

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -121,6 +121,43 @@ RSpec.describe Metalware::Node do
     end
   end
 
+  describe '#group_index' do
+    let :filesystem { FileSystem.setup }
+
+    def expect_group_index_raises_for_node(node)
+      filesystem.test do
+        expect{ node.group_index }.to raise_error(
+          Metalware::UnconfiguredGroupError
+        )
+      end
+    end
+
+    it 'raises when groups.yaml does not exist' do
+      expect_group_index_raises_for_node(testnode01)
+    end
+
+    context 'when some primary groups have been cached' do
+      before :each do
+        filesystem.with_fixtures('cache/groups.yaml', at: Metalware::Constants::GROUPS_CACHE_PATH)
+      end
+
+      it "returns the index of the node's primary group" do
+        filesystem.test do
+          expect(testnode01.group_index).to eq(1)
+        end
+      end
+
+      it "raises when the node's primary group is not in the cache" do
+        expect_group_index_raises_for_node(testnode02)
+      end
+
+      it 'raises for the null object node' do
+        expect_group_index_raises_for_node(node(nil))
+      end
+    end
+
+  end
+
   describe '#raw_config' do
     it 'performs a deep merge of all config files' do
       config = Metalware::Config.new(File.join(FIXTURES_PATH, "configs/deep-merge.yaml"))

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Metalware::Node do
 
     context 'when some primary groups have been cached' do
       before :each do
-        filesystem.with_fixtures('cache/groups.yaml', at: Metalware::Constants::GROUPS_CACHE_PATH)
+        filesystem.with_groups_cache_fixture('cache/groups.yaml')
       end
 
       it "returns the index of the node's primary group" do

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -194,9 +194,10 @@ RSpec.describe Metalware::Templater do
       end
     end
 
-    context 'with hunter cache file present' do
+    context 'with cache files present' do
       before :each do
         filesystem.with_hunter_cache_fixture 'cache/hunter.yaml'
+        filesystem.with_groups_cache_fixture 'cache/groups.yaml'
       end
 
       it 'is created with default values when no parameters passed' do
@@ -205,6 +206,7 @@ RSpec.describe Metalware::Templater do
           magic_namespace = templater.config.alces
 
           expect(magic_namespace.index).to eq(0)
+          expect(magic_namespace.group_index).to eq(nil)
           expect(magic_namespace.nodename).to eq(nil)
           expect(magic_namespace.firstboot).to eq(nil)
           expect(magic_namespace.files).to eq(nil)
@@ -228,6 +230,7 @@ RSpec.describe Metalware::Templater do
           magic_namespace = templater.config.alces
 
           expect(magic_namespace.index).to eq(2)
+          expect(magic_namespace.group_index).to eq(1)
           expect(magic_namespace.nodename).to eq('testnode03')
           expect(magic_namespace.firstboot).to eq(true)
           expect(magic_namespace.kickstart_url).to eq('http://1.2.3.4/metalware/kickstart/testnode03')

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -196,8 +196,7 @@ RSpec.describe Metalware::Templater do
 
     context 'with hunter cache file present' do
       before :each do
-        filesystem.with_fixtures 'cache/hunter.yaml',
-          at: '/var/lib/metalware/cache/hunter.yaml'
+        filesystem.with_hunter_cache_fixture 'cache/hunter.yaml'
       end
 
       it 'is created with default values when no parameters passed' do

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -32,7 +32,7 @@ module Metalware
         def record_primary_group
           unless primary_group_recorded?
             primary_groups << group_name
-            File.write(groups_cache_file, YAML.dump(groups_cache))
+            File.write(Constants::GROUPS_CACHE_PATH, YAML.dump(groups_cache))
           end
         end
 
@@ -45,11 +45,7 @@ module Metalware
         end
 
         def groups_cache
-          @groups_cache ||= Utils.safely_load_yaml(groups_cache_file)
-        end
-
-        def groups_cache_file
-          File.join(Constants::CACHE_PATH, 'groups.yaml')
+          @groups_cache ||= Utils.safely_load_yaml(Constants::GROUPS_CACHE_PATH)
         end
       end
 

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -30,6 +30,7 @@ module Metalware
     METALWARE_DATA_PATH = '/var/lib/metalware'
     CACHE_PATH = File.join(METALWARE_DATA_PATH, 'cache')
     HUNTER_PATH = File.join(CACHE_PATH, 'hunter.yaml')
+    GROUPS_CACHE_PATH = File.join(CACHE_PATH, 'groups.yaml')
 
     MAXIMUM_RECURSIVE_CONFIG_DEPTH = 10
 

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -92,7 +92,7 @@ module Metalware
 
   class MissingParameter < MetalwareError
   end
-  
+
   # Use this error as the general catch all in Dependencies
   # The dependency can't be checked as the logic doesn't make sense
   # NOTE: We should try and prevent these errors from appearing in production

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -103,4 +103,7 @@ module Metalware
   # NOTE: This is the only dependency error we see in production
   class DependencyFailure < MetalwareError
   end
+
+  class UnconfiguredGroupError < MetalwareError
+  end
 end

--- a/src/node.rb
+++ b/src/node.rb
@@ -108,6 +108,16 @@ module Metalware
       end
     end
 
+    def group_index
+      if cached_primary_group_index
+        cached_primary_group_index
+      else
+        error = "Cannot get 'group_index', the primary group " +
+          "'#{primary_group}' for this node (#{name}) has not been configured"
+        raise UnconfiguredGroupError, error
+      end
+    end
+
     private
 
     def build_complete_marker_file
@@ -120,6 +130,18 @@ module Metalware
       # It's OK for a node to not be in the genders file, it just means it's
       # not part of any groups.
       []
+    end
+
+    def cached_primary_group_index
+      cached_primary_groups.index(primary_group)
+    end
+
+    def cached_primary_groups
+      groups_cache['primary_groups'] || []
+    end
+
+    def groups_cache
+      Utils.safely_load_yaml(Constants::GROUPS_CACHE_PATH)
     end
 
     def primary_group

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -260,6 +260,14 @@ module Metalware
 
     delegate :index, to: :node
 
+    def group_index
+      node.group_index
+    rescue UnconfiguredGroupError
+      # If the node's primary group is not configured yet, return nil rather
+      # than blow up.
+      nil
+    end
+
     def nodename
       node.name
     end


### PR DESCRIPTION
Based on https://github.com/alces-software/metalware/pull/107.

This PR adds a `group_index` parameter to the `alces` templater namespace, which returns a unique, consistent, index for the current node's primary group. This forms another part of the work towards https://trello.com/c/XjtdbEHm.