### PR TITLE
Make group_index always default to 0 (fixes #161)

### DIFF
--- a/spec/fixtures/cache/groups.yaml
+++ b/spec/fixtures/cache/groups.yaml
@@ -1,4 +1,4 @@
-next_index: 2
+next_index: 3
 primary_groups:
-  some_group: 0
-  testnodes: 1
+  some_group: 1
+  testnodes: 2

--- a/spec/fixtures/setup1/cache/groups.yaml
+++ b/spec/fixtures/setup1/cache/groups.yaml
@@ -1,6 +1,6 @@
 ---
-next_index: 3
+next_index: 4
 primary_groups:
-  group1: 0
-  group2: 1
-  nodes: 2
+  group1: 1
+  group2: 2
+  nodes: 3

--- a/spec/group_cache_spec.rb
+++ b/spec/group_cache_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Metalware::GroupCache do
         cache.add('new_group')
         expect(cache.group?('new_group')).to eq(true)
 
-        next_available_index = 2
+        next_available_index = 3
         expect(cache.index('new_group')).to eq(next_available_index)
       end
     end
@@ -95,13 +95,13 @@ RSpec.describe Metalware::GroupCache do
       filesystem.test do
         group1 = 'group1'
         cache.add(group1)
-        expect(cache.index(group1)).to eq 2
+        expect(cache.index(group1)).to eq 3
 
         cache.remove(group1)
 
         group2 = 'group2'
         cache.add(group2)
-        expect(cache.index(group2)).to eq 3
+        expect(cache.index(group2)).to eq 4
       end
     end
   end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -151,16 +151,10 @@ RSpec.describe Metalware::Node do
   describe '#group_index' do
     let :filesystem { FileSystem.setup }
 
-    def expect_group_index_raises_for_node(node)
-      filesystem.test do
-        expect { node.group_index }.to raise_error(
-          Metalware::UnconfiguredGroupError
-        )
-      end
-    end
-
-    it 'raises when groups.yaml does not exist' do
-      expect_group_index_raises_for_node(testnode01)
+    it 'returns 0 when groups.yaml does not exist' do
+      # This should never happen now as a node should always have a primary
+      # group, which should be in the cache.
+      expect(testnode01.group_index).to eq 0
     end
 
     context 'when some primary groups have been cached' do
@@ -175,11 +169,13 @@ RSpec.describe Metalware::Node do
       end
 
       it "raises when the node's primary group is not in the cache" do
-        expect_group_index_raises_for_node(testnode02)
+        # This should never happen now as a node should always have a primary
+        # group.
+        expect(testnode02.group_index).to eq 0
       end
 
-      it 'raises for the null object node' do
-        expect_group_index_raises_for_node(node(nil))
+      it 'returns 0 for the null object node' do
+        expect(node(nil).group_index).to eq 0
       end
     end
   end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Metalware::Node do
 
       it "returns the index of the node's primary group" do
         filesystem.test do
-          expect(testnode01.group_index).to eq(1)
+          expect(testnode01.group_index).to eq(2)
         end
       end
 

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -124,15 +124,15 @@ RSpec.describe Metalware::Node do
         # We define the 'primary' group for a node as the first group it is
         # associated with in the genders file. This means for `testnode01` and
         # `testnode03` this is `testnodes`, but for `testnode02` it is
-        # `pregroup`, in which it is the first node and so has index 0.
+        # `pregroup`, in which it is the first node and so has index 1.
         #
         # This has the potential to cause confusion but I see no better way to
         # handle this currently, as a node can always have multiple groups and we
         # have to choose one to be the primary group. Later we may add more
         # structure and validation around handling this.
-        expect(testnode01.index).to eq(0)
-        expect(testnode02.index).to eq(0)
-        expect(testnode03.index).to eq(2)
+        expect(testnode01.index).to eq(1)
+        expect(testnode02.index).to eq(1)
+        expect(testnode03.index).to eq(3)
       end
 
       it 'returns 0 for node not in genders' do

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe Metalware::Templater do
           magic_namespace = templater.config.alces
 
           expect(magic_namespace.index).to eq(3)
-          expect(magic_namespace.group_index).to eq(1)
+          expect(magic_namespace.group_index).to eq(2)
           expect(magic_namespace.nodename).to eq('testnode03')
           expect(magic_namespace.firstboot).to eq(true)
           expect(magic_namespace.kickstart_url).to eq('http://1.2.3.4/metalware/kickstart/testnode03')

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -455,7 +455,7 @@ RSpec.describe Metalware::Templater do
           magic_namespace = templater.config.alces
 
           expect(magic_namespace.index).to eq(0)
-          expect(magic_namespace.group_index).to eq(nil)
+          expect(magic_namespace.group_index).to eq(0)
           expect(magic_namespace.nodename).to eq(nil)
           expect(magic_namespace.firstboot).to eq(nil)
           expect(magic_namespace.files).to eq(nil)

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe Metalware::Templater do
                                                        files: build_files)
           magic_namespace = templater.config.alces
 
-          expect(magic_namespace.index).to eq(2)
+          expect(magic_namespace.index).to eq(3)
           expect(magic_namespace.group_index).to eq(1)
           expect(magic_namespace.nodename).to eq('testnode03')
           expect(magic_namespace.firstboot).to eq(true)

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -117,9 +117,6 @@ module Metalware
   class DependencyFailure < MetalwareError
   end
 
-  class UnconfiguredGroupError < MetalwareError
-  end
-
   # Error to be used when a file that should exist doesn't.
   class FileDoesNotExistError < MetalwareError
   end

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -84,7 +84,7 @@ module Metalware
     def load
       loader.group_cache.tap do |d|
         if d.empty?
-          d.merge!(next_index: 0,
+          d.merge!(next_index: 1,
                    primary_groups: {})
         end
       end

--- a/src/node.rb
+++ b/src/node.rb
@@ -125,13 +125,7 @@ module Metalware
     end
 
     def group_index
-      if primary_group_index
-        primary_group_index
-      else
-        error = "Cannot get 'group_index', the primary group " \
-                "'#{primary_group}' for this node (#{name}) has not been configured"
-        raise UnconfiguredGroupError, error
-      end
+      primary_group_index || 0
     end
 
     def primary_group

--- a/src/node.rb
+++ b/src/node.rb
@@ -118,7 +118,7 @@ module Metalware
 
     def index
       if primary_group
-        Nodes.create(metalware_config, primary_group, true).index(self)
+        Nodes.create(metalware_config, primary_group, true).index(self) + 1
       else
         0
       end

--- a/src/templating/magic_namespace.rb
+++ b/src/templating/magic_namespace.rb
@@ -32,19 +32,11 @@ module Metalware
       end
 
       attr_reader :firstboot, :files
-      delegate :index, to: :node
+      delegate :index, :group_index, to: :node
       delegate :to_json, to: :to_h
 
       def to_h
         ObjectFieldsHasher.hash_object(self, groups: :groups_data)
-      end
-
-      def group_index
-        node.group_index
-      rescue UnconfiguredGroupError
-        # If the node's primary group is not configured yet, return nil rather
-        # than blow up.
-        nil
       end
 
       def nodename


### PR DESCRIPTION
Rather than having situations where this can be nil, which appears to just make templating more difficult without providing any benefit. Fixes issue discussed in https://github.com/alces-software/metalware/issues/161.