### PR TITLE
Install gethostip in installer

### DIFF
--- a/scripts/os/el7.sh
+++ b/scripts/os/el7.sh
@@ -29,6 +29,7 @@ install_runtime_prerequisites() {
         yum -e0 -y install gettext && \
         yum -e0 -y install epel-release && \
         yum -e0 -y install jq && \
+        yum -e0 -y install syslinux && \
         yum -e0 -y install git
 }
 


### PR DESCRIPTION
This is needed by Metalware but was not being installed when installing Metalware on a machine running a minimal Centos install. Based on https://github.com/alces-software/metalware/pull/149; fixes https://trello.com/c/wga3bOlt.