### PR TITLE
Add `groups` to `alces` namespace

### DIFF
--- a/spec/fixtures/answers/group_namespace_tests/domain.yaml
+++ b/spec/fixtures/answers/group_namespace_tests/domain.yaml
@@ -1,0 +1,3 @@
+
+domain_value: 'domain_value'
+overriding_domain_value: 'domain_value'

--- a/spec/fixtures/answers/group_namespace_tests/groups/testgroup.yaml
+++ b/spec/fixtures/answers/group_namespace_tests/groups/testgroup.yaml
@@ -1,0 +1,3 @@
+
+overriding_domain_value: 'testgroup_value'
+genders_host_range: 'node0[10-20]'

--- a/spec/templating/group_namespace_spec.rb
+++ b/spec/templating/group_namespace_spec.rb
@@ -1,0 +1,42 @@
+
+require 'templating/group_namespace'
+require 'filesystem'
+
+
+RSpec.describe Metalware::Templating::GroupNamespace do
+  subject do
+    Metalware::Templating::GroupNamespace.new(
+      Metalware::Config.new,
+      group_name
+    )
+  end
+
+  let :group_name { 'testgroup' }
+
+  let :filesystem {
+    FileSystem.setup do |fs|
+      fs.with_minimal_repo
+      fs.with_answer_fixtures('answers/group_namespace_tests')
+    end
+  }
+
+  describe '#name' do
+    it 'returns the name of the group' do
+      filesystem.test do
+        expect(subject.name).to eq(group_name)
+      end
+    end
+  end
+
+  describe '#answers' do
+    it 'returns the group answers merged into the domain answers' do
+      filesystem.test do
+        expect(subject.answers).to eq({
+          domain_value: 'domain_value',
+          overriding_domain_value: 'testgroup_value',
+          genders_host_range: 'node0[10-20]',
+        })
+      end
+    end
+  end
+end

--- a/spec/templating/magic_namespace_spec.rb
+++ b/spec/templating/magic_namespace_spec.rb
@@ -1,0 +1,28 @@
+
+RSpec.describe Metalware::Templating::MagicNamespace do
+  # Note: many `MagicNamespace` features are tested at the `Templater` level
+  # instead.
+
+  describe '#groups' do
+    subject {
+      Metalware::Templating::MagicNamespace.new(
+        config: Metalware::Config.new
+      )
+    }
+
+    it 'calls the passed block with a group namespace for each primary group' do
+      FileSystem.test do |fs|
+        fs.with_groups_cache_fixture('cache/groups.yaml')
+
+        group_names = []
+        subject.groups do |group|
+          expect(group).to be_a(Metalware::Templating::GroupNamespace)
+          group_names << group.name
+        end
+
+        expect(group_names).to eq(['some_group', 'testnodes'])
+      end
+    end
+
+  end
+end

--- a/src/node.rb
+++ b/src/node.rb
@@ -26,10 +26,17 @@ require 'constants'
 require 'system_command'
 require 'nodeattr_interface'
 require 'exceptions'
+require 'templating/configuration'
 
 module Metalware
   class Node
     attr_reader :name
+    delegate :raw_config,
+      :answers,
+      # XXX `Node#configs` does not actually need to be public, it is only used
+      # in the `Node` tests
+      :configs,
+      to: :templating_configuration
 
     def initialize(metalware_config, name)
       @metalware_config = metalware_config
@@ -55,22 +62,12 @@ module Metalware
       File.file? build_complete_marker_file
     end
 
-    # Return the raw merged config for this node, without parsing any embedded
-    # ERB (this should be done using the Templater if needed, as we won't know
-    # all the template parameters until a template is being rendered).
-    # XXX refactor `build_files` to use this
-    def raw_config
-      combine_hashes(configs.map { |c| load_config(c) })
-    end
-
-    def answers
-      @answers ||= combine_answers
-    end
-
-    # The repo config files for this node in order of precedence from lowest to
-    # highest.
-    def configs
-      [name, *groups, 'domain'].reverse.reject(&:nil?).uniq
+    def groups
+      NodeattrInterface.groups_for_node(name)
+    rescue NodeNotInGendersError
+      # It's OK for a node to not be in the genders file, it just means it's
+      # not part of any groups.
+      []
     end
 
     # Get the configured `files` for this node, to be rendered and used in
@@ -78,10 +75,12 @@ module Metalware
     # from all `files` namespaces within all configs for the node, with
     # identifiers in higher precedence configs replacing those with the same
     # basename in lower precendence configs.
+    # XXX this may be better living in `Templating::Configuration`? `configs`
+    # and `load_config` could then be private.
     def build_files
       files_memo = Hash.new {|k,v| k[v] = []}
       configs.reduce(files_memo) do |files, config_name|
-        config = load_config(config_name)
+        config = templating_configuration.load_config(config_name)
         new_files = config[:files]
         merge_in_files!(files, new_files)
         files
@@ -119,16 +118,13 @@ module Metalware
 
     private
 
-    def build_complete_marker_file
-      File.join(@metalware_config.built_nodes_storage_path, "metalwarebooter.#{name}")
+    def templating_configuration
+      @templating_configuration ||=
+        Templating::Configuration.for_node(name, config: @metalware_config)
     end
 
-    def groups
-      NodeattrInterface.groups_for_node(name)
-    rescue NodeNotInGendersError
-      # It's OK for a node to not be in the genders file, it just means it's
-      # not part of any groups.
-      []
+    def build_complete_marker_file
+      File.join(@metalware_config.built_nodes_storage_path, "metalwarebooter.#{name}")
     end
 
     def cached_primary_group_index
@@ -145,11 +141,6 @@ module Metalware
 
     def primary_group
       groups.first
-    end
-
-    def load_config(config_name)
-      config_path = @metalware_config.repo_config_path(config_name)
-      Data.load(config_path)
     end
 
     def merge_in_files!(existing_files, new_files)
@@ -170,41 +161,6 @@ module Metalware
 
     def same_basename?(path1, path2)
       File.basename(path1) == File.basename(path2)
-    end
-
-    def combine_answers
-      config_answers = configs.map { |c| Data.load(answers_path_for(c)) }
-      combine_hashes(config_answers)
-    end
-
-    def answers_path_for(config_name)
-      File.join(
-        @metalware_config.answer_files_path,
-        answers_directory_for(config_name),
-        "#{config_name}.yaml"
-      )
-    end
-
-    def answers_directory_for(config_name)
-      # XXX Using only the config name to determine the answers directory will
-      # lead to answers not being picked up if a group has the same name as the
-      # node, or either is 'domain'; we should probably use more information
-      # when determining this (possibly we should extract a `Config` object).
-      case config_name
-      when "domain"
-        "/"
-      when name
-        "nodes"
-      else
-        "groups"
-      end
-    end
-
-    def combine_hashes(hashes)
-      hashes.each_with_object({}) do |config, combined_config|
-        raise CombineHashError unless config.is_a? Hash
-        combined_config.deep_merge!(config)
-      end
     end
   end
 end

--- a/src/node.rb
+++ b/src/node.rb
@@ -26,6 +26,7 @@ require 'constants'
 require 'system_command'
 require 'nodeattr_interface'
 require 'exceptions'
+require 'primary_group'
 require 'templating/configuration'
 
 module Metalware
@@ -107,8 +108,8 @@ module Metalware
     end
 
     def group_index
-      if cached_primary_group_index
-        cached_primary_group_index
+      if primary_group_index
+        primary_group_index
       else
         error = "Cannot get 'group_index', the primary group " +
           "'#{primary_group}' for this node (#{name}) has not been configured"
@@ -129,16 +130,8 @@ module Metalware
       File.join(metalware_config.built_nodes_storage_path, "metalwarebooter.#{name}")
     end
 
-    def cached_primary_group_index
-      cached_primary_groups.index(primary_group)
-    end
-
-    def cached_primary_groups
-      groups_cache[:primary_groups] || []
-    end
-
-    def groups_cache
-      Data.load(Constants::GROUPS_CACHE_PATH)
+    def primary_group_index
+      PrimaryGroup.index(primary_group)
     end
 
     def primary_group

--- a/src/node.rb
+++ b/src/node.rb
@@ -91,7 +91,7 @@ module Metalware
     # will be rendered to for this node.
     def rendered_build_file_path(namespace, file_name)
       File.join(
-        @metalware_config.rendered_files_path,
+        metalware_config.rendered_files_path,
         name,
         namespace.to_s,
         file_name
@@ -100,7 +100,7 @@ module Metalware
 
     def index
       if primary_group
-        Nodes.create(@metalware_config, primary_group, true).index(self)
+        Nodes.create(metalware_config, primary_group, true).index(self)
       else
         0
       end
@@ -118,13 +118,15 @@ module Metalware
 
     private
 
+    attr_reader :metalware_config
+
     def templating_configuration
       @templating_configuration ||=
-        Templating::Configuration.for_node(name, config: @metalware_config)
+        Templating::Configuration.for_node(name, config: metalware_config)
     end
 
     def build_complete_marker_file
-      File.join(@metalware_config.built_nodes_storage_path, "metalwarebooter.#{name}")
+      File.join(metalware_config.built_nodes_storage_path, "metalwarebooter.#{name}")
     end
 
     def cached_primary_group_index

--- a/src/primary_group.rb
+++ b/src/primary_group.rb
@@ -1,0 +1,38 @@
+
+# XXX Possibly more behaviour should be moved here, from
+# `Templating::GroupNamespace` and/or `Nodes` classes.
+module Metalware
+  class PrimaryGroup
+    class << self
+      include Enumerable
+
+      def each(&block)
+        cached_primary_groups.each do |group_name|
+          yield new(group_name)
+        end
+      end
+
+      def index(primary_group_name)
+        find_index do |primary_group|
+          primary_group.name == primary_group_name
+        end
+      end
+
+      private
+
+      def cached_primary_groups
+        groups_cache[:primary_groups] || []
+      end
+
+      def groups_cache
+        Data.load(Constants::GROUPS_CACHE_PATH)
+      end
+    end
+
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+    end
+  end
+end

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -72,12 +72,13 @@ module Metalware
           [:firstboot, :files].include?(k) && !v.nil?
       }
 
-      magic_struct = Templating::MagicNamespace.new(
+      raw_magic_namespace = Templating::MagicNamespace.new(
         config: metalware_config,
         node: node,
         **passed_magic_parameters
       )
-      @magic_namespace = Templating::MissingParameterWrapper.new(magic_struct)
+      @magic_namespace = \
+        Templating::MissingParameterWrapper.new(raw_magic_namespace)
       @passed_hash = parameters
       @config = parse_config
     end

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -128,6 +128,10 @@ module Metalware
     # The merging of the raw combined config files, any additional passed
     # values, and the magic `alces` namespace; this is the config prior to
     # parsing any nested ERB values.
+    # XXX Get rid of merging in `passed_hash`? This will cause an issue if a
+    # config specifies a value with the same name as something in the
+    # `passed_hash`, as it will overshadow it, and we don't actually want to
+    # support this any more.
     def base_config
       @base_config ||= node.raw_config
         .merge(@passed_hash)

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -72,7 +72,11 @@ module Metalware
           [:firstboot, :files].include?(k) && !v.nil?
       }
 
-      magic_struct = Templating::MagicNamespace.new(**passed_magic_parameters, node: node)
+      magic_struct = Templating::MagicNamespace.new(
+        config: metalware_config,
+        node: node,
+        **passed_magic_parameters
+      )
       @magic_namespace = Templating::MissingParameterWrapper.new(magic_struct)
       @passed_hash = parameters
       @config = parse_config

--- a/src/templating/configuration.rb
+++ b/src/templating/configuration.rb
@@ -1,0 +1,104 @@
+
+require 'node'
+
+
+# A `Templating::Configuration` represents the configuration used when
+# rendering templates for a particular object, which currently can be either a
+# node or a primary group of nodes.
+module Metalware
+  module Templating
+    class Configuration
+      private_class_method :new
+
+      class << self
+        def for_node(node_name, config:)
+          groups = Node.new(config, node_name).groups
+          new(
+            node: node_name,
+            groups: groups,
+            config: config
+          )
+        end
+
+        def for_primary_group(group_name, config:)
+          new(
+            # The only group a primary group should use the configs for is
+            # itself.
+            groups: [group_name],
+            config: config
+          )
+        end
+      end
+
+      attr_reader :node_name, :groups
+
+      def answers
+        @answers ||= combine_answers
+      end
+
+      # Return the raw merged config for this node/group, without parsing any
+      # embedded ERB (this should be done using the `Templater` if needed, as
+      # we won't know all the template parameters until a template is being
+      # rendered).
+      def raw_config
+        combine_hashes(configs.map { |c| load_config(c) })
+      end
+
+      def load_config(config_name)
+        config_path = metalware_config.repo_config_path(config_name)
+        Data.load(config_path)
+      end
+
+      # The config file names for this node/group, in order of precedence from
+      # lowest to highest.
+      def configs
+        [node_name, *groups, 'domain'].reverse.reject(&:nil?).uniq
+      end
+
+      private
+
+      attr_reader :metalware_config
+
+      def initialize(node: nil, groups:, config:)
+        @node_name = node
+        @groups = groups
+        @metalware_config = config
+      end
+
+      def combine_answers
+        config_answers = configs.map { |c| Data.load(answers_path_for(c)) }
+        combine_hashes(config_answers)
+      end
+
+      def answers_path_for(config_name)
+        File.join(
+          metalware_config.answer_files_path,
+          answers_directory_for(config_name),
+          "#{config_name}.yaml"
+        )
+      end
+
+      def answers_directory_for(config_name)
+        # XXX Using only the config name to determine the answers directory
+        # will potentially lead to answers not being picked up if a group has
+        # the same name as a node, or either is 'domain'; we should probably
+        # use more information when determining this.
+        case config_name
+        when 'domain'
+          '/'
+        when node_name
+          'nodes'
+        else
+          'groups'
+        end
+      end
+
+      def combine_hashes(hashes)
+        hashes.each_with_object({}) do |config, combined_config|
+          raise CombineHashError unless config.is_a? Hash
+          combined_config.deep_merge!(config)
+        end
+      end
+    end
+  end
+end

--- a/src/templating/group_namespace.rb
+++ b/src/templating/group_namespace.rb
@@ -12,9 +12,11 @@ module Metalware
 
       private
 
+      attr_reader :metalware_config
+
       def templating_configuration
         @templating_configuration ||=
-          Configuration.for_primary_group(name, config: @metalware_config)
+          Configuration.for_primary_group(name, config: metalware_config)
       end
     end
   end

--- a/src/templating/group_namespace.rb
+++ b/src/templating/group_namespace.rb
@@ -1,0 +1,64 @@
+
+module Metalware
+  module Templating
+    class GroupNamespace
+      attr_reader :name
+
+      def initialize(metalware_config, group_name)
+        @metalware_config = metalware_config
+        @name = group_name
+      end
+
+      # XXX refactor all answers duplication with `Node`.
+      def answers
+        @answers ||= combine_answers
+      end
+
+      private
+
+      # XXX duplicated from `Node`.
+      def combine_answers
+        config_answers = configs.map { |c| Data.load(answers_path_for(c)) }
+        combine_hashes(config_answers)
+      end
+
+      # The repo config files for this group in order of precedence from lowest
+      # to highest.
+      # XXX adapted from `Node`.
+      def configs
+        ['domain', name]
+      end
+
+      # XXX duplicated from `Node`.
+      def answers_path_for(config_name)
+        File.join(
+          @metalware_config.answer_files_path,
+          answers_directory_for(config_name),
+          "#{config_name}.yaml"
+        )
+      end
+
+      # XXX adapted from `Node`.
+      def answers_directory_for(config_name)
+        # XXX Using only the config name to determine the answers directory will
+        # lead to answers not being picked up if a group has the same name as the
+        # node, or either is 'domain'; we should probably use more information
+        # when determining this (possibly we should extract a `Config` object).
+        case config_name
+        when "domain"
+          "/"
+        when name
+          "groups"
+        end
+      end
+
+      # XXX duplicated from `Node`.
+      def combine_hashes(hashes)
+        hashes.each_with_object({}) do |config, combined_config|
+          raise CombineHashError unless config.is_a? Hash
+          combined_config.deep_merge!(config)
+        end
+      end
+    end
+  end
+end

--- a/src/templating/group_namespace.rb
+++ b/src/templating/group_namespace.rb
@@ -3,61 +3,18 @@ module Metalware
   module Templating
     class GroupNamespace
       attr_reader :name
+      delegate :answers, to: :templating_configuration
 
       def initialize(metalware_config, group_name)
         @metalware_config = metalware_config
         @name = group_name
       end
 
-      # XXX refactor all answers duplication with `Node`.
-      def answers
-        @answers ||= combine_answers
-      end
-
       private
 
-      # XXX duplicated from `Node`.
-      def combine_answers
-        config_answers = configs.map { |c| Data.load(answers_path_for(c)) }
-        combine_hashes(config_answers)
-      end
-
-      # The repo config files for this group in order of precedence from lowest
-      # to highest.
-      # XXX adapted from `Node`.
-      def configs
-        ['domain', name]
-      end
-
-      # XXX duplicated from `Node`.
-      def answers_path_for(config_name)
-        File.join(
-          @metalware_config.answer_files_path,
-          answers_directory_for(config_name),
-          "#{config_name}.yaml"
-        )
-      end
-
-      # XXX adapted from `Node`.
-      def answers_directory_for(config_name)
-        # XXX Using only the config name to determine the answers directory will
-        # lead to answers not being picked up if a group has the same name as the
-        # node, or either is 'domain'; we should probably use more information
-        # when determining this (possibly we should extract a `Config` object).
-        case config_name
-        when "domain"
-          "/"
-        when name
-          "groups"
-        end
-      end
-
-      # XXX duplicated from `Node`.
-      def combine_hashes(hashes)
-        hashes.each_with_object({}) do |config, combined_config|
-          raise CombineHashError unless config.is_a? Hash
-          combined_config.deep_merge!(config)
-        end
+      def templating_configuration
+        @templating_configuration ||=
+          Configuration.for_primary_group(name, config: @metalware_config)
       end
     end
   end

--- a/src/templating/magic_namespace.rb
+++ b/src/templating/magic_namespace.rb
@@ -44,6 +44,12 @@ module Metalware
         GenderGroupProxy
       end
 
+      def groups(&block)
+        cached_primary_groups.each do |group_name|
+          yield group_namespace_for(group_name)
+        end
+      end
+
       def hunter
         if File.exist? Constants::HUNTER_PATH
           Hashie::Mash.load(Constants::HUNTER_PATH)
@@ -79,6 +85,19 @@ module Metalware
       private
 
       attr_reader :metalware_config, :node
+
+      def group_namespace_for(group_name)
+        GroupNamespace.new(metalware_config, group_name)
+      end
+
+      # XXX Following two methods duplicated from `Node`.
+      def cached_primary_groups
+        groups_cache[:primary_groups] || []
+      end
+
+      def groups_cache
+        Data.load(Constants::GROUPS_CACHE_PATH)
+      end
 
       module GenderGroupProxy
         class << self

--- a/src/templating/magic_namespace.rb
+++ b/src/templating/magic_namespace.rb
@@ -11,7 +11,8 @@ require 'templating/missing_parameter_wrapper'
 module Metalware
   module Templating
     class MagicNamespace
-      def initialize(node: nil, firstboot: nil, files: nil)
+      def initialize(config:, node: nil, firstboot: nil, files: nil)
+        @metalware_config = config
         @node = node
         @firstboot = firstboot
         @files = Hashie::Mash.new(files) if files
@@ -77,7 +78,7 @@ module Metalware
 
       private
 
-      attr_reader :node
+      attr_reader :metalware_config, :node
 
       module GenderGroupProxy
         class << self

--- a/src/templating/magic_namespace.rb
+++ b/src/templating/magic_namespace.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/hash'
 require "constants"
 require 'deployment_server'
 require 'nodeattr_interface'
+require 'primary_group'
 require 'templating/missing_parameter_wrapper'
 
 
@@ -45,8 +46,8 @@ module Metalware
       end
 
       def groups(&block)
-        cached_primary_groups.each do |group_name|
-          yield group_namespace_for(group_name)
+        PrimaryGroup.each do |group|
+          yield group_namespace_for(group.name)
         end
       end
 
@@ -88,15 +89,6 @@ module Metalware
 
       def group_namespace_for(group_name)
         GroupNamespace.new(metalware_config, group_name)
-      end
-
-      # XXX Following two methods duplicated from `Node`.
-      def cached_primary_groups
-        groups_cache[:primary_groups] || []
-      end
-
-      def groups_cache
-        Data.load(Constants::GROUPS_CACHE_PATH)
       end
 
       module GenderGroupProxy


### PR DESCRIPTION
Based on https://github.com/alces-software/metalware/pull/113.

This PR adds a `groups` function to the `alces` namespace, as discussed on Slack at https://alces.slack.com/archives/C5FL99R89/p1499856806970388. Currently `groups` will call the passed block once for each primary group (each group already configured with `metal group configure`), with each call passed a `GroupNamespace` for the current group. The `GroupNamespace` currently provides two properties: `name`, the group name, and `answers`, the `configure` answers for that group; this is the domain answers with the group answers merged in, as these are the only answers which are applicable to a particular primary group.

Access to the `nodes` will also be needed from a `GroupNamespace`, but this will follow in a future PR as this is already quite large; apart from this I don't think we will need anything else in this namespace for the moment in order to render the `genders` or `hosts` templates.

In the process of doing this I found there were a few things on `Node` which needed to be extracted, as we needed to use the same/similar functionality in other places. This resulted in extracting a `Templating::Configuration` class, which I think seems an OK abstraction, as well as a `PrimaryGroup` class, which I think will need a bit more work. I think there's probably a better way we could divide up the responsibilities of `Nodes`, `Templating::GroupNamespace`, and `PrimaryGroup`, but I'm not quite sure what that is yet so I'm leaving it for now.

This is part of the way towards handling https://trello.com/c/cj9s16dR/77-consider-how-to-make-groups-and-nodes-available-in-templater.