### PR TITLE
Handle generating bad `genders` file

### DIFF
--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -40,14 +40,8 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
   # This uses an ERB tag so can test the invalid rendered template is saved.
   let :genders_template { 'some genders template <%= alces.index %>' }
 
-  def stub_validate_genders(valid, error)
-    allow(Metalware::NodeattrInterface).to receive(
-      :validate_genders_file
-    ).and_return([valid, error])
-  end
-
   it 'renders the hosts and genders files' do
-    stub_validate_genders(true, '')
+    SpecUtils.mock_validate_genders_success(self)
 
     filesystem.test do
       # Genders file needs to be rendered first, as how this is rendered will
@@ -71,11 +65,12 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
   context 'when invalid genders file rendered' do
     let :nodeattr_error { 'oh no genders' }
     before :each do
-      stub_validate_genders(false, nodeattr_error)
+      SpecUtils.mock_validate_genders_failure(self, nodeattr_error)
     end
 
     it 'does not render hosts file and gives error' do
       filesystem.test do
+        expect(Metalware::Io).to receive(:abort)
 
         # Error should be shown including the `nodeattr` error message and
         # where to find the invalid genders file.

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe Metalware::Commands::Configure::Group do
     FileSystem.setup(&:with_minimal_repo)
   end
 
+  before :each do
+    SpecUtils.mock_validate_genders_success(self)
+  end
+
   describe 'recording groups' do
     context 'when `cache/groups.yaml` does not exist' do
       it 'creates it and inserts new primary group' do

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -119,6 +119,7 @@ class FileSystem
   # install.
   def create_initial_directory_hierarchy
     [
+      '/tmp',
       '/etc',
       '/var/log/metalware',
       '/var/lib/metalware/rendered/kickstart',

--- a/spec/nodeattr_interface_spec.rb
+++ b/spec/nodeattr_interface_spec.rb
@@ -27,45 +27,47 @@ require 'spec_utils'
 require 'exceptions'
 
 RSpec.describe Metalware::NodeattrInterface do
-  before do
-    SpecUtils.use_mock_genders(self)
-  end
-
-  describe '#nodes_in_group' do
-    it 'returns names of all nodes in the given gender group' do
-      expect(
-        Metalware::NodeattrInterface.nodes_in_group('masters')
-      ).to eq(['login1'])
-      expect(
-        Metalware::NodeattrInterface.nodes_in_group('nodes')
-      ).to eq(['testnode01', 'testnode02', 'testnode03'])
-      expect(
-        Metalware::NodeattrInterface.nodes_in_group('domain')
-      ).to eq(['login1', 'testnode01', 'testnode02', 'testnode03'])
+  context 'using mock genders' do
+    before do
+      SpecUtils.use_mock_genders(self)
     end
 
-    it 'raises if cannot find gender group' do
-      expect do
-        Metalware::NodeattrInterface.nodes_in_group('non_existent')
-      end.to raise_error Metalware::NoGenderGroupError
-    end
-  end
+    describe '#nodes_in_group' do
+      it 'returns names of all nodes in the given gender group' do
+        expect(
+          Metalware::NodeattrInterface.nodes_in_group('masters')
+        ).to eq(['login1'])
+        expect(
+          Metalware::NodeattrInterface.nodes_in_group('nodes')
+        ).to eq(['testnode01', 'testnode02', 'testnode03'])
+        expect(
+          Metalware::NodeattrInterface.nodes_in_group('domain')
+        ).to eq(['login1', 'testnode01', 'testnode02', 'testnode03'])
+      end
 
-  describe '#groups_for_node' do
-    it 'returns groups for given node, ordered as in genders' do
-      testnode_groups = ['testnodes', 'nodes', 'cluster', 'domain']
-      expect(
-        Metalware::NodeattrInterface.groups_for_node('testnode01')
-      ).to eq(testnode_groups)
-      expect(
-        Metalware::NodeattrInterface.groups_for_node('testnode02')
-      ).to eq(['pregroup'] + testnode_groups + ['postgroup'])
+      it 'raises if cannot find gender group' do
+        expect do
+          Metalware::NodeattrInterface.nodes_in_group('non_existent')
+        end.to raise_error Metalware::NoGenderGroupError
+      end
     end
 
-    it 'raises if cannot find node' do
-      expect do
-        Metalware::NodeattrInterface.groups_for_node('non_existent')
-      end.to raise_error Metalware::NodeNotInGendersError
+    describe '#groups_for_node' do
+      it 'returns groups for given node, ordered as in genders' do
+        testnode_groups = ['testnodes', 'nodes', 'cluster', 'domain']
+        expect(
+          Metalware::NodeattrInterface.groups_for_node('testnode01')
+        ).to eq(testnode_groups)
+        expect(
+          Metalware::NodeattrInterface.groups_for_node('testnode02')
+        ).to eq(['pregroup'] + testnode_groups + ['postgroup'])
+      end
+
+      it 'raises if cannot find node' do
+        expect do
+          Metalware::NodeattrInterface.groups_for_node('non_existent')
+        end.to raise_error Metalware::NodeNotInGendersError
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,10 +120,9 @@ RSpec.configure do |config|
     config.default_formatter = 'doc'
   end
 
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
+  # Print slowest examples and example groups at the end of the spec run, to
+  # help surface which specs are running particularly slow.
+  config.profile_examples = 2
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/spec_utils.rb
+++ b/spec/spec_utils.rb
@@ -32,6 +32,14 @@ module SpecUtils
   class << self
     # Mocks.
 
+    def mock_validate_genders_success(example_group)
+      mock_validate_genders(example_group, true, '')
+    end
+
+    def mock_validate_genders_failure(example_group, nodeattr_error)
+      mock_validate_genders(example_group, false, nodeattr_error)
+    end
+
     def use_mock_genders(example_group, genders_file: 'genders/default')
       genders_path = File.join(FIXTURES_PATH, genders_file)
 
@@ -102,6 +110,16 @@ module SpecUtils
 
     def fixtures_config(config_file)
       File.join(FIXTURES_PATH, 'configs', config_file)
+    end
+
+    private
+
+    def mock_validate_genders(example_group, valid, error)
+      example_group.instance_exec do
+        allow(Metalware::NodeattrInterface).to receive(
+          :validate_genders_file
+        ).and_return([valid, error])
+      end
     end
   end
 end

--- a/spec/system_command_spec.rb
+++ b/spec/system_command_spec.rb
@@ -31,9 +31,27 @@ RSpec.describe Metalware::SystemCommand do
     ).to eq "something\n"
   end
 
-  it 'raises if the command fails' do
-    expect do
-      Metalware::SystemCommand.run('false')
-    end.to raise_error Metalware::SystemCommandError
+  context 'when command fails' do
+    it 'raises' do
+      expect do
+        Metalware::SystemCommand.run('false')
+      end.to raise_error Metalware::SystemCommandError
+    end
+
+    it 'formats the error for displaying to users when `format_error` is true' do
+      begin
+        Metalware::SystemCommand.run('false', format_error: true)
+      rescue Metalware::SystemCommandError => e
+        expect(e.message).to match(/produced error/)
+      end
+    end
+
+    it 'does not format the error when `format_error` is false' do
+      begin
+        Metalware::SystemCommand.run('false', format_error: false)
+      rescue Metalware::SystemCommandError => e
+        expect(e.message).not_to match(/produced error/)
+      end
+    end
   end
 end

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -191,6 +191,24 @@ RSpec.describe Metalware::Templater do
     end
   end
 
+  describe '#render_to_file' do
+    let :template { "simple template without ERB\n" }
+    let :output_path { '/output' }
+    let :output { File.read(output_path) }
+
+    it 'renders the template to the file' do
+      filesystem.test do
+        Metalware::Templater.render_to_file(
+          config,
+          template_path,
+          output_path
+        )
+
+        expect(output).to eq(template)
+      end
+    end
+  end
+
   # XXX These tests test `Templating::MagicNamespace` via the `Templater`; this
   # is useful to check they work together but we may want to test some things
   # directly on the `MagicNamespace`.

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -207,25 +207,28 @@ RSpec.describe Metalware::Templater do
 
     it 'renders the template to the file by default' do
       filesystem.test do
-        render_to_file_with_block
+        template_rendered = render_to_file_with_block
 
         expect(output).to eq(template)
+        expect(template_rendered).to be true
       end
     end
 
     it 'renders template to the file if passed a block with truthy output' do
       filesystem.test do
-        render_to_file_with_block(&:present?)
+        template_rendered = render_to_file_with_block(&:present?)
 
         expect(output).to eq(template)
+        expect(template_rendered).to be true
       end
     end
 
     it 'does not render template to the file if passed a block with falsy output' do
       filesystem.test do
-        render_to_file_with_block(&:empty?)
+        template_rendered = render_to_file_with_block(&:empty?)
 
         expect(File.exist?(output_path)).to be false
+        expect(template_rendered).to be false
       end
     end
   end

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -196,15 +196,36 @@ RSpec.describe Metalware::Templater do
     let :output_path { '/output' }
     let :output { File.read(output_path) }
 
-    it 'renders the template to the file' do
+    def render_to_file_with_block(&block)
+      Metalware::Templater.render_to_file(
+        config,
+        template_path,
+        output_path,
+        &block
+      )
+    end
+
+    it 'renders the template to the file by default' do
       filesystem.test do
-        Metalware::Templater.render_to_file(
-          config,
-          template_path,
-          output_path
-        )
+        render_to_file_with_block
 
         expect(output).to eq(template)
+      end
+    end
+
+    it 'renders template to the file if passed a block with truthy output' do
+      filesystem.test do
+        render_to_file_with_block(&:present?)
+
+        expect(output).to eq(template)
+      end
+    end
+
+    it 'does not render template to the file if passed a block with falsy output' do
+      filesystem.test do
+        render_to_file_with_block(&:empty?)
+
+        expect(File.exist?(output_path)).to be false
       end
     end
   end

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -54,12 +54,55 @@ module Metalware
       # are re-rendered at the end of every configure command as the data used
       # in the templates could change with each command.
       def render_domain_templates
-        render_template(genders_template, to: Constants::GENDERS_PATH)
+        # `hosts` file is typically rendered using info from `genders`, so if
+        # the rendered `genders` is invalid we should not render it.
+        render_hosts if render_genders
+      end
+
+      def render_genders
+        render_template(
+          genders_template,
+          to: Constants::GENDERS_PATH
+        ) do |rendered_genders|
+          validate_rendered_genders(rendered_genders)
+        end
+      end
+
+      def validate_rendered_genders(rendered_genders)
+        genders_valid, nodeattr_error = Tempfile.open do |tempfile|
+          tempfile.write(rendered_genders)
+          tempfile.flush
+          NodeattrInterface.validate_genders_file(tempfile.path)
+        end
+
+        unless genders_valid
+          cache_invalid_genders(rendered_genders)
+          display_genders_error(nodeattr_error)
+        end
+
+        genders_valid
+      end
+
+      def cache_invalid_genders(rendered_genders)
+        File.write(Constants::INVALID_RENDERED_GENDERS_PATH, rendered_genders)
+      end
+
+      def display_genders_error(nodeattr_error)
+        # XXX add note here about how to re-render templates once this is
+        # directly supported.
+        Output.stderr "\nAborting rendering domain templates; " \
+          'the rendered genders file is invalid:'
+        Output.stderr_indented_error_message(nodeattr_error)
+        Output.stderr \
+          "The rendered file can be found at #{Constants::INVALID_RENDERED_GENDERS_PATH}"
+      end
+
+      def render_hosts
         render_template(hosts_template, to: Constants::HOSTS_PATH)
       end
 
-      def render_template(template, to:)
-        Templater.render_to_file(config, template, to)
+      def render_template(template, to:, &block)
+        Templater.render_to_file(config, template, to, &block)
       end
 
       def genders_template

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -4,6 +4,7 @@
 require 'command_helpers/base_command'
 require 'configurator'
 require 'constants'
+require 'io'
 
 module Metalware
   module CommandHelpers
@@ -56,7 +57,11 @@ module Metalware
       def render_domain_templates
         # `hosts` file is typically rendered using info from `genders`, so if
         # the rendered `genders` is invalid we should not render it.
-        render_hosts if render_genders
+        if render_genders
+          render_hosts
+        else
+          Io.abort
+        end
       end
 
       def render_genders

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -33,6 +33,7 @@ module Metalware
     CACHE_PATH = File.join(METALWARE_DATA_PATH, 'cache')
     HUNTER_PATH = File.join(CACHE_PATH, 'hunter.yaml')
     GROUPS_CACHE_PATH = File.join(CACHE_PATH, 'groups.yaml')
+    INVALID_RENDERED_GENDERS_PATH = File.join(CACHE_PATH, 'invalid.genders')
 
     MAXIMUM_RECURSIVE_CONFIG_DEPTH = 10
 

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -118,3 +118,6 @@ end
 # Alias for Exception to use to indicate we want to catch everything, and to
 # also tell Rubocop to be quiet about this.
 IntentionallyCatchAnyException = Exception
+
+class AbortInTestError < StandardError
+end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -108,6 +108,10 @@ module Metalware
 
   class UnconfiguredGroupError < MetalwareError
   end
+
+  # Error to be used when a file that should exist doesn't.
+  class FileDoesNotExistError < MetalwareError
+  end
 end
 
 

--- a/src/io.rb
+++ b/src/io.rb
@@ -1,0 +1,17 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  # An easily stubbable module to handle certain behaviour which is hard to
+  # test directly, so we can just test this receives correct messages.
+  module Io
+    class << self
+      def abort(*args)
+        # If we're in a unit test, raise so we can clearly tell an unexpected
+        # `abort` occurred, rather than aborting the test suite.
+        raise AbortInTestError, *args if $PROGRAM_NAME.match?(/rspec$/)
+        Kernel.abort(*args)
+      end
+    end
+  end
+end

--- a/src/nodeattr_interface.rb
+++ b/src/nodeattr_interface.rb
@@ -46,10 +46,26 @@ module Metalware
         raise NodeNotInGendersError, "Could not find node in genders: #{node}"
       end
 
+      # Returns whether the given file is a valid genders file, along with any
+      # validation error.
+      def validate_genders_file(genders_path)
+        unless File.exist?(genders_path)
+          raise FileDoesNotExistError, "File does not exist: #{genders_path}"
+        end
+
+        nodeattr("-f #{genders_path} --parse-check", format_error: false)
+        [true, '']
+      rescue SystemCommandError => e
+        [false, e.message]
+      end
+
       private
 
-      def nodeattr(command)
-        SystemCommand.run("#{Constants::NODEATTR_COMMAND} #{command}")
+      def nodeattr(command, format_error: true)
+        SystemCommand.run(
+          "#{Constants::NODEATTR_COMMAND} #{command}",
+          format_error: format_error
+        )
       end
     end
   end

--- a/src/system_command.rb
+++ b/src/system_command.rb
@@ -30,14 +30,28 @@ module Metalware
       # This is just a slightly more robust version of Kernel.`, so we get an
       # exception that must be handled or be displayed if the command run
       # fails.
-      def run(command)
+      #
+      # `format_error` option specifies whether any error produced should be
+      # formatted suitably for displaying to a user.
+      def run(command, format_error: true)
         stdout, stderr, status = Open3.capture3(command)
         if status.exitstatus != 0
-          raise SystemCommandError,
-                "'#{command}' produced error '#{stderr.strip}'"
+          handle_error(command, stderr, format_error: format_error)
         else
           stdout
         end
+      end
+
+      private
+
+      def handle_error(command, stderr, format_error:)
+        stderr = stderr.strip
+        error = if format_error
+                  "'#{command}' produced error '#{stderr}'"
+                else
+                  stderr
+                end
+        raise SystemCommandError, error
       end
     end
   end

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -47,8 +47,15 @@ module Metalware
       end
 
       def render_to_file(config, template, save_file, template_parameters = {})
+        rendered_template = render(config, template, template_parameters)
+
+        # If a block is given, pass it the rendered template and it should
+        # return whether this is valid and should be written to the file.
+        rendered_template_invalid = block_given? && !yield(rendered_template)
+        return if rendered_template_invalid
+
         File.open(save_file.chomp, 'w') do |f|
-          f.puts render(config, template, template_parameters)
+          f.puts rendered_template
         end
         MetalLog.info "Template Saved: #{save_file}"
       end

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -52,12 +52,13 @@ module Metalware
         # If a block is given, pass it the rendered template and it should
         # return whether this is valid and should be written to the file.
         rendered_template_invalid = block_given? && !yield(rendered_template)
-        return if rendered_template_invalid
+        return false if rendered_template_invalid
 
         File.open(save_file.chomp, 'w') do |f|
           f.puts rendered_template
         end
         MetalLog.info "Template Saved: #{save_file}"
+        true
       end
 
       def render_and_append_to_file(config, template, append_file, template_parameters = {})


### PR DESCRIPTION
If after a `configure` process an invalid `genders` file is rendered, then we now handle this by:

- reporting the error;

- not replacing the existing `genders` file;

- not rendering the `hosts` file, as this normally uses information obtained from the `genders` file using `nodeattr`;

- making the invalid rendered `genders` file available for inspection, at a location reported to the user.
