### PR TITLE
Improve rugged errors

### DIFF
--- a/src/commands/repo/update.rb
+++ b/src/commands/repo/update.rb
@@ -25,6 +25,7 @@
 require 'command_helpers/base_command'
 require 'metal_log'
 require 'rugged'
+require 'exceptions'
 
 require 'constants'
 
@@ -75,8 +76,7 @@ module Metalware
             puts str
             MetalLog.info str
           else
-            MetalLog.fatal 'Internal error. An impossible condition has been reached!'
-            raise 'Internal error. Check metal log'
+            raise UnexpectedError
           end
         end
 
@@ -84,23 +84,6 @@ module Metalware
           {
             repo: [],
           }
-        end
-      end
-
-      # TODO: Moves these errors into Exceptions class
-      class LocalAheadOfRemote < StandardError
-        def initialize(num)
-          msg = "The local repo is #{num} commits ahead of remote. -f will " \
-            'override local commits'
-          super msg
-        end
-      end
-
-      class UncommitedChanges < StandardError
-        def initialize(num)
-          msg = "The local repo has #{num} uncommitted changes. -f will " \
-            'delete these changes. (untracked unaffected)'
-          super msg
         end
       end
     end

--- a/src/commands/repo/use.rb
+++ b/src/commands/repo/use.rb
@@ -47,8 +47,10 @@ module Metalware
 
           Rugged::Repository.clone_at(@repo_url, config.repo_path)
           MetalLog.info "Cloned repo from #{@repo_url}"
+        rescue Rugged::NetworkError
+          raise RuggedCloneError, "Could not find repo: #{@repo_url}"
         rescue Rugged::InvalidError
-          raise $ERROR_INFO, 'Repository already exists. Use -f to force clone a new one'
+          raise RuggedCloneError, 'Repository already exists. Use -f to force clone a new one'
         end
       end
     end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -120,6 +120,25 @@ module Metalware
   # dumped.
   class DataError < MetalwareError
   end
+
+  class RuggedError < MetalwareError
+  end
+
+  class LocalAheadOfRemote < RuggedError
+    def initialize(num)
+      msg = "The local repo is #{num} commits ahead of remote. -f will " \
+        'override local commits'
+      super msg
+    end
+  end
+
+  class UncommitedChanges < RuggedError
+    def initialize(num)
+      msg = "The local repo has #{num} uncommitted changes. -f will " \
+        'delete these changes. (untracked unaffected)'
+      super msg
+    end
+  end
 end
 
 

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -124,6 +124,9 @@ module Metalware
   class RuggedError < MetalwareError
   end
 
+  class RuggedCloneError < RuggedError
+  end
+
   class LocalAheadOfRemote < RuggedError
     def initialize(num)
       msg = "The local repo is #{num} commits ahead of remote. -f will " \


### PR DESCRIPTION
Moves the last remaining errors into the unified `Exceptions` module. Also updated some of the error messages to be more descriptive. 

Card: https://trello.com/c/HLPwJePq/88-change-rugged-errors-to-metalware-errors-in-repo-use