### PR TITLE
Configure command improvements

### DIFF
--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -43,7 +43,10 @@ RSpec.describe Metalware::Configurator do
       highline: hl,
       configure_file: configure_file_path,
       questions_section: :test,
-      answers_file: answers_file_path
+      answers_file: answers_file_path,
+      # Do not want to use readline to get input in tests as tests will then
+      # hang waiting for input.
+      use_readline: false
     )
   end
 

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -94,15 +94,7 @@ RSpec.describe Metalware::Configurator do
         }
       })
 
-      expect(highline).to receive(
-        :ask
-      ).with(
-        'Can you enter a string?'
-      ).and_return(
-        'My string'
-      )
-
-      configurator.configure
+      configure_with_answers(['My string'])
 
       expect(answers).to eq({
         string_q: 'My string'
@@ -119,15 +111,7 @@ RSpec.describe Metalware::Configurator do
         }
       })
 
-      expect(highline).to receive(
-        :ask
-      ).with(
-        'Can you enter a string?'
-      ).and_return(
-        'My string'
-      )
-
-      configurator.configure
+      configure_with_answers(['My string'])
 
       expect(answers).to eq({
         string_q: 'My string'
@@ -144,15 +128,7 @@ RSpec.describe Metalware::Configurator do
         }
       })
 
-      expect(highline).to receive(
-        :ask
-      ).with(
-        'Can you enter an integer?', Integer
-      ).and_return(
-        7
-      )
-
-      configurator.configure
+      configure_with_answers(['7'])
 
       expect(answers).to eq({
         integer_q: 7
@@ -174,12 +150,10 @@ RSpec.describe Metalware::Configurator do
       ).with(
         # Note that an indication of what the input should be has been appended
         # to the asked question.
-       'Should this cluster be awesome? [yes/no]'
-      ).and_return(
-        true
-      )
+        'Should this cluster be awesome? [yes/no]'
+      ).and_call_original
 
-      configurator.configure
+      configure_with_answers(['yes'])
 
       expect(answers).to eq({
         boolean_q: true
@@ -201,11 +175,9 @@ RSpec.describe Metalware::Configurator do
         :choose
       ).with(
         'foo', 'bar'
-      ).and_return(
-        'bar'
-      )
+      ).and_call_original
 
-      configurator.configure
+      configure_with_answers(['bar'])
 
       expect(answers).to eq({
         choice_q: 'bar'
@@ -235,14 +207,7 @@ RSpec.describe Metalware::Configurator do
         }
       })
 
-      allow(highline).to receive(
-        :ask
-      ).and_return('Some string', 11)
-      allow(highline).to receive(
-        :agree
-      ).and_return(false)
-
-      configurator.configure
+      configure_with_answers(['Some string', '11', 'no'])
 
       expect(answers).to eq(
         string_q: 'Some string',

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -259,16 +259,28 @@ RSpec.describe Metalware::Configurator do
             question: 'Integer?',
             type: 'integer',
             default: 10
-          }
+          },
+          true_boolean_q: {
+            question: 'Boolean?',
+            type: 'boolean',
+            default: true
+          },
+          false_boolean_q: {
+            question: 'More boolean?',
+            type: 'boolean',
+            default: false
+          },
         }
       })
 
-      configure_with_answers([''] * 3)
+      configure_with_answers([''] * 5)
 
       expect(answers).to eq({
         string_q: str_ans,
         string_erb: erb_ans,
         integer_q: 10,
+        true_boolean_q: true,
+        false_boolean_q: false
       })
     end
 
@@ -283,14 +295,26 @@ RSpec.describe Metalware::Configurator do
             question: 'Integer?',
             type: 'integer',
             default: 10
-          }
+          },
+          false_saved_boolean_q: {
+            question: 'Boolean?',
+            type: 'boolean',
+            default: true
+          },
+          true_saved_boolean_q: {
+            question: 'More boolean?',
+            type: 'boolean',
+            default: false
+          },
         }
       })
 
       old_answers = {
         string_q: "CORRECT",
         integer_q: -100,
-        should_not_see_me: "OHHH SNAP"
+        false_saved_boolean_q: false,
+        true_saved_boolean_q: true,
+        should_not_see_me: "OHHH SNAP",
       }
       new_answers = old_answers.dup.tap { |h| h.delete(:should_not_see_me) }
 
@@ -301,7 +325,7 @@ RSpec.describe Metalware::Configurator do
       end
       expect(first_run_configure.send(:old_answers)).to eq(old_answers)
 
-      configure_with_answers([''] * 2)
+      configure_with_answers([''] * 4)
       expect(answers).to eq(new_answers)
     end
 

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -78,6 +78,11 @@ RSpec.describe Metalware::Configurator do
     end
   end
 
+  def configure_with_answers(answers)
+    # Each answer must be entered followed by a newline to terminate it.
+    configure_with_input(answers.join("\n") + "\n")
+  end
+
   describe '#configure' do
     it 'asks questions with type `string`' do
       define_questions({
@@ -293,7 +298,7 @@ RSpec.describe Metalware::Configurator do
         }
       })
 
-      configure_with_input("\n\n\n\n\n")
+      configure_with_answers([''] * 3)
 
       expect(answers).to eq({
         string_q: str_ans,
@@ -331,7 +336,7 @@ RSpec.describe Metalware::Configurator do
       end
       expect(first_run_configure.send(:old_answers)).to eq(old_answers)
 
-      configure_with_input("\n\n\n\n\n\n")
+      configure_with_answers([''] * 2)
       expect(answers).to eq(new_answers)
     end
 
@@ -349,7 +354,7 @@ RSpec.describe Metalware::Configurator do
         begin
           $stderr = Tempfile.new
           STDERR = $stderr
-          configure_with_input("\n\n")
+          configure_with_answers([''] * 2)
         ensure
           STDERR = old_stderr
           $stderr = STDERR
@@ -378,7 +383,7 @@ RSpec.describe Metalware::Configurator do
         string_q: ''
       }
 
-      configure_with_input("\n")
+      configure_with_answers([''])
       expect(answers).to eq(expected)
     end
   end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -167,7 +167,9 @@ RSpec.describe Metalware::Configurator do
       expect(highline).to receive(
         :agree
       ).with(
-       'Should this cluster be awesome?'
+        # Note that an indication of what the input should be has been appended
+        # to the asked question.
+       'Should this cluster be awesome? [yes/no]'
       ).and_return(
         true
       )

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -32,12 +32,14 @@ module Metalware
       highline: HighLine.new,
       configure_file:,
       questions_section:,
-      answers_file:
+      answers_file:,
+      use_readline: true
     )
       @highline = highline
       @configure_file = configure_file
       @questions_section = questions_section
       @answers_file = answers_file
+      @use_readline = use_readline
     end
 
     def configure
@@ -50,7 +52,8 @@ module Metalware
     attr_reader :highline,
       :configure_file,
       :questions_section,
-      :answers_file
+      :answers_file,
+      :use_readline
 
     def questions
       @questions ||= Data.load(configure_file)[questions_section].
@@ -78,7 +81,8 @@ module Metalware
         properties: properties,
         configure_file: configure_file,
         questions_section: questions_section,
-        old_answer: old_answers[identifier]
+        old_answer: old_answers[identifier],
+        use_readline: use_readline
       )
     end
 
@@ -90,19 +94,22 @@ module Metalware
         :type,
         :choices,
         :default,
-        :required
+        :required,
+        :use_readline
 
       def initialize(
         identifier:,
         properties:,
         configure_file:,
         questions_section:,
-        old_answer: nil
+        old_answer: nil,
+        use_readline:
       )
         @identifier = identifier
         @question = properties[:question]
         @choices = properties[:choices]
         @required = !properties[:optional]
+        @use_readline = use_readline
 
         @type = type_for(
           properties[:type],
@@ -119,6 +126,8 @@ module Metalware
       def ask(highline)
         ask_method = "ask_#{type}_question"
         self.send(ask_method, highline) do |highline_question|
+          highline_question.readline = true if use_readline
+
           if default.present?
             highline_question.default = default
           elsif required

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -139,9 +139,7 @@ module Metalware
       private
 
       def ask_boolean_question(highline)
-        highline.agree(question + ' [yes/no]')
-        # Cannot set default for boolean questions, so do not yield to passed
-        # block.
+        highline.agree(question + ' [yes/no]') { |q| yield q }
       end
 
       def ask_choice_question(highline, &block)
@@ -180,13 +178,17 @@ module Metalware
       def determine_default(question_default:, old_answer:)
         # XXX Remove validation/conversion here and do in earlier step for
         # validating `configure.yaml`? Similarly in `type_for` etc.
-        raw_default = old_answer.present? ? old_answer : question_default
+        raw_default = old_answer.nil? ? question_default : old_answer
         unless raw_default.nil?
           case type
           when :string
             raw_default.to_s
           when :integer
             raw_default.to_i
+          when :boolean
+            # Default for a boolean question needs to be set to the input
+            # HighLine's `agree` expects, i.e. 'yes' or 'no'.
+            raw_default ? 'yes' : 'no'
           else
             msg = "Unrecognized data type (#{type}) as a default"
             raise UnknownDataTypeError, msg

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -139,7 +139,7 @@ module Metalware
       private
 
       def ask_boolean_question(highline)
-        highline.agree(question)
+        highline.agree(question + ' [yes/no]')
         # Cannot set default for boolean questions, so do not yield to passed
         # block.
       end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -28,8 +28,12 @@ HighLine::Question.prepend Metalware::Patches::HighLine::Questions
 
 module Metalware
   class Configurator
-    def initialize(highline: HighLine.new, configure_file:,
-                   questions_section:, answers_file:)
+    def initialize(
+      highline: HighLine.new,
+      configure_file:,
+      questions_section:,
+      answers_file:
+    )
       @highline = highline
       @configure_file = configure_file
       @questions_section = questions_section
@@ -81,11 +85,20 @@ module Metalware
     class Question
       VALID_TYPES = [:boolean, :choice, :integer, :string]
 
-      attr_reader :identifier, :question, :type, :choices,
-                  :default, :required
+      attr_reader :identifier,
+        :question,
+        :type,
+        :choices,
+        :default,
+        :required
 
-      def initialize(identifier:, properties:, configure_file:,
-                     questions_section:, old_answer: nil)
+      def initialize(
+        identifier:,
+        properties:,
+        configure_file:,
+        questions_section:,
+        old_answer: nil
+      )
         @identifier = identifier
         @question = properties[:question]
         @choices = properties[:choices]


### PR DESCRIPTION
This PR makes some improvements to the `metal configure` commands. In particular, in addition to some test improvements, readline bindings are now available when entering input for questions, and defaults and the loading of old answers now work for questions of type `boolean`.