### PR TITLE
Fix `view-config` error for unconfigured node (fixes #136)

### DIFF
--- a/src/commands/view_config.rb
+++ b/src/commands/view_config.rb
@@ -15,6 +15,16 @@ module Metalware
         pretty_print_json(templating_config_json)
       end
 
+      def dependency_hash
+        # If we want to view templating config for particular node,
+        # then that node must be part of a configured group.
+        if node_name
+          dependency_specifications.for_node_in_configured_group(node_name)
+        else
+          {}
+        end
+      end
+
       private
 
       attr_reader :node_name, :options


### PR DESCRIPTION
This PR is based on https://github.com/alces-software/metalware/pull/130 as it depends on a function added in that PR.

This fixes the issue raised in #136 by giving an informative error message when an attempt is made to `view-config` for a node which doesn't exist; I'll address the other aspect of that issue there.