### PR TITLE
Dynamically decide namespace fields to hash

### DIFF
--- a/spec/object_fields_hasher_spec.rb
+++ b/spec/object_fields_hasher_spec.rb
@@ -1,0 +1,37 @@
+
+# frozen_string_literal: true
+
+require 'object_fields_hasher'
+
+RSpec.describe Metalware::ObjectFieldsHasher do
+  class MyClass
+    attr_reader :foo, :bar
+
+    def initialize(foo, bar)
+      @foo = foo
+      @bar = bar
+    end
+
+    private
+
+    def customize_foo
+      foo + '_customized'
+    end
+  end
+
+  describe '#hash_object' do
+    subject { MyClass.new('my_foo', 'my_bar') }
+
+    it "converts the object's unique instance methods to hash properties" do
+      expect(
+        Metalware::ObjectFieldsHasher.hash_object(subject)
+      ).to eq(foo: 'my_foo', bar: 'my_bar')
+    end
+
+    it 'uses given method instead for passed in method keys' do
+      expect(
+        Metalware::ObjectFieldsHasher.hash_object(subject, foo: :customize_foo)
+      ).to eq(foo: 'my_foo_customized', bar: 'my_bar')
+    end
+  end
+end

--- a/src/object_fields_hasher.rb
+++ b/src/object_fields_hasher.rb
@@ -1,0 +1,24 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  module ObjectFieldsHasher
+    IGNORED_METHODS = Object.instance_methods + [:to_h, :to_json]
+
+    class << self
+      def hash_object(object, **overrides)
+        unique_object_methods(object).map do |field|
+          field_getter = overrides[field] || field
+          value = object.send(field_getter)
+          [field, value]
+        end.to_h
+      end
+
+      private
+
+      def unique_object_methods(object)
+        object.class.instance_methods - IGNORED_METHODS
+      end
+    end
+  end
+end

--- a/src/templating/group_namespace.rb
+++ b/src/templating/group_namespace.rb
@@ -8,14 +8,6 @@ module Metalware
 
       delegate :to_json, to: :to_h
 
-      # Every time a new property is added to this namespace it should be added
-      # to this array (so it shows in the `view-config` output).
-      FIELDS = [
-        :name,
-        :answers,
-        :nodes,
-      ].freeze
-
       def initialize(metalware_config, group_name)
         @metalware_config = metalware_config
         @name = group_name
@@ -35,13 +27,7 @@ module Metalware
       end
 
       def to_h
-        # Note: this is very similar to `MagicNamespace#to_h`, but
-        # de-duplicating them may not be worth the obfuscation that would
-        # involve.
-        FIELDS.map do |field|
-          value = field == :nodes ? nodes_data : send(field)
-          [field, value]
-        end.to_h
+        ObjectFieldsHasher.hash_object(self, nodes: :nodes_data)
       end
 
       private

--- a/src/templating/magic_namespace.rb
+++ b/src/templating/magic_namespace.rb
@@ -10,30 +10,11 @@ require 'nodeattr_interface'
 require 'primary_group'
 require 'templating/missing_parameter_wrapper'
 require 'templating/group_namespace'
+require 'object_fields_hasher'
 
 module Metalware
   module Templating
     class MagicNamespace
-      # Every time a new property is added to this namespace it should be added
-      # to this array (so it shows in the `view-config` output), as well as to
-      # the docs in `docs/templating-system.md`.
-      FIELDS = [
-        :answers,
-        :build_complete_url,
-        :files,
-        :firstboot,
-        :genders,
-        :genders_url,
-        :group_index,
-        :groups,
-        :hostip,
-        :hosts_url,
-        :hunter,
-        :index,
-        :kickstart_url,
-        :nodename,
-      ].freeze
-
       # `include_groups` = whether to include the group namespaces when
       # converting this `MagicNamespace` instance to a hash.
       def initialize(
@@ -55,10 +36,7 @@ module Metalware
       delegate :to_json, to: :to_h
 
       def to_h
-        FIELDS.map do |field|
-          value = field == :groups ? groups_data : send(field)
-          [field, value]
-        end.to_h
+        ObjectFieldsHasher.hash_object(self, groups: :groups_data)
       end
 
       def group_index


### PR DESCRIPTION
This commit introduces a module with a single function which will take an object and convert its methods and their values to the keys and values of a hash, with the optional ability to override what method is
used to get certain fields. This function is then used in the `MagicNamespace` and `GroupNamespace` when we convert them to hashes, so we don't need to manually specify the fields to include.

This function will of course only work for objects where all methods to be included can take no arguments, otherwise it will blow up as the methods won't be sent enough arguments.

As suggested in https://github.com/alces-software/metalware/pull/129#discussion_r129885647.