### PR TITLE
Add basic metal build method (closes #145)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -77,7 +77,7 @@ say_done $?
 title "Creating initial directory structure"
 doing 'Create'
 mkdir -p /var/log/metalware
-mkdir -p /var/lib/metalware/rendered/{kickstart,system}
+mkdir -p /var/lib/metalware/rendered/{basic,kickstart,system}
 mkdir -p /var/lib/metalware/cache/{built-nodes,templates}
 mkdir -p /var/lib/metalware/repo
 mkdir -p /var/lib/metalware/answers/{groups,nodes}

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -115,6 +115,10 @@ RSpec.describe Metalware::Commands::Build do
     }
   end
 
+  let :testnodes_config_path do
+    metal_config.repo_config_path('testnodes')
+  end
+
   let :filesystem do
     FileSystem.setup do |fs|
       fs.with_repo_fixtures('repo')
@@ -147,7 +151,6 @@ RSpec.describe Metalware::Commands::Build do
 
     context 'when templates specified in repo config' do
       before :each do
-        testnodes_config_path = metal_config.repo_config_path('testnodes')
         testnodes_config = {
           templates: {
             pxelinux: 'repo_pxelinux',
@@ -243,7 +246,6 @@ RSpec.describe Metalware::Commands::Build do
           Metalware::Data.load(fixtures_testnodes_config_path)
         FakeFS.activate!
 
-        testnodes_config_path = metal_config.repo_config_path('testnodes')
         testnodes_config = fixtures_testnodes_config.merge(build_method: 'basic')
         filesystem.dump(testnodes_config_path, testnodes_config)
       end

--- a/spec/minimal_repo.rb
+++ b/spec/minimal_repo.rb
@@ -30,6 +30,7 @@ module MinimalRepo
       'files/': nil,
       'pxelinux/default': "<%= alces.firstboot ? 'FIRSTBOOT' : 'NOT_FIRSTBOOT' %>\n",
       'kickstart/default': '',
+      'basic/default': '',
       'hosts/default': '',
       'genders/default': '',
       'dhcp/default': '',

--- a/src/build_methods.rb
+++ b/src/build_methods.rb
@@ -1,0 +1,6 @@
+
+# frozen_string_literal: true
+
+require 'build_methods/build_method'
+require 'build_methods/kickstart'
+require 'build_methods/basic'

--- a/src/build_methods/basic.rb
+++ b/src/build_methods/basic.rb
@@ -1,0 +1,20 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  module BuildMethods
+    class Basic < BuildMethod
+      def render_build_started_templates(parameters)
+        render_basic(parameters)
+      end
+
+      def render_build_complete_templates(_parameters); end
+
+      private
+
+      def render_basic(parameters)
+        render_template(:basic, parameters: parameters)
+      end
+    end
+  end
+end

--- a/src/build_methods/basic.rb
+++ b/src/build_methods/basic.rb
@@ -10,6 +10,10 @@ module Metalware
 
       def render_build_complete_templates(_parameters); end
 
+      def template_paths
+        # XXX Specify template paths here
+      end
+
       private
 
       def render_basic(parameters)

--- a/src/build_methods/build_method.rb
+++ b/src/build_methods/build_method.rb
@@ -1,0 +1,39 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  module BuildMethods
+    class BuildMethod
+      def initialize(config, node)
+        @config = config
+        @node = node
+      end
+
+      def render_build_started_templates(_parameters)
+        raise NotImplementedError
+      end
+
+      def render_build_complete_templates(_parameters)
+        raise NotImplementedError
+      end
+
+      private
+
+      attr_reader :config, :node
+
+      delegate :template_path, to: :file_path
+
+      def file_path
+        @file_path ||= FilePath.new(config)
+      end
+
+      def render_template(template_type, parameters:, save_path: nil)
+        template_type_path = template_path template_type, node: node
+        save_path ||= File.join(
+          config.rendered_files_path, template_type.to_s, node.name
+        )
+        Templater.render_to_file(config, template_type_path, save_path, parameters)
+      end
+    end
+  end
+end

--- a/src/build_methods/build_method.rb
+++ b/src/build_methods/build_method.rb
@@ -17,6 +17,10 @@ module Metalware
         raise NotImplementedError
       end
 
+      def template_paths
+        raise NotImplementedError
+      end
+
       private
 
       attr_reader :config, :node

--- a/src/build_methods/kickstart.rb
+++ b/src/build_methods/kickstart.rb
@@ -1,0 +1,30 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  module BuildMethods
+    class Kickstart < BuildMethod
+      def render_build_started_templates(parameters)
+        render_kickstart(parameters)
+        render_pxelinux(parameters)
+      end
+
+      def render_build_complete_templates(parameters)
+        render_pxelinux(parameters)
+      end
+
+      private
+
+      def render_kickstart(parameters)
+        render_template(:kickstart, parameters: parameters)
+      end
+
+      def render_pxelinux(parameters)
+        # XXX handle nodes without hexadecimal IP, i.e. nodes not in `hosts`
+        # file yet - best place to do this may be when creating `Node` objects?
+        save_path = File.join(config.pxelinux_cfg_path, node.hexadecimal_ip)
+        render_template(:pxelinux, parameters: parameters, save_path: save_path)
+      end
+    end
+  end
+end

--- a/src/build_methods/kickstart.rb
+++ b/src/build_methods/kickstart.rb
@@ -13,6 +13,13 @@ module Metalware
         render_pxelinux(parameters)
       end
 
+      def template_paths
+        [:pxelinux, :kickstart].map do |template_type|
+          full_template_path = template_path(template_type, node: node)
+          file_path.repo_relative_path_to(full_template_path)
+        end
+      end
+
       private
 
       def render_kickstart(parameters)

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -40,6 +40,8 @@ module Metalware
 
       attr_reader :options, :group_name, :nodes
 
+      delegate :template_path, to: :file_path
+
       def setup(args, options)
         @options = options
         node_identifier = args.first
@@ -143,24 +145,6 @@ module Metalware
           config.rendered_files_path, template_type.to_s, node.name
         )
         Templater.render_to_file(config, template_type_path, save_path, parameters)
-      end
-
-      def template_path(template_type, node:)
-        File.join(
-          config.repo_path,
-          template_type.to_s,
-          template_file_name(template_type, node: node)
-        )
-      end
-
-      def template_file_name(template_type, node:)
-        repo_template(template_type, node: node) ||
-          'default'
-      end
-
-      def repo_template(template_type, node:)
-        repo_specified_templates = node.repo_config[:templates] || {}
-        repo_specified_templates[template_type]
       end
 
       def basic_build_node?(node)

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -66,12 +66,7 @@ module Metalware
       end
 
       def repo_dependencies
-        nodes.map do |node|
-          [:pxelinux, :kickstart].map do |template_type|
-            full_template_path = template_path(template_type, node: node)
-            file_path.repo_relative_path_to(full_template_path)
-          end
-        end.flatten.uniq
+        nodes.map(&:build_template_paths).flatten.uniq
       end
 
       def render_build_templates

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -114,29 +114,35 @@ module Metalware
       end
 
       def render_basic(parameters, node)
-        basic_template_path = template_path :basic, node: node
-        basic_save_path = File.join(
-          config.rendered_files_path, 'basic', node.name
+        render_build_method_template(
+          :basic, parameters: parameters, node: node
         )
-        Templater.render_to_file(config, basic_template_path, basic_save_path, parameters)
       end
 
       def render_kickstart(parameters, node)
-        kickstart_template_path = template_path :kickstart, node: node
-        kickstart_save_path = File.join(
-          config.rendered_files_path, 'kickstart', node.name
+        render_build_method_template(
+          :kickstart, parameters: parameters, node: node
         )
-        Templater.render_to_file(config, kickstart_template_path, kickstart_save_path, parameters)
       end
 
       def render_pxelinux(parameters, node)
         # XXX handle nodes without hexadecimal IP, i.e. nodes not in `hosts`
         # file yet - best place to do this may be when creating `Node` objects?
-        pxelinux_template_path = template_path :pxelinux, node: node
-        pxelinux_save_path = File.join(
-          config.pxelinux_cfg_path, node.hexadecimal_ip
+        save_path = File.join(config.pxelinux_cfg_path, node.hexadecimal_ip)
+        render_build_method_template(
+          :pxelinux,
+          parameters: parameters,
+          node: node,
+          save_path: save_path
         )
-        Templater.render_to_file(config, pxelinux_template_path, pxelinux_save_path, parameters)
+      end
+
+      def render_build_method_template(template_type, parameters:, node:, save_path: nil)
+        template_type_path = template_path template_type, node: node
+        save_path ||= File.join(
+          config.rendered_files_path, template_type.to_s, node.name
+        )
+        Templater.render_to_file(config, template_type_path, save_path, parameters)
       end
 
       def template_path(template_type, node:)

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -159,18 +159,13 @@ module Metalware
       end
 
       def repo_template(template_type, node:)
-        repo_config = repo_config_for_node(node)
-        repo_specified_templates = repo_config[:templates] || {}
+        repo_specified_templates = node.repo_config[:templates] || {}
         repo_specified_templates[template_type]
       end
 
       def basic_build_node?(node)
-        build_method = repo_config_for_node(node)[:build_method]
+        build_method = node.repo_config[:build_method]
         build_method == 'basic'
-      end
-
-      def repo_config_for_node(node)
-        Templater.new(config, nodename: node.name).config
       end
 
       def wait_for_nodes_to_build

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -111,7 +111,7 @@ module Metalware
             !rerendered_nodes.include?(node) && node.built?
           end
                .tap do |nodes|
-            render_permanent_pxelinux_configs(nodes)
+            render_build_complete_templates(nodes)
             rerendered_nodes.push(*nodes)
           end
                .each do |node|
@@ -125,11 +125,11 @@ module Metalware
         end
       end
 
-      def render_all_permanent_pxelinux_configs
-        render_permanent_pxelinux_configs(nodes)
+      def render_all_build_complete_templates
+        render_build_complete_templates(nodes)
       end
 
-      def render_permanent_pxelinux_configs(nodes)
+      def render_build_complete_templates(nodes)
         nodes.template_each firstboot: false do |parameters, node|
           parameters[:files] = build_files(node)
           node.render_build_complete_templates(parameters)
@@ -149,20 +149,20 @@ module Metalware
 
       def handle_interrupt(_e)
         Output.stderr 'Exiting...'
-        ask_if_should_rerender_pxelinux_configs
+        ask_if_should_rerender
         teardown
       rescue Interrupt
-        Output.stderr 'Re-rendering all permanent PXELINUX templates anyway...'
-        render_all_permanent_pxelinux_configs
+        Output.stderr 'Re-rendering templates anyway...'
+        render_all_build_complete_templates
         teardown
       end
 
-      def ask_if_should_rerender_pxelinux_configs
+      def ask_if_should_rerender
         should_rerender = <<-EOF.strip_heredoc
-          Re-render permanent PXELINUX templates for all nodes as if build succeeded?
+          Re-render appropriate templates for nodes as if build succeeded?
           [yes/no]
         EOF
-        render_all_permanent_pxelinux_configs if agree(should_rerender)
+        render_all_build_complete_templates if agree(should_rerender)
       end
     end
   end

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -76,12 +76,7 @@ module Metalware
         nodes.template_each firstboot: true do |parameters, node|
           parameters[:files] = build_files(node)
           render_build_files(parameters, node)
-          if basic_build_node?(node)
-            render_basic(parameters, node)
-          else
-            render_kickstart(parameters, node)
-            render_pxelinux(parameters, node)
-          end
+          render_build_method_templates(parameters, node)
         end
       end
 
@@ -106,6 +101,15 @@ module Metalware
             FileUtils.mkdir_p(File.dirname(render_path))
             Templater.render_to_file(config, file[:template_path], render_path, parameters)
           end
+        end
+      end
+
+      def render_build_method_templates(parameters, node)
+        if basic_build_node?(node)
+          render_basic(parameters, node)
+        else
+          render_kickstart(parameters, node)
+          render_pxelinux(parameters, node)
         end
       end
 

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -53,6 +53,14 @@ module Metalware
       Pathname.new(path).relative_path_from(repo_path).to_s
     end
 
+    def template_path(template_type, node:)
+      File.join(
+        config.repo_path,
+        template_type.to_s,
+        template_file_name(template_type, node: node)
+      )
+    end
+
     private
 
     attr_reader :config
@@ -66,6 +74,15 @@ module Metalware
                    Constants.const_get(const)
                  end
                end
+    end
+
+    def template_file_name(template_type, node:)
+      repo_template(template_type, node: node) || 'default'
+    end
+
+    def repo_template(template_type, node:)
+      repo_specified_templates = node.repo_config[:templates] || {}
+      repo_specified_templates[template_type]
     end
   end
 end

--- a/src/node.rb
+++ b/src/node.rb
@@ -30,6 +30,7 @@ require 'nodeattr_interface'
 require 'exceptions'
 require 'primary_group'
 require 'templating/configuration'
+require 'build_methods'
 
 module Metalware
   class Node
@@ -40,6 +41,10 @@ module Metalware
              # in the `Node` tests
              :configs,
              to: :templating_configuration
+
+    delegate :render_build_started_templates,
+             :render_build_complete_templates,
+             to: :build_method
 
     def initialize(metalware_config, name, should_be_configured: false)
       @metalware_config = metalware_config
@@ -170,6 +175,19 @@ module Metalware
 
     def same_basename?(path1, path2)
       File.basename(path1) == File.basename(path2)
+    end
+
+    def build_method
+      @build_method ||= build_method_class.new(metalware_config, self)
+    end
+
+    def build_method_class
+      case repo_config[:build_method]&.to_sym
+      when :basic
+        BuildMethods::Basic
+      else
+        BuildMethods::Kickstart
+      end
     end
   end
 end

--- a/src/node.rb
+++ b/src/node.rb
@@ -142,6 +142,10 @@ module Metalware
       @repo_config ||= Templater.new(metalware_config, nodename: name).config
     end
 
+    def build_template_paths
+      build_method.template_paths
+    end
+
     private
 
     attr_reader :metalware_config, :should_be_configured

--- a/src/node.rb
+++ b/src/node.rb
@@ -133,6 +133,10 @@ module Metalware
       groups.first
     end
 
+    def repo_config
+      Templater.new(metalware_config, nodename: name).config
+    end
+
     private
 
     attr_reader :metalware_config, :should_be_configured

--- a/src/node.rb
+++ b/src/node.rb
@@ -134,7 +134,7 @@ module Metalware
     end
 
     def repo_config
-      Templater.new(metalware_config, nodename: name).config
+      @repo_config ||= Templater.new(metalware_config, nodename: name).config
     end
 
     private


### PR DESCRIPTION
This PR adds a `basic` `metal build` method for nodes, specified by the `build_method key in the repo config for a node, which is an alternative to the existing default Kickstart build method. See https://github.com/alces-software/metalware/commit/3fb444b94ca656e3216847fdb472cf15c7fa02c7 for the main details of what is involved in this method.

This resolves https://github.com/alces-software/metalware/issues/145 / https://trello.com/c/0wZYT7o9/164-add-basic-metal-build-method. It is based on https://github.com/alces-software/metalware/pull/155.