### PR TITLE
Render hosts and genders after each configure process

### DIFF
--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -1,0 +1,50 @@
+
+RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
+  TEST_COMMAND_NAME = :testcommand
+
+  # Subclass of `ConfigureCommand` for use in tests, to test it independently
+  # of any individual subclass.
+  class TestCommand < Metalware::CommandHelpers::ConfigureCommand
+    protected
+
+    def setup(args, options)
+    end
+
+    # Overridden as superclass method depends on this being in the
+    # `Metalware::Commands` namespace.
+    def command_name
+      TEST_COMMAND_NAME
+    end
+
+    def answers_file
+      '/var/lib/metalware/answers/some_file.yaml'
+    end
+  end
+
+  it 'renders the hosts and genders files' do
+    FileSystem.test do |fs|
+      fs.with_minimal_repo
+
+      # `configure.yaml` needs to contain a key with the same name as the
+      # command.
+      Metalware::Data.dump(
+        '/var/lib/metalware/repo/configure.yaml',
+        {TEST_COMMAND_NAME => []}
+      )
+
+      expect(Metalware::Templater).to receive(:render_to_file).with(
+          instance_of(Metalware::Config),
+          '/var/lib/metalware/repo/genders/default',
+          Metalware::Constants::GENDERS_PATH
+      ).and_call_original
+
+      expect(Metalware::Templater).to receive(:render_to_file).with(
+          instance_of(Metalware::Config),
+          '/var/lib/metalware/repo/hosts/default',
+          Metalware::Constants::HOSTS_PATH
+      ).and_call_original
+
+      SpecUtils.run_command(TestCommand)
+    end
+  end
+end

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -17,59 +17,60 @@ RSpec.describe Metalware::Commands::Configure::Group do
   let :groups_yaml { Metalware::Data.load(groups_file) }
   let :primary_groups { groups_yaml[:primary_groups] }
 
-  context 'when `cache/groups.yaml` does not exist' do
-    it 'creates it and inserts new primary group' do
-      FileSystem.test do |fs|
-        fs.with_minimal_repo
+  describe 'recording groups' do
+    context 'when `cache/groups.yaml` does not exist' do
+      it 'creates it and inserts new primary group' do
+        FileSystem.test do |fs|
+          fs.with_minimal_repo
 
-        run_configure_group 'testnodes'
+          run_configure_group 'testnodes'
 
-        expect(primary_groups).to eq [
-          'testnodes'
-        ]
-      end
-    end
-  end
-
-
-  context 'when `cache/groups.yaml` exists' do
-    it 'inserts primary group if new' do
-      FileSystem.test do |fs|
-        fs.with_minimal_repo
-        Metalware::Data.dump(groups_file, {
-          primary_groups: [
-            'first_group',
+          expect(primary_groups).to eq [
+            'testnodes'
           ]
-        })
-
-        run_configure_group 'second_group'
-
-        expect(primary_groups).to eq [
-          'first_group',
-          'second_group',
-        ]
+        end
       end
-
     end
 
-    it 'does nothing if primary group already presnt' do
-      FileSystem.test do |fs|
-        fs.with_minimal_repo
-        Metalware::Data.dump(groups_file, {
-          primary_groups: [
+    context 'when `cache/groups.yaml` exists' do
+      it 'inserts primary group if new' do
+        FileSystem.test do |fs|
+          fs.with_minimal_repo
+          Metalware::Data.dump(groups_file, {
+            primary_groups: [
+              'first_group',
+            ]
+          })
+
+          run_configure_group 'second_group'
+
+          expect(primary_groups).to eq [
             'first_group',
             'second_group',
           ]
-        })
+        end
 
-        run_configure_group 'second_group'
-
-        expect(primary_groups).to eq [
-          'first_group',
-          'second_group',
-        ]
       end
 
+      it 'does nothing if primary group already presnt' do
+        FileSystem.test do |fs|
+          fs.with_minimal_repo
+          Metalware::Data.dump(groups_file, {
+            primary_groups: [
+              'first_group',
+              'second_group',
+            ]
+          })
+
+          run_configure_group 'second_group'
+
+          expect(primary_groups).to eq [
+            'first_group',
+            'second_group',
+          ]
+        end
+      end
     end
+
   end
 end

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -17,12 +17,16 @@ RSpec.describe Metalware::Commands::Configure::Group do
   let :groups_yaml { Metalware::Data.load(groups_file) }
   let :primary_groups { groups_yaml[:primary_groups] }
 
+  let :filesystem {
+    FileSystem.setup do |fs|
+      fs.with_minimal_repo
+    end
+  }
+
   describe 'recording groups' do
     context 'when `cache/groups.yaml` does not exist' do
       it 'creates it and inserts new primary group' do
-        FileSystem.test do |fs|
-          fs.with_minimal_repo
-
+        filesystem.test do
           run_configure_group 'testnodes'
 
           expect(primary_groups).to eq [
@@ -34,8 +38,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
 
     context 'when `cache/groups.yaml` exists' do
       it 'inserts primary group if new' do
-        FileSystem.test do |fs|
-          fs.with_minimal_repo
+        filesystem.test do
           Metalware::Data.dump(groups_file, {
             primary_groups: [
               'first_group',
@@ -53,8 +56,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
       end
 
       it 'does nothing if primary group already presnt' do
-        FileSystem.test do |fs|
-          fs.with_minimal_repo
+        filesystem.test do
           Metalware::Data.dump(groups_file, {
             primary_groups: [
               'first_group',

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -38,6 +38,7 @@ class FileSystem
   # invoked when `FileSystem.test` is run with that instance. If these were run
   # directly outside of a `test` block then the real file system would be used.
   delegate :mkdir_p, to: FileUtils
+  delegate :write, to: File
   delegate :dump, to: Metalware::Data
 
   # Perform optional configuration of the `FileSystem` prior to a `test`. The

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -38,6 +38,7 @@ class FileSystem
   # invoked when `FileSystem.test` is run with that instance. If these were run
   # directly outside of a `test` block then the real file system would be used.
   delegate :mkdir_p, to: FileUtils
+  delegate :dump, to: Metalware::Data
 
   # Perform optional configuration of the `FileSystem` prior to a `test`. The
   # yielded and returned `FileSystemConfigurator` caches any unknown method

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -117,6 +117,7 @@ class FileSystem
   # install.
   def create_initial_directory_hierarchy
     [
+      '/etc',
       '/var/log/metalware',
       '/var/lib/metalware/rendered/kickstart',
       '/var/lib/metalware/rendered/system',

--- a/spec/fixtures/repo/config/domain.yaml
+++ b/spec/fixtures/repo/config/domain.yaml
@@ -1,6 +1,6 @@
 
 some_repo_value: repo_value
-erb_repo_value: <%= alces[:index] + 1 %>
+erb_repo_value: <%= alces.index + 1 %>
 
 first_level_erb_repo_value: <%= some_repo_value %>
 second_level_erb_repo_value: <%= first_level_erb_repo_value %>

--- a/spec/fixtures/repo/config/domain.yaml
+++ b/spec/fixtures/repo/config/domain.yaml
@@ -7,6 +7,11 @@ second_level_erb_repo_value: <%= first_level_erb_repo_value %>
 third_level_erb_repo_value: <%= second_level_erb_repo_value %>
 very_recursive_erb_repo_value: <%= third_level_erb_repo_value %>
 
+true_repo_value: true
+false_repo_value: false
+recursive_true_repo_value: <%= true_repo_value %>
+recursive_false_repo_value: <%= false_repo_value %>
+
 nested:
   repo_value: nested_repo_value
 

--- a/spec/fixtures/template.erb
+++ b/spec/fixtures/template.erb
@@ -1,7 +1,0 @@
-This is a test template
-some_passed_value: <%= some_passed_value %>
-some_repo_value: <%= some_repo_value %>
-erb_repo_value: <%= erb_repo_value %>
-very_recursive_erb_repo_value: <%= very_recursive_erb_repo_value %>
-nested.repo_value: <%= nested ? nested.repo_value : nil %>
-alces.index: <%= alces.index %>

--- a/spec/fixtures/unset_parameter_template.erb
+++ b/spec/fixtures/unset_parameter_template.erb
@@ -1,1 +1,0 @@
-unset.parameter: <%= unset.parameter %>

--- a/spec/minimal_repo.rb
+++ b/spec/minimal_repo.rb
@@ -6,6 +6,7 @@ module MinimalRepo
       '.git',
       'config',
       'hosts',
+      'genders',
       'dhcp',
       'files',
       'pxelinux',
@@ -16,6 +17,7 @@ module MinimalRepo
       'pxelinux/default': "<%= alces.firstboot ? 'FIRSTBOOT' : 'NOT_FIRSTBOOT' %>\n",
       'kickstart/default': '',
       'hosts/default': '',
+      'genders/default': '',
       'dhcp/default': '',
       'config/domain.yaml': '',
       'configure.yaml': YAML.dump({

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -150,6 +150,28 @@ RSpec.describe Metalware::Templater do
           end
         end
       end
+
+      context 'when parsing recursive boolean values' do
+        let :template {
+          <<-EOF
+          <% if recursive_true_repo_value -%>
+          true worked
+          <% end %>
+          <% unless recursive_false_repo_value -%>
+          false worked
+          <% end %>
+          EOF
+        }
+
+        it 'renders them as booleans not strings' do
+          expected = <<-EOF
+          true worked
+          false worked
+          EOF
+
+          expect_renders({}, expected)
+        end
+      end
     end
 
     context 'when passed node not in genders file' do

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -180,22 +180,31 @@ RSpec.describe Metalware::Templater do
       SpecUtils.use_mock_genders(self)
     end
 
-    context 'when node has answers' do
-      # XXX May be possible to combine this with other passed parameter test
-      # below? They rely on file system however and this relies on a mocked
-      # Node object.
-      it 'provides access to the answers' do
-        expect(Metalware::Node).to receive(:new).and_return(
-          OpenStruct.new({
-            answers: 'testnode01_answers',
-            raw_config: {}
-          })
-        )
+    # XXX May be possible to combine these with other passed parameter testsgqic
+    # below?
+    describe 'answers' do
+      before :each do
+        filesystem.dump '/var/lib/metalware/answers/nodes/testnode01.yaml', {
+          some_question: 'some_answer'
+        }
+      end
 
-        templater = Metalware::Templater.new(config, {nodename: 'testnode01'})
+      let :answers { templater.config.alces.answers }
 
-        expect(templater.config.alces.answers).to be_a(Metalware::Templating::MissingParameterWrapper)
-        expect(templater.config.alces.answers.inspect).to eq('testnode01_answers')
+      context 'when node passed' do
+        let :templater {
+          Metalware::Templater.new(config, {nodename: 'testnode01'})
+        }
+
+        it 'can access answers for the node' do
+          filesystem.test do
+            expect(answers.some_question).to eq('some_answer')
+          end
+        end
+
+        it "raises if attempt to access an answer which isn't present" do
+          expect{ answers.invalid_question }.to raise_error(Metalware::MissingParameterError)
+        end
       end
     end
 

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -206,6 +206,16 @@ RSpec.describe Metalware::Templater do
           expect{ answers.invalid_question }.to raise_error(Metalware::MissingParameterError)
         end
       end
+
+      context 'when no node passed' do
+        let :templater {
+          Metalware::Templater.new(config)
+        }
+
+        it 'returns nil for all values in answers namespace' do
+          expect(answers.anything).to be nil
+        end
+      end
     end
 
     context 'with cache files present' do

--- a/src/command_helpers/base_command.rb
+++ b/src/command_helpers/base_command.rb
@@ -52,13 +52,6 @@ module Metalware
         enforce_dependencies
       end
 
-      def validate_repo_exists_if_required
-        if requires_repo? && !repo.exists?
-          raise NoRepoError,
-            "'#{command_name}' requires a repo to operate on; please run 'metal repo use' first"
-        end
-      end
-
       def setup_config(options)
         cli_options = {
           strict: !!options.strict,

--- a/src/command_helpers/base_command.rb
+++ b/src/command_helpers/base_command.rb
@@ -68,9 +68,7 @@ module Metalware
       end
 
       def dependencies_hash
-        {
-          #repo: [], Array of files or true for base dir
-        }
+        {}
       end
 
       def enforce_dependencies

--- a/src/command_helpers/bash_command.rb
+++ b/src/command_helpers/bash_command.rb
@@ -27,7 +27,7 @@ require 'constants'
 
 module Metalware
   module CommandHelpers
-    class BashCommand < CommandHelpers::BaseCommand
+    class BashCommand < BaseCommand
       private
       def setup(args, options)
         @command = ARGV[0]

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -8,6 +8,7 @@ module Metalware
     class ConfigureCommand < CommandHelpers::BaseCommand
       def run
         configurator.configure
+        custom_configuration
       end
 
       def handle_interrupt(_e)
@@ -15,6 +16,11 @@ module Metalware
       end
 
       protected
+
+      def custom_configuration
+        # Custom additional configuration for a `configure` command, if any,
+        # should be performed in this method in subclasses.
+      end
 
       def answers_file
         raise NotImplementedError

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -9,6 +9,7 @@ module Metalware
       def run
         configurator.configure
         custom_configuration
+        render_domain_templates
       end
 
       def handle_interrupt(_e)
@@ -45,6 +46,31 @@ module Metalware
 
       def questions_section
         self.class.name.split('::')[-1].downcase.to_sym
+      end
+
+      # Render the templates which are relevant across the whole domain; these
+      # are re-rendered at the end of every configure command as the data used
+      # in the templates could change with each command.
+      def render_domain_templates
+        render_template(genders_template, to: Constants::GENDERS_PATH)
+        render_template(hosts_template, to: Constants::HOSTS_PATH)
+      end
+
+      def render_template(template, to:)
+        Templater.render_to_file(config, template, to)
+      end
+
+      def genders_template
+        template_path('genders')
+      end
+
+      def hosts_template
+        template_path('hosts')
+      end
+
+      def template_path(template_type)
+        # We currently always/only render the 'default' templates.
+        File.join(config.repo_path, template_type, 'default')
       end
     end
   end

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -5,7 +5,7 @@ require 'constants'
 
 module Metalware
   module CommandHelpers
-    class ConfigureCommand < CommandHelpers::BaseCommand
+    class ConfigureCommand < BaseCommand
       def run
         configurator.configure
         custom_configuration

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -12,12 +12,11 @@ module Metalware
           @group_name = args.first
         end
 
-        def run
-          super
+        protected
+
+        def custom_configuration
           record_primary_group
         end
-
-        protected
 
         def answers_file
           file_name = "#{group_name}.yaml"

--- a/src/commands/hosts.rb
+++ b/src/commands/hosts.rb
@@ -54,7 +54,7 @@ module Metalware
           if @options.dry_run
             Templater.render_to_stdout(config, template_path, parameters)
           else
-            Templater.render_and_append_to_file(config, template_path, HOSTS_FILE, parameters)
+            Templater.render_and_append_to_file(config, template_path, Constants::HOSTS_PATH, parameters)
           end
         end
       end

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -36,6 +36,7 @@ module Metalware
 
     NODEATTR_COMMAND = 'nodeattr'
 
+    GENDERS_PATH = File.join(METALWARE_CONFIGS_PATH, 'genders')
     HOSTS_PATH = '/etc/hosts'
   end
 end

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -35,5 +35,7 @@ module Metalware
     MAXIMUM_RECURSIVE_CONFIG_DEPTH = 10
 
     NODEATTR_COMMAND = 'nodeattr'
+
+    HOSTS_PATH = '/etc/hosts'
   end
 end

--- a/src/templating/magic_namespace.rb
+++ b/src/templating/magic_namespace.rb
@@ -36,7 +36,16 @@ module Metalware
       end
 
       def answers
-        MissingParameterWrapper.new(node.answers, raise_on_missing: true)
+        # If we're templating for a particular node then we should be strict
+        # about accessing answers which don't exist, as this indicates a
+        # problem in the repo; otherwise (e.g. when rendering hosts or genders
+        # templates) we should not be strict, to avoid erroring as many answers
+        # may be unset.
+        if node.name.present?
+          MissingParameterWrapper.new(node.answers, raise_on_missing: true)
+        else
+          Hashie::Mash.new
+        end
       end
 
       def genders

--- a/src/templating/repo_config_parser.rb
+++ b/src/templating/repo_config_parser.rb
@@ -93,12 +93,32 @@ module Metalware
       def parse_config_value(value, current_parsed_config)
         case value
         when String
-          parameters = create_template_parameters(current_parsed_config)
-          Renderer.replace_erb(value, parameters)
+          parse_string_config_value(value, current_parsed_config)
         when Hash
           value.map do |k,v|
             [k, parse_config_value(v, current_parsed_config)]
           end.to_h
+        else
+          value
+        end
+      end
+
+      def parse_string_config_value(value, config)
+        parameters = create_template_parameters(config)
+        rendered_value = Renderer.replace_erb(value, parameters)
+        convert_rendered_value(rendered_value)
+      end
+
+      def convert_rendered_value(value)
+        # Currently we just special case so rendered boolean strings are
+        # converted to booleans, so using recursive boolean values in templates
+        # works as expected; without this the wrong thing can silently happen
+        # as "false" is truthy. This is a bit ugly though.
+        case value
+        when 'true'
+          true
+        when 'false'
+          false
         else
           value
         end


### PR DESCRIPTION
This PR makes the hosts and genders files be re-rendered after each `configure` command, as the information used to generate these can change with any `configure` command. Some related changes are also included such as some testing improvements and conversion of boolean values when templating.

Trello: https://trello.com/c/HE3R0A3a/19-have-hosts-fully-render-the-hosts-file-in-a-single-pass and https://trello.com/c/KHcNThRO/115-have-genders-be-generated-based-on-configured-groups.