### PR TITLE
Split build command with edit flags

### DIFF
--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -155,7 +155,7 @@ commands:
       - *group_option
       - tags: [--edit-start]
         description: >
-          Only renders the build templates to be editted. Does not wait for the
+          Only renders the build templates to be edited. Does not wait for the
           nodes to be built
       - tags: [--edit-continue]
         description: >

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -153,6 +153,14 @@ commands:
     action: Commands::Build
     options:
       - *group_option
+      - tags: [--edit-start]
+        description: >
+          Only renders the build templates to be editted. Does not wait for the
+          nodes to be built
+      - tags: [--edit-continue]
+        description: >
+          Continues the build process after the files have been editted. Skips
+          the initial template rendering step
 
   configure:
     syntax: metal configure [options]

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -52,7 +52,10 @@ module Metalware
 
       def run
         render_build_templates unless edit_continue
-        return if run_edit_start
+        if edit_start
+          puts(EDIT_START_MSG)
+          return
+        end
         wait_for_nodes_to_build
         teardown
       end
@@ -179,11 +182,6 @@ module Metalware
         The build templates have been rendered and ready to be edited with `metal edit`
         Continue the build process with the `--edit-continue` flag
       EOF
-
-      def run_edit_start
-        puts EDIT_START_MSG if @edit_start
-        @edit_start
-      end
     end
   end
 end

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -32,24 +32,27 @@ require 'node'
 require 'nodes'
 require 'output'
 require 'build_files_retriever'
+require 'exceptions'
 
 module Metalware
   module Commands
     class Build < CommandHelpers::BaseCommand
       private
 
-      attr_reader :group_name, :nodes
+      attr_reader :group_name, :nodes, :edit_start, :edit_continue
 
       delegate :template_path, to: :file_path
 
       def setup
+        setup_edit_mode
         node_identifier = args.first
         @group_name = node_identifier if options.group
         @nodes = Nodes.create(config, node_identifier, options.group)
       end
 
       def run
-        render_build_templates
+        render_build_templates unless edit_continue
+        return if run_edit_start
         wait_for_nodes_to_build
         teardown
       end
@@ -162,6 +165,24 @@ module Metalware
           [yes/no]
         EOF
         render_all_build_complete_templates if agree(should_rerender)
+      end
+
+      EDIT_SETUP_ERROR = 'Can not start and continue editing together'
+
+      def setup_edit_mode
+        @edit_start = options.edit_start
+        @edit_continue = options.edit_continue
+        raise EditModeError, EDIT_SETUP_ERROR if edit_start && edit_continue
+      end
+
+      EDIT_START_MSG = <<-EOF.strip_heredoc
+        The build templates have been rendered and ready to be edited with `metal edit`
+        Continue the build process with the `--edit-continue` flag
+      EOF
+
+      def run_edit_start
+        puts EDIT_START_MSG if @edit_start
+        @edit_start
       end
     end
   end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -150,6 +150,9 @@ module Metalware
 
   class DomainTemplatesInternalError < MetalwareError
   end
+
+  class EditModeError < MetalwareError
+  end
 end
 
 


### PR DESCRIPTION
First commit to implement the `edit` command. This commit concerns itself with how the `edit` command is used with `build`. At this point in time, the easiest way to implement it, is to split the build command into a render then build stages. This can be done with the use of flags on command line. At a latter date we can implement a more durable way to render the templates.