### PR TITLE
Run every test using FakeFS unless specify not to

### DIFF
--- a/spec/build_files_retriever_spec.rb
+++ b/spec/build_files_retriever_spec.rb
@@ -27,7 +27,7 @@ require 'input'
 require 'spec_utils'
 require 'config'
 
-RSpec.describe Metalware::BuildFilesRetriever do
+RSpec.describe Metalware::BuildFilesRetriever, real_fs: true do
   TEST_FILES_HASH = {
     namespace01: [
       'some/file_in_repo',

--- a/spec/commands/each_spec.rb
+++ b/spec/commands/each_spec.rb
@@ -26,7 +26,7 @@ require 'commands/each'
 require 'spec_utils'
 require 'ostruct'
 
-RSpec.describe Metalware::Commands::Each do
+RSpec.describe Metalware::Commands::Each, real_fs: true do
   before :each do
     SpecUtils.use_mock_genders(self)
     SpecUtils.use_unit_test_config(self)

--- a/spec/commands/status_spec.rb
+++ b/spec/commands/status_spec.rb
@@ -33,7 +33,7 @@ require 'timeout'
 RSpec.describe Metalware::Commands::Status do
 end
 
-RSpec.describe Metalware::Status::Monitor do
+RSpec.describe Metalware::Status::Monitor, real_fs: true do
   before :each do
     SpecUtils.use_mock_genders(self)
     SpecUtils.use_unit_test_config(self)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -29,7 +29,7 @@ require 'exceptions'
 require 'constants'
 require 'spec_utils'
 
-RSpec.describe Metalware::Config do
+RSpec.describe Metalware::Config, real_fs: true do
   it 'can have default values retrieved' do
     config_file = SpecUtils.fixtures_config('empty.yaml')
     config = Metalware::Config.new(config_file)

--- a/spec/dependency_specifications_spec.rb
+++ b/spec/dependency_specifications_spec.rb
@@ -4,7 +4,7 @@
 require 'spec_utils'
 require 'dependency_specifications'
 
-RSpec.describe Metalware::DependencySpecifications do
+RSpec.describe Metalware::DependencySpecifications, real_fs: true do
   subject do
     Metalware::DependencySpecifications.new(Metalware::Config.new)
   end

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -31,7 +31,7 @@ require 'minimal_repo'
 # TODO: Could test rendering in these tests as well, though already doing in
 # unit tests.
 
-RSpec.describe '`metal build`' do
+RSpec.describe '`metal build`', real_fs: true do
   METAL = File.join(Metalware::Constants::METALWARE_INSTALL_PATH, 'bin/metal')
   TEST_DIR = 'tmp/integration-test'
   CONFIG_FILE = SpecUtils.fixtures_config('integration-test.yaml')

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Metalware::Node do
   end
 
   # XXX adapt these to use FakeFS and make dependencies explicit?
-  context 'without using FakeFS' do
+  context 'without using FakeFS', real_fs: true do
     before do
       SpecUtils.use_unit_test_config(self)
     end

--- a/spec/nodeattr_interface_spec.rb
+++ b/spec/nodeattr_interface_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Metalware::NodeattrInterface do
     end
   end
 
-  describe '#validate_genders_file' do
+  describe '#validate_genders_file', real_fs: true do
     let :genders_file { Tempfile.new }
     let :genders_path { genders_file.path }
 

--- a/spec/slow/status/job_spec.rb
+++ b/spec/slow/status/job_spec.rb
@@ -30,7 +30,7 @@ require 'config'
 require 'nodes'
 require 'timeout'
 
-RSpec.describe Metalware::Status::Job do
+RSpec.describe Metalware::Status::Job, real_fs: true do
   before :all do
     Metalware::Status::Job.send(:define_method, :busy_sleep, lambda {
       until 1 == 2; end

--- a/spec/slow/status/monitor_spec.rb
+++ b/spec/slow/status/monitor_spec.rb
@@ -30,7 +30,7 @@ require 'config'
 require 'nodes'
 require 'timeout'
 
-RSpec.describe Metalware::Status::Monitor do
+RSpec.describe Metalware::Status::Monitor, real_fs: true do
   before :each do
     SpecUtils.use_mock_genders(self)
     SpecUtils.use_unit_test_config(self)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -135,4 +135,17 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  config.around :each do |example|
+    # Run every test using `FakeFS` unless a truthy `real_fs` metadata value is
+    # passed; this prevents us polluting the real file system unless explicitly
+    # requested.
+    if example.metadata[:real_fs]
+      example.run
+    else
+      FakeFS do
+        example.run
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,8 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '../src')
 # simplecov, even entirely untested ones.
 require 'cli'
 
+require 'filesystem'
+
 FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')
 
 RSpec.configure do |config|
@@ -143,7 +145,7 @@ RSpec.configure do |config|
     if example.metadata[:real_fs]
       example.run
     else
-      FakeFS do
+      FileSystem.test do
         example.run
       end
     end

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Metalware::Templater do
   end
 
   describe '#render' do
-    context 'without a repo' do
+    context 'without a repo', real_fs: true do
       before :each do
         @config = Metalware::Config.new(EMPTY_REPO_PATH)
       end


### PR DESCRIPTION
Run every test using `FakeFS` unless a truthy `real_fs` metadata value is passed; this prevents us polluting the real file system unless explicitly requested.

With this change it may be possible to simplify our use of `FileSystem` to not need to re-specify running in a `FakeFS` block around every test. However this would be quite a large refactoring and I'm not sure exactly how we'd want to do this at the moment, so I'm holding off on this until we've used this change for a bit.