### PR TITLE
Prevent duplicated nodes being listed in `/etc/hosts`

### DIFF
--- a/src/templating/group_namespace.rb
+++ b/src/templating/group_namespace.rb
@@ -21,7 +21,7 @@ module Metalware
       end
 
       def nodes
-        NodeattrInterface.nodes_in_group(name).map do |node_name|
+        NodeattrInterface.nodes_in_primary_group(name).map do |node_name|
           yield templating_config_for_node(node_name)
         end
       end


### PR DESCRIPTION
This PR is based off #147. Please merge it first.

Fixes #127 in which nodes would be duplicated in `/etc/hosts` if they are in a secondary group that is also a primary group. This is because, when we the hosts template is rendered, it loops through all the primary groups and all nodes belong to the group. This includes nodes that are in a different primary group and thus leads to duplicates.

This commit changes the behaviour to only loop through nodes that are part of the primary group and thus prevents duplicates.