### PR TITLE
Allow optional files in Dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 coverage
 tmp
 spec/examples.txt
+vendor
+.bundle

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ rsync:
 		--exclude tmp/ \
 		--exclude .git/ \
 		--exclude coverage/ \
+		--exclude vendor/ \
+		--exclude .bundle/ \
 		--perms \
 		. dev@${IP}:${REMOTE_DIR}
 

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -118,5 +118,32 @@ RSpec.describe Metalware::Dependency do
         end.not_to raise_error
       end
     end
+
+    context 'with optional dependencies' do
+      before :each do
+        filesystem.with_minimal_repo
+        filesystem.with_answer_fixtures('answers/basic_structure')
+      end
+
+      it 'skips a single missing file' do
+        expect do
+          enforce_dependencies(
+            optional: {
+              configure: ['not_found.yaml'],
+            }
+          )
+        end.not_to raise_error
+      end
+
+      it 'validates a correct answer file' do
+        expect do
+          enforce_dependencies(
+            optional: {
+              configure: ['domain.yaml', 'not_found.yaml'],
+            }
+          )
+        end.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe '`metal build`' do
   end
 
   def run_command(command)
-    Timeout::timeout 20 do
+    Timeout.timeout 20 do
       Open3.popen3 command do |stdin, stdout, stderr, thread|
         begin
           pid = thread.pid


### PR DESCRIPTION
A new optional hash can be included in the dependency_hash which indicates files that should be validated but does not throw an error if they do not exist.

The optional hash has the same syntax as a regular dependency_hash. At this point in time, the superfluous, however it will be needed once Answer Validation is included.

