### PR TITLE
Only rerender parts of hosts and genders

### DIFF
--- a/spec/shared_examples/render_domain_templates.rb
+++ b/spec/shared_examples/render_domain_templates.rb
@@ -54,18 +54,16 @@ RSpec.shared_examples :render_domain_templates do |test_command|
 
       # Genders file needs to be rendered before hosts, as how this is rendered
       # will effect the groups and nodes used when rendering the hosts file.
-      expect(Metalware::Templater).to receive(:render_to_file).with(
+      expect(Metalware::Templater).to receive(:render_managed_file).with(
         instance_of(Metalware::Config),
         '/var/lib/metalware/repo/genders/default',
-        Metalware::Constants::GENDERS_PATH,
-        prepend_managed_file_message: true
+        Metalware::Constants::GENDERS_PATH
       ).ordered.and_call_original
 
-      expect(Metalware::Templater).to receive(:render_to_file).with(
+      expect(Metalware::Templater).to receive(:render_managed_file).with(
         instance_of(Metalware::Config),
         '/var/lib/metalware/repo/hosts/default',
-        Metalware::Constants::HOSTS_PATH,
-        prepend_managed_file_message: true
+        Metalware::Constants::HOSTS_PATH
       ).ordered.and_call_original
 
       SpecUtils.run_command(test_command)
@@ -137,11 +135,10 @@ RSpec.shared_examples :render_domain_templates do |test_command|
         ).to eq(existing_genders_contents)
 
         # Invalid rendered genders available for inspection.
-        expected_invalid_rendered_genders = \
-          "#{Metalware::Templater::MANAGED_FILE_MESSAGE}\nsome genders template 0"
+        expected_invalid_rendered_genders = "some genders template 0"
         expect(
           File.read(Metalware::Constants::INVALID_RENDERED_GENDERS_PATH)
-        ).to eq(expected_invalid_rendered_genders)
+        ).to include(expected_invalid_rendered_genders)
       end
     end
   end

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -273,11 +273,39 @@ RSpec.describe Metalware::Templater do
       )
     end
 
+    def render_managed_file_with_block(&block)
+      Metalware::Templater.render_managed_file(
+        config,
+        template_path,
+        output_path,
+        &block
+      )
+    end
+
     context 'when file does not exist already' do
       it 'renders template within markers' do
         filesystem.test do
           render_managed_file
           expect(output).to match(rendered_file_section_regex)
+        end
+      end
+
+      # XXX Following two tests similar to those for `render_to_file` above.
+      it 'renders template if passed a block with truthy output' do
+        filesystem.test do
+          template_rendered = render_managed_file_with_block(&:present?)
+
+          expect(output).to match(rendered_file_section_regex)
+          expect(template_rendered).to be true
+        end
+      end
+
+      it 'does not render template if passed a block with falsy output' do
+        filesystem.test do
+          template_rendered = render_managed_file_with_block(&:empty?)
+
+          expect(File.exist?(output_path)).to be false
+          expect(template_rendered).to be false
         end
       end
     end

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -258,10 +258,10 @@ RSpec.describe Metalware::Templater do
 
     let :rendered_file_section_regex do
       [
-        Metalware::Templater::MANAGED_START_COMMENT,
+        Metalware::Templater::MANAGED_START,
         Metalware::Templater::MANAGED_COMMENT,
         template,
-        Metalware::Templater::MANAGED_END_COMMENT,
+        Metalware::Templater::MANAGED_END,
       ].join("\n") + "\n"
     end
 
@@ -334,9 +334,9 @@ RSpec.describe Metalware::Templater do
         <<-EOF.strip_heredoc
         BEFORE
 
-        # #{Metalware::Templater::MANAGED_START}
+        #{Metalware::Templater::MANAGED_START}
         previous rendered template
-        # #{Metalware::Templater::MANAGED_END}
+        #{Metalware::Templater::MANAGED_END}
 
         AFTER
         EOF

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Metalware::Templater do
 
   describe '#render_managed_file' do
     # XXX Similar to above.
-    let :template { "simple template without ERB\n" }
+    let :template { "simple template without ERB" }
     let :output_path { '/output' }
     let :output { File.read(output_path) }
 
@@ -314,7 +314,7 @@ RSpec.describe Metalware::Templater do
       let :existing_contents { "existing file contents\n" }
 
       let :rendered_file_regex do
-        existing_contents + rendered_file_section_regex
+        [existing_contents, "\n", rendered_file_section_regex].join
       end
 
       before :each do

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -250,6 +250,98 @@ RSpec.describe Metalware::Templater do
     end
   end
 
+  describe '#render_managed_file' do
+    # XXX Similar to above.
+    let :template { "simple template without ERB\n" }
+    let :output_path { '/output' }
+    let :output { File.read(output_path) }
+
+    let :rendered_file_section_regex do
+      <<-EOF.strip_heredoc
+      # #{Metalware::Templater::MANAGED_START}
+      # #{Metalware::Templater::MANAGED_COMMENT.truncate(30)}.*
+      #{template}
+      # #{Metalware::Templater::MANAGED_END}
+      EOF
+    end
+
+    def render_managed_file
+      Metalware::Templater.render_managed_file(
+        config,
+        template_path,
+        output_path
+      )
+    end
+
+    context 'when file does not exist already' do
+      it 'renders template within markers' do
+        filesystem.test do
+          render_managed_file
+          expect(output).to match(rendered_file_section_regex)
+        end
+      end
+    end
+
+    context 'when file exists without markers' do
+      let :existing_contents { "existing file contents\n" }
+
+      let :rendered_file_regex do
+        existing_contents + rendered_file_section_regex
+      end
+
+      before :each do
+        filesystem.write(output_path, existing_contents)
+      end
+
+      it 'renders template within markers at bottom of existing file' do
+        filesystem.test do
+          render_managed_file
+          expect(output).to match(rendered_file_regex)
+        end
+      end
+    end
+
+    context 'when file exists with markers' do
+      let :existing_contents do
+        <<-EOF.strip_heredoc
+        BEFORE
+
+        # #{Metalware::Templater::MANAGED_START}
+        previous rendered template
+        # #{Metalware::Templater::MANAGED_END}
+
+        AFTER
+        EOF
+      end
+
+      let :rendered_file_regex do
+        "BEFORE\n\n" + rendered_file_section_regex + "\n\nAFTER"
+      end
+
+      before :each do
+        filesystem.write(output_path, existing_contents)
+      end
+
+      it 'renders template and replaces within markers' do
+        filesystem.test do
+          render_managed_file
+          expect(output).to match(rendered_file_regex)
+        end
+      end
+
+      it 'is idempotent' do
+        filesystem do
+          3.times { render_managed_file }
+
+          # So long as the existing file and the rendered template remain the
+          # same, the final template output should also remain the same after
+          # repeated renderings.
+          expect(output).to match(rendered_file_regex)
+        end
+      end
+    end
+  end
+
   # XXX These tests test `Templating::MagicNamespace` via the `Templater`; this
   # is useful to check they work together but we may want to test some things
   # directly on the `MagicNamespace`.

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -257,12 +257,12 @@ RSpec.describe Metalware::Templater do
     let :output { File.read(output_path) }
 
     let :rendered_file_section_regex do
-      <<-EOF.strip_heredoc
-      # #{Metalware::Templater::MANAGED_START}
-      # #{Metalware::Templater::MANAGED_COMMENT.truncate(30)}.*
-      #{template}
-      # #{Metalware::Templater::MANAGED_END}
-      EOF
+      [
+        Metalware::Templater::MANAGED_START_COMMENT,
+        Metalware::Templater::MANAGED_COMMENT,
+        template,
+        Metalware::Templater::MANAGED_END_COMMENT,
+      ].join("\n") + "\n"
     end
 
     def render_managed_file

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,0 +1,21 @@
+
+# frozen_string_literal: true
+
+require 'utils'
+
+RSpec.describe Metalware::Utils do
+  describe '#commentify' do
+    it 'wraps string and prepends comment character to each line' do
+      my_string = 'this is my string, it should be wrapped and commented'
+      result = described_class.commentify(my_string, comment_char: '#', line_length: 20)
+      expect(result).to eq(
+        <<-EOF.strip_heredoc.strip
+        # this is my string,
+        # it should be
+        # wrapped and
+        # commented
+        EOF
+      )
+    end
+  end
+end

--- a/src/domain_templates_renderer.rb
+++ b/src/domain_templates_renderer.rb
@@ -58,7 +58,7 @@ module Metalware
     end
 
     def render_metalware_server_config
-      render_template(
+      render_fully_managed_template(
         server_config_template,
         to: Constants::SERVER_CONFIG_PATH
       ) do |rendered_config|
@@ -83,7 +83,7 @@ module Metalware
     end
 
     def render_genders
-      render_template(
+      render_managed_section_template(
         genders_template,
         to: Constants::GENDERS_PATH
       ) do |rendered_genders|
@@ -124,10 +124,14 @@ module Metalware
     end
 
     def render_hosts
-      render_template(hosts_template, to: Constants::HOSTS_PATH)
+      render_managed_section_template(hosts_template, to: Constants::HOSTS_PATH)
     end
 
-    def render_template(template, to:, &block)
+    def render_managed_section_template(template, to:, &block)
+      Templater.render_managed_file(config, template, to, &block)
+    end
+
+    def render_fully_managed_template(template, to:, &block)
       Templater.render_to_file(
         config,
         template,

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -28,6 +28,7 @@ require 'active_support/core_ext/string/strip'
 require 'constants'
 require 'metal_log'
 require 'exceptions'
+require 'utils'
 require 'templating/iterable_recursive_open_struct'
 require 'templating/missing_parameter_wrapper'
 require 'templating/magic_namespace'
@@ -46,12 +47,14 @@ module Metalware
     MANAGED_END = 'METALWARE_END'
     MANAGED_START_COMMENT = "# #{MANAGED_START}"
     MANAGED_END_COMMENT = "# #{MANAGED_END}"
-    MANAGED_COMMENT = <<-EOF.squish
-    This section of this file is managed by Alces Metalware. Any changes made
-    to this file between the #{MANAGED_START} and
-    #{MANAGED_END} markers may be lost; you should make any changes
-    you want to persist outside of this section or to the template directly.
+    MANAGED_COMMENT = Utils.commentify(
+      <<-EOF.squish
+      This section of this file is managed by Alces Metalware. Any changes made
+      to this file between the #{MANAGED_START} and #{MANAGED_END} markers may
+      be lost; you should make any changes you want to persist outside of this
+      section or to the template directly.
     EOF
+    )
 
     class << self
       # XXX rename args in these methods - use `**parameters` for passing
@@ -134,7 +137,7 @@ module Metalware
       def managed_section(rendered_template)
         [
           MANAGED_START_COMMENT,
-          "# #{MANAGED_COMMENT}",
+          MANAGED_COMMENT,
           rendered_template,
           MANAGED_END_COMMENT,
         ].join("\n") + "\n"

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -43,16 +43,16 @@ module Metalware
     # `metal configure` commands.
     EOF
 
-    MANAGED_START = 'METALWARE_START'
-    MANAGED_END = 'METALWARE_END'
-    MANAGED_START_COMMENT = "# #{MANAGED_START}"
-    MANAGED_END_COMMENT = "# #{MANAGED_END}"
+    MANAGED_START_MARKER = 'METALWARE_START'
+    MANAGED_START = "########## #{MANAGED_START_MARKER} ##########"
+    MANAGED_END_MARKER = 'METALWARE_END'
+    MANAGED_END = "########## #{MANAGED_END_MARKER} ##########"
     MANAGED_COMMENT = Utils.commentify(
       <<-EOF.squish
       This section of this file is managed by Alces Metalware. Any changes made
-      to this file between the #{MANAGED_START} and #{MANAGED_END} markers may
-      be lost; you should make any changes you want to persist outside of this
-      section or to the template directly.
+      to this file between the #{MANAGED_START_MARKER} and
+      #{MANAGED_END_MARKER} markers may be lost; you should make any changes
+      you want to persist outside of this section or to the template directly.
     EOF
     )
 
@@ -125,9 +125,9 @@ module Metalware
       end
 
       def split_on_managed_section(file_contents)
-        if file_contents.include? MANAGED_START_COMMENT
-          pre, rest = file_contents.split(MANAGED_START_COMMENT)
-          _, post = rest.split(MANAGED_END_COMMENT)
+        if file_contents.include? MANAGED_START
+          pre, rest = file_contents.split(MANAGED_START)
+          _, post = rest.split(MANAGED_END)
           [pre, post]
         else
           [file_contents + "\n\n", nil]
@@ -136,10 +136,10 @@ module Metalware
 
       def managed_section(rendered_template)
         [
-          MANAGED_START_COMMENT,
+          MANAGED_START,
           MANAGED_COMMENT,
           rendered_template,
-          MANAGED_END_COMMENT,
+          MANAGED_END,
         ].join("\n") + "\n"
       end
 

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -112,7 +112,7 @@ module Metalware
         pre, post = split_on_managed_section(
           current_file_contents(managed_file)
         )
-        new_managed_file = [pre, managed_section(rendered_template), post].join
+        new_managed_file = [pre, managed_section(rendered_template.strip), post].join
         write_rendered_template(new_managed_file, save_file: managed_file)
       end
 
@@ -130,7 +130,7 @@ module Metalware
           _, post = rest.split(MANAGED_END_COMMENT)
           [pre, post]
         else
-          [file_contents + "\n", nil]
+          [file_contents + "\n\n", nil]
         end
       end
 

--- a/src/utils.rb
+++ b/src/utils.rb
@@ -1,0 +1,26 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  module Utils
+    class << self
+      def commentify(string, comment_char: '#', line_length: 80)
+        comment_string = "#{comment_char} "
+        max_commented_line_length = line_length - comment_string.length
+
+        wrap(string, max_commented_line_length)
+          .split("\n")
+          .map { |line| line.prepend(comment_string) }
+          .join("\n")
+      end
+
+      private
+
+      # From
+      # https://www.safaribooksonline.com/library/view/ruby-cookbook/0596523696/ch01s15.html.
+      def wrap(string, width)
+        string.gsub(/(.{1,#{width}})(\s+|\Z)/, "\\1\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR changes how we handle rendering the `hosts` and `genders` files, to only render part of each file (which I call the 'managed section') and keep the rest of the file outside this section the same. This change will allow cluster admins to edit these files manually outside of this section, without needing to know or care about Metalware or how it changes these files.

An exact description of how this new rendering method functions depending on the existing file contents is in 3887a39d93ce2359b23dcc569aeffbe6e31f1ce0.

Based on #156; Trello: https://trello.com/c/pb8yT6qP.