### PR TITLE
Extract more templater parts

### DIFF
--- a/src/templater.rb
+++ b/src/templater.rb
@@ -28,6 +28,7 @@ require 'exceptions'
 require 'templating/iterable_recursive_open_struct'
 require 'templating/missing_parameter_wrapper'
 require 'templating/magic_namespace'
+require 'templating/renderer'
 
 
 module Metalware
@@ -95,40 +96,7 @@ module Metalware
 
     private
 
-    def replace_erb(template, template_parameters)
-      parameters_binding = template_parameters.instance_eval {binding}
-      render_erb_template(template, parameters_binding)
-    rescue NoMethodError => e
-      # May be useful to include the name of the unset parameter in this error,
-      # however this is tricky as by the time we attempt to access a method on
-      # it the unset parameter is just `nil` as far as we can see here.
-      raise UnsetParameterAccessError,
-        "Attempted to call method `#{e.name}` of unset template parameter"
-    end
-
-    def render_erb_template(template, binding)
-      # This mode allows templates to prevent inserting a newline for a given
-      # line by ending the ERB tag on that line with `-%>`.
-      trim_mode = '-'
-
-      safe_level = 0
-      erb = ERB.new(template, safe_level, trim_mode)
-
-      begin
-        erb.result(binding)
-      rescue SyntaxError => error
-        handle_error_rendering_erb(template, error)
-      end
-    end
-
-    def handle_error_rendering_erb(template, error)
-      Output.stderr "\nRendering template failed!\n\n"
-      Output.stderr "Template:\n\n"
-      Output.stderr_indented_error_message template
-      Output.stderr "\nError message:\n\n"
-      Output.stderr_indented_error_message error.message
-      abort
-    end
+    delegate :replace_erb, to: Templating::Renderer
 
     # The merging of the raw combined config files, any additional passed
     # values, and the magic `alces` namespace; this is the config prior to

--- a/src/templating/missing_parameter_wrapper.rb
+++ b/src/templating/missing_parameter_wrapper.rb
@@ -16,24 +16,6 @@ module Metalware
                        end
       end
 
-      def method_missing(s, *a, &b)
-        value = @wrapped_obj.send(s)
-        if value.nil? && ! @missing_tags.include?(s)
-          msg = "Unset template parameter: #{s}"
-          # TODO: This code causes alces.answer.<missing-parameter> to throw an error
-          # This is the correct behavior but it is breaking the tests
-          # The offending tests need to be switched over to using FakeFS, then this
-          # code can be uncommented.
-          #if @fatal
-          #  raise MissingParameterError, msg
-          #else
-          @missing_tags.push s
-          MetalLog.warn msg
-          #end
-        end
-        value
-      end
-
       def inspect
         @wrapped_obj
       end

--- a/src/templating/renderer.rb
+++ b/src/templating/renderer.rb
@@ -1,0 +1,47 @@
+
+module Metalware
+  module Templating
+    module Renderer
+      class << self
+        # Replace all ERB in given template, generating the binding to use from
+        # the given parameters.
+        def replace_erb(template, template_parameters)
+          parameters_binding = template_parameters.instance_eval {binding}
+          render_erb_template(template, parameters_binding)
+        rescue NoMethodError => e
+          # May be useful to include the name of the unset parameter in this error,
+          # however this is tricky as by the time we attempt to access a method on
+          # it the unset parameter is just `nil` as far as we can see here.
+          raise UnsetParameterAccessError,
+            "Attempted to call method `#{e.name}` of unset template parameter"
+        end
+
+        private
+
+        def render_erb_template(template, binding)
+          # This mode allows templates to prevent inserting a newline for a given
+          # line by ending the ERB tag on that line with `-%>`.
+          trim_mode = '-'
+
+          safe_level = 0
+          erb = ERB.new(template, safe_level, trim_mode)
+
+          begin
+            erb.result(binding)
+          rescue SyntaxError => error
+            handle_error_rendering_erb(template, error)
+          end
+        end
+
+        def handle_error_rendering_erb(template, error)
+          Output.stderr "\nRendering template failed!\n\n"
+          Output.stderr "Template:\n\n"
+          Output.stderr_indented_error_message template
+          Output.stderr "\nError message:\n\n"
+          Output.stderr_indented_error_message error.message
+          abort
+        end
+      end
+    end
+  end
+end

--- a/src/templating/repo_config_parser.rb
+++ b/src/templating/repo_config_parser.rb
@@ -1,0 +1,60 @@
+
+require 'templating/renderer'
+
+
+module Metalware
+  module Templating
+    module RepoConfigParser
+      class << self
+        def parse(base_config)
+          current_parsed_config = base_config
+          current_config_string = current_parsed_config.to_s
+          previous_config_string = nil
+          count = 0
+
+          # Loop through the config and recursively parse any config values which
+          # contain ERB, until the parsed config is not changing or we have
+          # exceeded the maximum number of passes to make.
+          while previous_config_string != current_config_string
+            count += 1
+            if count > Constants::MAXIMUM_RECURSIVE_CONFIG_DEPTH
+              raise RecursiveConfigDepthExceededError
+            end
+
+            previous_config_string = current_config_string
+            current_parsed_config = perform_config_parsing_pass(current_parsed_config)
+            current_config_string = current_parsed_config.to_s
+          end
+
+          create_template_parameters(current_parsed_config)
+        end
+
+        private
+
+        def perform_config_parsing_pass(current_parsed_config)
+          current_parsed_config.map do |k,v|
+            [k, parse_config_value(v, current_parsed_config)]
+          end.to_h
+        end
+
+        def parse_config_value(value, current_parsed_config)
+          case value
+          when String
+            parameters = create_template_parameters(current_parsed_config)
+            Renderer.replace_erb(value, parameters)
+          when Hash
+            value.map do |k,v|
+              [k, parse_config_value(v, current_parsed_config)]
+            end.to_h
+          else
+            value
+          end
+        end
+
+        def create_template_parameters(config)
+          MissingParameterWrapper.new(IterableRecursiveOpenStruct.new(config))
+        end
+      end
+    end
+  end
+end

--- a/src/templating/repo_config_parser.rb
+++ b/src/templating/repo_config_parser.rb
@@ -4,56 +4,108 @@ require 'templating/renderer'
 
 module Metalware
   module Templating
-    module RepoConfigParser
+    class RepoConfigParser
+      private_class_method :new
+
       class << self
-        def parse(base_config)
-          current_parsed_config = base_config
-          current_config_string = current_parsed_config.to_s
-          previous_config_string = nil
-          count = 0
 
-          # Loop through the config and recursively parse any config values which
-          # contain ERB, until the parsed config is not changing or we have
-          # exceeded the maximum number of passes to make.
-          while previous_config_string != current_config_string
-            count += 1
-            if count > Constants::MAXIMUM_RECURSIVE_CONFIG_DEPTH
-              raise RecursiveConfigDepthExceededError
-            end
+        # XXX get rid of handling `additional_parameters`? And just take what
+        # we need.
+        def parse_for_node(node_name:, config:, additional_parameters:)
+          new(
+            node_name: node_name,
+            config: config,
+            additional_parameters: additional_parameters
+          ).parse
+        end
+      end
 
-            previous_config_string = current_config_string
-            current_parsed_config = perform_config_parsing_pass(current_parsed_config)
-            current_config_string = current_parsed_config.to_s
+      def parse
+        current_parsed_config = base_config
+        current_config_string = current_parsed_config.to_s
+        previous_config_string = nil
+        count = 0
+
+        # Loop through the config and recursively parse any config values which
+        # contain ERB, until the parsed config is not changing or we have
+        # exceeded the maximum number of passes to make.
+        while previous_config_string != current_config_string
+          count += 1
+          if count > Constants::MAXIMUM_RECURSIVE_CONFIG_DEPTH
+            raise RecursiveConfigDepthExceededError
           end
 
-          create_template_parameters(current_parsed_config)
+          previous_config_string = current_config_string
+          current_parsed_config = perform_config_parsing_pass(current_parsed_config)
+          current_config_string = current_parsed_config.to_s
         end
 
-        private
+        create_template_parameters(current_parsed_config)
+      end
 
-        def perform_config_parsing_pass(current_parsed_config)
-          current_parsed_config.map do |k,v|
+      private
+
+      attr_reader :node_name, :metalware_config, :additional_parameters
+
+      def initialize(node_name:, config:, additional_parameters:)
+        @node_name = node_name
+        @metalware_config = config
+        @additional_parameters = additional_parameters
+      end
+
+      def node
+        @node ||= Node.new(metalware_config, node_name)
+      end
+
+      # The merging of the raw combined config files, any additional passed
+      # values, and the magic `alces` namespace; this is the config prior to
+      # parsing any nested ERB values.
+      # XXX Get rid of merging in `passed_hash`? This will cause an issue if a
+      # config specifies a value with the same name as something in the
+      # `passed_hash`, as it will overshadow it, and we don't actually want to
+      # support this any more.
+      def base_config
+        @base_config ||= node.raw_config
+          .merge(additional_parameters)
+          .merge(alces: magic_namespace)
+      end
+
+      def magic_namespace
+        MissingParameterWrapper.new(MagicNamespace.new(
+          config: metalware_config,
+          node: node,
+          **magic_parameters
+        ))
+      end
+
+      def magic_parameters
+        additional_parameters.select { |k,v|
+          [:firstboot, :files].include?(k) && !v.nil?
+        }
+      end
+
+      def perform_config_parsing_pass(current_parsed_config)
+        current_parsed_config.map do |k,v|
+          [k, parse_config_value(v, current_parsed_config)]
+        end.to_h
+      end
+
+      def parse_config_value(value, current_parsed_config)
+        case value
+        when String
+          parameters = create_template_parameters(current_parsed_config)
+          Renderer.replace_erb(value, parameters)
+        when Hash
+          value.map do |k,v|
             [k, parse_config_value(v, current_parsed_config)]
           end.to_h
+        else
+          value
         end
+      end
 
-        def parse_config_value(value, current_parsed_config)
-          case value
-          when String
-            parameters = create_template_parameters(current_parsed_config)
-            Renderer.replace_erb(value, parameters)
-          when Hash
-            value.map do |k,v|
-              [k, parse_config_value(v, current_parsed_config)]
-            end.to_h
-          else
-            value
-          end
-        end
-
-        def create_template_parameters(config)
-          MissingParameterWrapper.new(IterableRecursiveOpenStruct.new(config))
-        end
+      def create_template_parameters(config)
+        MissingParameterWrapper.new(IterableRecursiveOpenStruct.new(config))
       end
     end
   end


### PR DESCRIPTION
Based on https://github.com/alces-software/metalware/pull/115.

This PR extracts some more parts of the `Templater` to two new classes, `RepoConfigParser` and `Renderer`, along with some other small refactoring. This is done as we need to use this functionality in other places now, and it makes sense to split this up a bit more in any case.