### PR TITLE
Tidy up command args and options handling

### DIFF
--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
   class TestCommand < Metalware::CommandHelpers::ConfigureCommand
     private
 
-    def setup(args, options); end
+    def setup; end
 
     # Overridden to be three element array with third a valid `configure.yaml`
     # questions section; `BaseCommand` expects command classes to be namespaced

--- a/src/command_helpers/base_command.rb
+++ b/src/command_helpers/base_command.rb
@@ -35,7 +35,7 @@ module Metalware
     class BaseCommand
       def initialize(args, options)
         pre_setup(args, options)
-        setup(args, options)
+        setup
         post_setup
         run
       rescue Interrupt => e
@@ -101,7 +101,7 @@ module Metalware
         MetalLog.info "metal #{ARGV.join(' ')}"
       end
 
-      def setup(_args, _options)
+      def setup
         raise NotImplementedError
       end
 

--- a/src/command_helpers/base_command.rb
+++ b/src/command_helpers/base_command.rb
@@ -46,11 +46,13 @@ module Metalware
 
       private
 
-      attr_reader :config
+      attr_reader :config, :args, :options
 
-      def pre_setup(_args, options)
+      def pre_setup(args, options)
         setup_config(options)
         log_command
+        @args = args
+        @options = options
       end
 
       def post_setup

--- a/src/command_helpers/bash_command.rb
+++ b/src/command_helpers/bash_command.rb
@@ -32,7 +32,7 @@ module Metalware
     class BashCommand < BaseCommand
       private
 
-      def setup(_args, _options)
+      def setup
         @command = ARGV[0]
         @cli_input = ARGV[1..(ARGV.length - 1)]
       end

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -38,12 +38,11 @@ module Metalware
     class Build < CommandHelpers::BaseCommand
       private
 
-      attr_reader :options, :group_name, :nodes
+      attr_reader :group_name, :nodes
 
       delegate :template_path, to: :file_path
 
       def setup(args, options)
-        @options = options
         node_identifier = args.first
         @group_name = node_identifier if options.group
         @nodes = Nodes.create(config, node_identifier, options.group)

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -42,7 +42,7 @@ module Metalware
 
       delegate :template_path, to: :file_path
 
-      def setup(args, options)
+      def setup
         node_identifier = args.first
         @group_name = node_identifier if options.group
         @nodes = Nodes.create(config, node_identifier, options.group)

--- a/src/commands/configure/domain.rb
+++ b/src/commands/configure/domain.rb
@@ -10,7 +10,7 @@ module Metalware
       class Domain < CommandHelpers::ConfigureCommand
         private
 
-        def setup(_args, _options); end
+        def setup; end
 
         def answers_file
           config.domain_answers_file

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -34,7 +34,7 @@ module Metalware
 
         attr_reader :group_name, :cache
 
-        def setup(args, _options)
+        def setup
           @group_name = args.first
           @cache = GroupCache.new(config)
         end

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -27,8 +27,6 @@ module Metalware
           ]
         end
 
-        attr_reader :node_name
-
         def node
           Metalware::Node.new(config, node_name)
         end

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -12,7 +12,7 @@ module Metalware
 
         attr_reader :node_name
 
-        def setup(args, _options)
+        def setup
           @node_name = args.first
         end
 

--- a/src/commands/configure/rerender.rb
+++ b/src/commands/configure/rerender.rb
@@ -9,7 +9,7 @@ module Metalware
       class Rerender < CommandHelpers::BaseCommand
         private
 
-        def setup(_args, _options); end
+        def setup; end
 
         def run
           DomainTemplatesRenderer.new(config).render

--- a/src/commands/dhcp.rb
+++ b/src/commands/dhcp.rb
@@ -39,7 +39,7 @@ module Metalware
 
       private
 
-      def setup(_args, _options); end
+      def setup; end
 
       def run
         render_template

--- a/src/commands/dhcp.rb
+++ b/src/commands/dhcp.rb
@@ -51,7 +51,7 @@ module Metalware
 
       def dependency_hash
         {
-          repo: ["dhcp/#{@options.template}"],
+          repo: ["dhcp/#{options.template}"],
         }
       end
 
@@ -62,7 +62,7 @@ module Metalware
       end
 
       def template_path
-        File.join(config.repo_path, 'dhcp', @options.template)
+        File.join(config.repo_path, 'dhcp', options.template)
       end
 
       def validate_rendered_template!

--- a/src/commands/dhcp.rb
+++ b/src/commands/dhcp.rb
@@ -39,9 +39,7 @@ module Metalware
 
       private
 
-      def setup(_args, options)
-        @options = options
-      end
+      def setup(_args, _options); end
 
       def run
         render_template

--- a/src/commands/each.rb
+++ b/src/commands/each.rb
@@ -31,7 +31,7 @@ module Metalware
     class Each < CommandHelpers::BaseCommand
       private
 
-      def setup(args, options)
+      def setup
         node_identifier = args[0]
         @nodes = Nodes.create(config, node_identifier, options.group)
         @command = args[1]

--- a/src/commands/hunter.rb
+++ b/src/commands/hunter.rb
@@ -44,7 +44,7 @@ module Metalware
         :hunter_log,
         :network
 
-      def setup(_args, options)
+      def setup
         @hunter_log = MetalLog.new('hunter')
 
         @detection_count = options.start

--- a/src/commands/hunter.rb
+++ b/src/commands/hunter.rb
@@ -42,13 +42,10 @@ module Metalware
         :detected_macs,
         :detection_count,
         :hunter_log,
-        :network,
-        :options
+        :network
 
       def setup(_args, options)
         @hunter_log = MetalLog.new('hunter')
-
-        @options = options
 
         @detection_count = options.start
         @detected_macs = []

--- a/src/commands/remove/group.rb
+++ b/src/commands/remove/group.rb
@@ -31,7 +31,7 @@ module Metalware
   module Commands
     module Remove
       class Group < CommandHelpers::BaseCommand
-        def setup(args, _options)
+        def setup
           @primary_group = args[0]
           @cache = GroupCache.new(config)
         end

--- a/src/commands/render.rb
+++ b/src/commands/render.rb
@@ -35,7 +35,7 @@ module Metalware
       end
 
       def run
-        template_path, maybe_node = @args
+        template_path, maybe_node = args
 
         template_parameters = {
           nodename: maybe_node,

--- a/src/commands/render.rb
+++ b/src/commands/render.rb
@@ -30,9 +30,7 @@ module Metalware
     class Render < CommandHelpers::BaseCommand
       private
 
-      def setup(args, _options)
-        @args = args
-      end
+      def setup(_args, _options); end
 
       def run
         template_path, maybe_node = args

--- a/src/commands/render.rb
+++ b/src/commands/render.rb
@@ -30,7 +30,7 @@ module Metalware
     class Render < CommandHelpers::BaseCommand
       private
 
-      def setup(_args, _options); end
+      def setup; end
 
       def run
         template_path, maybe_node = args

--- a/src/commands/repo/update.rb
+++ b/src/commands/repo/update.rb
@@ -35,7 +35,7 @@ module Metalware
       class Update < CommandHelpers::BaseCommand
         private
 
-        def setup(_args, options)
+        def setup
           @force = !!options.force
         end
 

--- a/src/commands/repo/use.rb
+++ b/src/commands/repo/use.rb
@@ -40,7 +40,7 @@ module Metalware
         end
 
         def run
-          if @options.force
+          if options.force
             FileUtils.rm_rf config.repo_path
             MetalLog.info 'Force deleted old repo'
           end

--- a/src/commands/repo/use.rb
+++ b/src/commands/repo/use.rb
@@ -34,7 +34,7 @@ module Metalware
       class Use < CommandHelpers::BaseCommand
         private
 
-        def setup(args, _options)
+        def setup
           @repo_url = args.first
         end
 

--- a/src/commands/repo/use.rb
+++ b/src/commands/repo/use.rb
@@ -34,9 +34,8 @@ module Metalware
       class Use < CommandHelpers::BaseCommand
         private
 
-        def setup(args, options)
+        def setup(args, _options)
           @repo_url = args.first
-          @options = options
         end
 
         def run

--- a/src/commands/status.rb
+++ b/src/commands/status.rb
@@ -33,7 +33,7 @@ module Metalware
     class Status < CommandHelpers::BaseCommand
       private
 
-      def setup(args, options)
+      def setup
         @opt = options
         if @opt.thread_limit < 1
           raise InvalidInput, 'The thread limit can not be less than 1'

--- a/src/commands/view_answers/domain.rb
+++ b/src/commands/view_answers/domain.rb
@@ -9,7 +9,7 @@ module Metalware
       class Domain < CommandHelpers::BaseCommand
         private
 
-        def setup(_args, _options); end
+        def setup; end
 
         def run
           puts AnswersTableCreator.new(config).domain_table

--- a/src/commands/view_answers/group.rb
+++ b/src/commands/view_answers/group.rb
@@ -11,7 +11,7 @@ module Metalware
 
         attr_reader :group_name
 
-        def setup(args, _options)
+        def setup
           @group_name = args.first
         end
 

--- a/src/commands/view_answers/node.rb
+++ b/src/commands/view_answers/node.rb
@@ -11,7 +11,7 @@ module Metalware
 
         attr_reader :node_name
 
-        def setup(args, _options)
+        def setup
           @node_name = args.first
         end
 

--- a/src/commands/view_config.rb
+++ b/src/commands/view_config.rb
@@ -10,7 +10,7 @@ module Metalware
 
       attr_reader :node_name
 
-      def setup(args, _options)
+      def setup
         @node_name = args.first
       end
 

--- a/src/commands/view_config.rb
+++ b/src/commands/view_config.rb
@@ -8,11 +8,10 @@ module Metalware
     class ViewConfig < CommandHelpers::BaseCommand
       private
 
-      attr_reader :node_name, :options
+      attr_reader :node_name
 
-      def setup(args, options)
+      def setup(args, _options)
         @node_name = args.first
-        @options = options
       end
 
       def run


### PR DESCRIPTION
This PR contains some tidying up of how we handle `args` and `options `in Metalware in some places. The important change here is https://github.com/alces-software/metalware/commit/9b4eb1ca1b82a993b29fbd297fb11450907acda9, which I made so I could access the `options` in multiple `configure` commands without needing to independently set these in their different `setup` methods (the details of this are unimportant; it will be in a future PR). The other changes came out of this, when I spotted a few places we could improve things; see commits for details.