### PR TITLE
Default hunter interface to build interface

### DIFF
--- a/spec/cli_helper/parser_spec.rb
+++ b/spec/cli_helper/parser_spec.rb
@@ -41,5 +41,23 @@ RSpec.describe Metalware::CliHelper::Parser do
 
       subject.parse_commands
     end
+
+    it 'uses DynamicDefaults module to determine dynamic default values' do
+      define_config_with_default('dynamic' => 'build_interface')
+
+      stubbed_dynamic_default = 'eth3'
+      expect(
+        Metalware::CliHelper::DynamicDefaults
+      ).to receive(:build_interface).and_return(stubbed_dynamic_default)
+
+      expect_any_instance_of(Commander::Command).to receive(:option).with(
+        '-f', '--foo', # tags
+        nil, # type
+        { default: stubbed_dynamic_default }, # default
+        '' # description
+      )
+
+      subject.parse_commands
+    end
   end
 end

--- a/spec/cli_helper/parser_spec.rb
+++ b/spec/cli_helper/parser_spec.rb
@@ -1,0 +1,45 @@
+
+# frozen_string_literal: true
+
+RSpec.describe Metalware::CliHelper::Parser do
+  subject do
+    Metalware::CliHelper::Parser.new(
+      Metalware::Cli.new
+    )
+  end
+
+  before do
+    stub_const('Metalware::CliHelper::CONFIG_PATH', test_config_path)
+  end
+
+  let :test_config_path { '/tmp/config.yaml' }
+
+  describe 'default parsing' do
+    def define_config_with_default(default_value)
+      File.write(test_config_path, YAML.dump(
+                                     'commands' => {
+                                       'my_command' => {
+                                         'options' => [{
+                                           'tags' => ['-f', '--foo'],
+                                           'default' => default_value,
+                                         }],
+                                       },
+                                     },
+                                     'global_options' => {}
+      ))
+    end
+
+    it 'passes simple default values straight through as option default' do
+      define_config_with_default(5)
+
+      expect_any_instance_of(Commander::Command).to receive(:option).with(
+        '-f', '--foo', # tags
+        nil, # type
+        { default: 5 }, # default
+        '' # description
+      )
+
+      subject.parse_commands
+    end
+  end
+end

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -204,9 +204,11 @@ commands:
     options:
       - tags: [-i INTERFACE, --interface INTERFACE]
         type: String
-        default: eth0
+        default:
+          dynamic: build_interface
         description: >
-          Local interface to hunt on
+          Local interface to hunt on; defaults to standard build interface if
+          unspecified
       - tags: [-p PREFIX, --prefix PREFIX]
         type: String
         default: node

--- a/src/cli_helper/dynamic_defaults.rb
+++ b/src/cli_helper/dynamic_defaults.rb
@@ -1,0 +1,14 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  module CliHelper
+    module DynamicDefaults
+      class << self
+        def build_interface
+          DeploymentServer.build_interface
+        end
+      end
+    end
+  end
+end

--- a/src/cli_helper/parser.rb
+++ b/src/cli_helper/parser.rb
@@ -26,17 +26,18 @@ require 'commands'
 
 module Metalware
   module CliHelper
+    CONFIG_PATH = File.join(File.dirname(__FILE__), 'config.yaml')
+
     class Parser
       def initialize(calling_obj = nil)
         @calling_obj = calling_obj
-        config = File.join(File.dirname(__FILE__), 'config.yaml')
 
         # NOTE: Now that Metalware has a `Data` module the majority of yaml
         # handling occurs through that.
         # CliHelper and autocomplete are exceptions as they should only ever be
         # altered by developers and need to load the file as is, instead of
         # Metalware altering it to what it thinks it needs to be.
-        @yaml = YAML.load_file(config)
+        @yaml = YAML.load_file(CONFIG_PATH)
       end
 
       def parse_commands

--- a/src/cli_helper/parser.rb
+++ b/src/cli_helper/parser.rb
@@ -22,7 +22,9 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 require 'yaml'
+
 require 'commands'
+require 'cli_helper/dynamic_defaults'
 
 module Metalware
   module CliHelper
@@ -65,7 +67,7 @@ module Metalware
                 end
                 c.option(*opt['tags'],
                          eval(opt['type'].to_s),
-                         { default: opt['default'] },
+                         { default: parse_default(opt) },
                          (opt['description']).to_s.chomp)
               end
             when 'subcommands'
@@ -79,6 +81,16 @@ module Metalware
               c.send("#{a}=", v.respond_to?(:chomp) ? v.chomp : v)
             end
           end
+        end
+      end
+
+      def parse_default(opt)
+        default_value = opt['default']
+        if default_value.is_a? Hash
+          dynamic_default_method = default_value['dynamic']
+          DynamicDefaults.send(dynamic_default_method)
+        else
+          default_value
         end
       end
     end

--- a/src/cli_helper/parser.rb
+++ b/src/cli_helper/parser.rb
@@ -48,6 +48,8 @@ module Metalware
         end
       end
 
+      private
+
       # TODO: Currently the parser does not support the example option
       def parse_command_attributes(command, attributes)
         @calling_obj.command command do |c|

--- a/src/deployment_server.rb
+++ b/src/deployment_server.rb
@@ -49,13 +49,6 @@ module Metalware
         url path
       end
 
-      private
-
-      def url(url_path)
-        full_path = File.join('metalware', url_path)
-        URI.join("http://#{ip}", full_path).to_s
-      end
-
       def build_interface
         # Default to 'eth0' if `build_interface` is not set yet. In practise
         # this _should_ only occur prior to first render of server config, but
@@ -64,6 +57,13 @@ module Metalware
         # dependent on the `build_interface`, but if it's unspecified the
         # `alces` namespace will fail to be created).
         server_config[:build_interface] || 'eth0'
+      end
+
+      private
+
+      def url(url_path)
+        full_path = File.join('metalware', url_path)
+        URI.join("http://#{ip}", full_path).to_s
       end
 
       def server_config


### PR DESCRIPTION
This PR is a small addition, based on https://github.com/alces-software/metalware/pull/148. Now that we define the Metalware build interface in a consistent location, the rendered `server.yaml` file, this PR makes this build interface be the default interface used when `metal hunter` is run, rather than defaulting to `eth0` as we did previously. This is useful as this is almost always (or possibly just always) the interface we want to hunt on, so specifying this as the default means we should normally not need to pass this option.