### PR TITLE
Allow build template selection in configs (closes #143)

### DIFF
--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -108,19 +108,15 @@ RSpec.describe Metalware::Commands::Build do
           fs.with_minimal_repo
 
           testnodes_config_path = metal_config.repo_config_path('testnodes')
-          fs.dump(testnodes_config_path, {
-            templates: {
-              pxelinux: 'repo_pxelinux',
-              kickstart: 'repo_kickstart',
-            }
-          })
+          fs.dump(testnodes_config_path,                     templates: {
+                    pxelinux: 'repo_pxelinux',
+                    kickstart: 'repo_kickstart',
+                  })
 
           testnode02_config_path = metal_config.repo_config_path('testnode02')
-          fs.dump(testnode02_config_path, {
-            templates: {
-              pxelinux: 'testnode02_repo_pxelinux',
-            }
-          })
+          fs.dump(testnode02_config_path,                     templates: {
+                    pxelinux: 'testnode02_repo_pxelinux',
+                  })
         end
       end
 

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -139,29 +139,6 @@ RSpec.describe Metalware::Commands::Build do
         end
       end
 
-      it 'uses different standard templates if template options passed' do
-        filesystem.test do
-          expect(Metalware::Templater).to receive(:render_to_file).with(
-            instance_of(Metalware::Config),
-            "#{metal_config.repo_path}/kickstart/my_kickstart",
-            '/var/lib/metalware/rendered/kickstart/testnode01',
-            expected_template_parameters
-          )
-          expect(Metalware::Templater).to receive(:render_to_file).with(
-            instance_of(Metalware::Config),
-            "#{metal_config.repo_path}/pxelinux/my_pxelinux",
-            '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
-            expected_template_parameters
-          ).at_least(:once)
-
-          run_build(
-            'testnode01',
-            kickstart: 'my_kickstart',
-            pxelinux: 'my_pxelinux'
-          )
-        end
-      end
-
       it 'specifies correct template dependencies' do
         filesystem.test do
           build_command = run_build('cluster', group: true)
@@ -254,35 +231,30 @@ RSpec.describe Metalware::Commands::Build do
     it 'renders standard templates for each node' do
       expect(Metalware::Templater).to receive(:render_to_file).with(
         instance_of(Metalware::Config),
-        "#{metal_config.repo_path}/kickstart/my_kickstart",
+        "#{metal_config.repo_path}/kickstart/default",
         '/var/lib/metalware/rendered/kickstart/testnode01',
         hash_including(nodename: 'testnode01')
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
         instance_of(Metalware::Config),
-        "#{metal_config.repo_path}/pxelinux/my_pxelinux",
+        "#{metal_config.repo_path}/pxelinux/default",
         '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
         hash_including(nodename: 'testnode01')
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
         instance_of(Metalware::Config),
-        "#{metal_config.repo_path}/kickstart/my_kickstart",
+        "#{metal_config.repo_path}/kickstart/default",
         '/var/lib/metalware/rendered/kickstart/testnode02',
         hash_including(nodename: 'testnode02')
       )
       expect(Metalware::Templater).to receive(:render_to_file).with(
         instance_of(Metalware::Config),
-        "#{metal_config.repo_path}/pxelinux/my_pxelinux",
+        "#{metal_config.repo_path}/pxelinux/default",
         '/var/lib/tftpboot/pxelinux.cfg/testnode02_HEX_IP',
         hash_including(nodename: 'testnode02')
       )
 
-      run_build(
-        'testnodes',
-        group: true,
-        kickstart: 'my_kickstart',
-        pxelinux: 'my_pxelinux'
-      )
+      run_build('testnodes', group: true)
     end
   end
 end

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -117,6 +117,25 @@ RSpec.describe Metalware::Commands::Build do
         end
       end
 
+      it 'uses specified templates' do
+        filesystem.test do
+          expect(Metalware::Templater).to receive(:render_to_file).with(
+            instance_of(Metalware::Config),
+            "#{metal_config.repo_path}/kickstart/repo_kickstart",
+            '/var/lib/metalware/rendered/kickstart/testnode01',
+            expected_template_parameters
+          )
+          expect(Metalware::Templater).to receive(:render_to_file).with(
+            instance_of(Metalware::Config),
+            "#{metal_config.repo_path}/pxelinux/repo_pxelinux",
+            '/var/lib/tftpboot/pxelinux.cfg/testnode01_HEX_IP',
+            expected_template_parameters
+          ).at_least(:once)
+
+          run_build('testnode01')
+        end
+      end
+
       it 'uses different standard templates if template options passed' do
         filesystem.test do
           expect(Metalware::Templater).to receive(:render_to_file).with(

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -33,10 +33,6 @@ RSpec.describe Metalware::Commands::Build do
   let :metal_config { Metalware::Config.new }
 
   def run_build(node_identifier, **options_hash)
-    # Adds the default values if they do not exist
-    options_hash[:kickstart] = 'default' unless options_hash.key?(:kickstart)
-    options_hash[:pxelinux] = 'default' unless options_hash.key?(:pxelinux)
-
     # Run command in timeout as `build` will wait indefinitely, but want to
     # abort tests if it looks like this is happening.
     Timeout.timeout 0.5 do

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Metalware::Commands::Build do
   before :each do
     allow(Metalware::Templater).to receive(:render_to_file)
     use_mock_nodes
-    SpecUtils.use_mock_genders(self)
+    SpecUtils.use_mock_genders(self, genders_file: 'genders/simple_cluster')
     SpecUtils.fake_download_error(self)
     SpecUtils.use_mock_dependency(self)
   end

--- a/spec/fixtures/genders/simple_cluster
+++ b/spec/fixtures/genders/simple_cluster
@@ -1,0 +1,3 @@
+
+login1 master,cluster
+testnode[01-03] testnodes,nodes,cluster

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -127,28 +127,42 @@ commands:
     syntax: metal build NODE_IDENTIFIER [options]
     summary: Renders the templates used to build the nodes
     description: >
-      Build is used to rendered template files before waiting for the compute
-      nodes to pxe-boot and build. Build by default will render the pxelinux and
-      kickstart templates. In additional, build renders the "files" list in
-      [config].yaml for the gender group and node.
+      Build handles the build process for a given node or group. This consists
+      of retrieving and rendering the specified 'files' for each node,
+      rendering the 'pxelinux' and 'kickstart' templates for each node, and
+      then waiting for each node to report itself as built and re-rendering its
+      'pxelinux' template for permanent booting. The build command will keep
+      running until all nodes have reported as built, or until it is
+      interrupted.
 
 
-      Build will then wait for the nodes to build. Once a node has finished
-      building, it needs to curl "alces.build_complete_url" which notifies build
-      that the node is complete. This will trigger the pxelinux file to be
-      re-rendered with "firstboot" set to false. Build will exit once all the
-      nodes have finished building.
+      The 'files' for each node are specified under the 'files' key in the repo
+      config for that node, while the 'pxelinux' and 'kickstart' templates are
+      specified by the corresponding key in the 'templates' section of the
+      config (unless overridden).
+
+
+      In order to have a node report itself as built it must make a request to
+      the 'alces.build_complete_url' when it has finished building.
+
+
+      The 'pxelinux' template rendering can be modified using the
+      'alces.firstboot' parameter within the template, which will be set to
+      'true' the first time this is rendered and 'false' the second.
+
     action: Commands::Build
     options:
       - *group_option
       - tags: [-k KICKSTART_TEMPLATE, --kickstart KICKSTART_TEMPLATE]
         type: String
         description: >
-          Specify kickstart template to use
+          Specify 'kickstart' template to use; overrides configured 'kickstart'
+          template to use for every node to be built
       - tags: [-p PXELINUX_TEMPLATE, --pxelinux PXELINUX_TEMPLATE]
         type: String
         description: >
-          Specify pxelinux template to use
+          Specify 'pxelinux' template to use; overrides configured 'pxelinux'
+          template to use for every node to be built
 
   configure:
     syntax: metal configure [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -139,7 +139,7 @@ commands:
       The 'files' for each node are specified under the 'files' key in the repo
       config for that node, while the 'pxelinux' and 'kickstart' templates are
       specified by the corresponding key in the 'templates' section of the
-      config (unless overridden).
+      config.
 
 
       In order to have a node report itself as built it must make a request to
@@ -153,16 +153,6 @@ commands:
     action: Commands::Build
     options:
       - *group_option
-      - tags: [-k KICKSTART_TEMPLATE, --kickstart KICKSTART_TEMPLATE]
-        type: String
-        description: >
-          Specify 'kickstart' template to use; overrides configured 'kickstart'
-          template to use for every node to be built
-      - tags: [-p PXELINUX_TEMPLATE, --pxelinux PXELINUX_TEMPLATE]
-        type: String
-        description: >
-          Specify 'pxelinux' template to use; overrides configured 'pxelinux'
-          template to use for every node to be built
 
   configure:
     syntax: metal configure [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -143,12 +143,10 @@ commands:
       - *group_option
       - tags: [-k KICKSTART_TEMPLATE, --kickstart KICKSTART_TEMPLATE]
         type: String
-        default: default
         description: >
           Specify kickstart template to use
       - tags: [-p PXELINUX_TEMPLATE, --pxelinux PXELINUX_TEMPLATE]
         type: String
-        default: default
         description: >
           Specify pxelinux template to use
 

--- a/src/cli_helper/dynamic_defaults.rb
+++ b/src/cli_helper/dynamic_defaults.rb
@@ -5,9 +5,7 @@ module Metalware
   module CliHelper
     module DynamicDefaults
       class << self
-        def build_interface
-          DeploymentServer.build_interface
-        end
+        delegate :build_interface, to: DeploymentServer
       end
     end
   end

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -175,11 +175,11 @@ module Metalware
           nodes.select do |node|
             !rerendered_nodes.include?(node) && node.built?
           end
-                .tap do |nodes|
+               .tap do |nodes|
             render_permanent_pxelinux_configs(nodes)
             rerendered_nodes.push(*nodes)
           end
-                .each do |node|
+               .each do |node|
             Output.stderr "Node #{node.name} built."
           end
 

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -55,13 +55,26 @@ module Metalware
 
       def dependency_hash
         {
-          repo: ["pxelinux/#{options.pxelinux}",
-                 "kickstart/#{options.kickstart}"],
+          repo: repo_dependencies,
           configure: ['domain.yaml'],
           optional: {
             configure: ["groups/#{group_name}.yaml"],
           },
         }
+      end
+
+      def repo_dependencies
+        nodes.map do |node|
+          [:pxelinux, :kickstart].map do |template_type|
+            full_template_path = template_path(template_type, node: node)
+            repo_relative_path_to(full_template_path)
+          end
+        end.flatten.uniq
+      end
+
+      def repo_relative_path_to(path)
+        repo_path = Pathname.new(config.repo_path)
+        Pathname.new(path).relative_path_from(repo_path).to_s
       end
 
       def render_build_templates

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -38,11 +38,12 @@ module Metalware
     class Build < CommandHelpers::BaseCommand
       private
 
-      attr_reader :options, :node_identifier, :nodes
+      attr_reader :options, :group_name, :nodes
 
       def setup(args, options)
         @options = options
-        @node_identifier = args.first
+        node_identifier = args.first
+        @group_name = node_identifier if options.group
         @nodes = Nodes.create(config, node_identifier, options.group)
       end
 
@@ -58,7 +59,7 @@ module Metalware
                  "kickstart/#{options.kickstart}"],
           configure: ['domain.yaml'],
           optional: {
-            configure: ["groups/#{node_identifier}.yaml"],
+            configure: ["groups/#{group_name}.yaml"],
           },
         }
       end

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -151,13 +151,8 @@ module Metalware
       end
 
       def template_file_name(template_type, node:)
-        passed_template(template_type) ||
-          repo_template(template_type, node: node) ||
+        repo_template(template_type, node: node) ||
           'default'
-      end
-
-      def passed_template(template_type)
-        options.__send__(template_type)
       end
 
       def repo_template(template_type, node:)

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -67,14 +67,9 @@ module Metalware
         nodes.map do |node|
           [:pxelinux, :kickstart].map do |template_type|
             full_template_path = template_path(template_type, node: node)
-            repo_relative_path_to(full_template_path)
+            file_path.repo_relative_path_to(full_template_path)
           end
         end.flatten.uniq
-      end
-
-      def repo_relative_path_to(path)
-        repo_path = Pathname.new(config.repo_path)
-        Pathname.new(path).relative_path_from(repo_path).to_s
       end
 
       def render_build_templates

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -127,10 +127,12 @@ module Metalware
       end
 
       def template_path(template_type)
+        passed_template = @options.__send__(template_type)
+        template_file_name = passed_template || 'default'
         File.join(
           config.repo_path,
           template_type.to_s,
-          @options.__send__(template_type)
+          template_file_name
         )
       end
 

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -48,6 +48,11 @@ module Metalware
       config.node_answers_file(node)
     end
 
+    def repo_relative_path_to(path)
+      repo_path = Pathname.new(config.repo_path)
+      Pathname.new(path).relative_path_from(repo_path).to_s
+    end
+
     private
 
     attr_reader :config


### PR DESCRIPTION
This PR allows the PXELINUX and Kickstart templates used when building each node to be specified in the repo config for that node; following the meeting earlier the `--kickstart` and `--pxelinux` options have also been removed as they are now superfluous.

Trello: https://trello.com/c/ySxv4Z1s/155-pxe-and-kickstart-file-selection-in-configs. Corresponding repo change demonstrating use of this feature: https://github.com/alces-software/metalware-default/commit/00c0bf0f47cd47a6d42fbb46a91ccb410fbbc976.