### PR TITLE
Implement the edit command

### DIFF
--- a/bin/autocomplete
+++ b/bin/autocomplete
@@ -45,6 +45,7 @@ class AutoComplete
   def run
     auto_complete_commands
     auto_complete_options
+    auto_complete_set
     return_values
   end
 
@@ -67,6 +68,10 @@ class AutoComplete
         add_return_values(opt['tags'])
       end
     end
+  end
+
+  def auto_complete_set
+    add_return_values(current_hash['autocomplete'].to_s) unless current_hash.empty?
   end
 
   def current_hash

--- a/bin/autocomplete
+++ b/bin/autocomplete
@@ -23,6 +23,7 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
+require 'pathname'
 require 'yaml'
 
 class AutoComplete
@@ -45,7 +46,7 @@ class AutoComplete
   def run
     auto_complete_commands
     auto_complete_options
-    auto_complete_set
+    command_dependent_auto_complete
     return_values
   end
 
@@ -70,8 +71,24 @@ class AutoComplete
     end
   end
 
-  def auto_complete_set
-    add_return_values(current_hash['autocomplete'].to_s) unless current_hash.empty?
+  def command_dependent_auto_complete
+    autocomplete_definition = current_hash.fetch('autocomplete', {})
+
+    # Currently only a single command-dependent auto-complete definition is
+    # supported, to auto-complete file paths relative to a given root path.
+    relative_paths_root = autocomplete_definition['files_relative_to']
+    auto_complete_relative_file_paths(relative_paths_root) if relative_paths_root
+  end
+
+  def auto_complete_relative_file_paths(relative_paths_root)
+    base_path = Pathname.new(relative_paths_root)
+
+    paths = Pathname
+            .glob("#{relative_paths_root}/**/*")
+            .select(&:file?)
+            .map { |path| path.relative_path_from(base_path).to_s }
+
+    add_return_values(paths)
   end
 
   def current_hash

--- a/etc/profile.d/base.sh
+++ b/etc/profile.d/base.sh
@@ -24,8 +24,8 @@ alias met=metal
 
 if [ "$BASH_VERSION" ]; then
     _metal() {
-        local cur="$2" cmds input cur_ruby path cur_path
         local _compreply=()
+        local cur="$2" cmds input cur_ruby
 
         if [[ -z "$cur" ]]; then
             cur_ruby="__CUR_IS_EMPTY__"
@@ -39,20 +39,7 @@ if [ "$BASH_VERSION" ]; then
             bin/autocomplete $cur_ruby ${COMP_WORDS[*]}
         )
 
-        # Completes file paths
-        if [[ $cmds =~ ^COMP_FILE\:\:.*$ ]]; then
-            path=$(echo $cmds | sed s/COMP_FILE:://)
-            if [[ -z "$cur" ]]; then
-                cur_path=$path
-            else
-                cur_path="$path/$cur/"
-            fi
-            COMPREPLY=( $(compgen -f -- ${cur_path}/) )
-
-        # Completes everything else
-        else
-            COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )
-        fi
+        COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )
     }
     complete -o default -F _metal metal me
 fi

--- a/etc/profile.d/base.sh
+++ b/etc/profile.d/base.sh
@@ -24,7 +24,8 @@ alias met=metal
 
 if [ "$BASH_VERSION" ]; then
     _metal() {
-        local cur="$2" cmds input cur_ruby
+        local cur="$2" cmds input cur_ruby path cur_path
+        local _compreply=()
 
         if [[ -z "$cur" ]]; then
             cur_ruby="__CUR_IS_EMPTY__"
@@ -33,12 +34,25 @@ if [ "$BASH_VERSION" ]; then
         fi
 
         cmds=$(
-            cd /opt/metalware &&
+            cd /tmp/metalware &&
             PATH="/opt/metalware/opt/ruby/bin:$PATH"
             bin/autocomplete $cur_ruby ${COMP_WORDS[*]}
         )
 
-        COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )
+        # Completes file paths
+        if [[ $cmds =~ ^COMP_FILE\:\:.*$ ]]; then
+            path=$(echo $cmds | sed s/COMP_FILE:://)
+            if [[ -z "$cur" ]]; then
+                cur_path=$path
+            else
+                cur_path="$path/$cur/"
+            fi
+            COMPREPLY=( $(compgen -f -- ${cur_path}/) )
+        
+        # Completes everything else
+        else
+            COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )
+        fi
     }
     complete -o default -F _metal metal me
 fi

--- a/etc/profile.d/base.sh
+++ b/etc/profile.d/base.sh
@@ -48,7 +48,7 @@ if [ "$BASH_VERSION" ]; then
                 cur_path="$path/$cur/"
             fi
             COMPREPLY=( $(compgen -f -- ${cur_path}/) )
-        
+
         # Completes everything else
         else
             COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )

--- a/etc/profile.d/base.sh
+++ b/etc/profile.d/base.sh
@@ -24,7 +24,6 @@ alias met=metal
 
 if [ "$BASH_VERSION" ]; then
     _metal() {
-        local _compreply=()
         local cur="$2" cmds input cur_ruby
 
         if [[ -z "$cur" ]]; then

--- a/etc/profile.d/base.sh
+++ b/etc/profile.d/base.sh
@@ -34,7 +34,7 @@ if [ "$BASH_VERSION" ]; then
         fi
 
         cmds=$(
-            cd /tmp/metalware &&
+            cd /opt/metalware &&
             PATH="/opt/metalware/opt/ruby/bin:$PATH"
             bin/autocomplete $cur_ruby ${COMP_WORDS[*]}
         )

--- a/spec/shared_examples/render_domain_templates.rb
+++ b/spec/shared_examples/render_domain_templates.rb
@@ -135,7 +135,7 @@ RSpec.shared_examples :render_domain_templates do |test_command|
         ).to eq(existing_genders_contents)
 
         # Invalid rendered genders available for inspection.
-        expected_invalid_rendered_genders = "some genders template 0"
+        expected_invalid_rendered_genders = 'some genders template 0'
         expect(
           File.read(Metalware::Constants::INVALID_RENDERED_GENDERS_PATH)
         ).to include(expected_invalid_rendered_genders)

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Metalware::Templater do
 
   describe '#render_managed_file' do
     # XXX Similar to above.
-    let :template { "simple template without ERB" }
+    let :template { 'simple template without ERB' }
     let :output_path { '/output' }
     let :output { File.read(output_path) }
 

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -211,9 +211,9 @@ commands:
     summary: Opens a rendered file for editing
     description: >
       Opens the specified rendered file in the default system text editor.
-      Requires the absolute path to the file to be edited.
     action: Commands::Edit
-    autocomplete: COMP_FILE::/var/lib/metalware/rendered
+    autocomplete:
+      files_relative_to: /var/lib/metalware/rendered
 
   hunter:
     syntax: metal hunter [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -206,6 +206,15 @@ commands:
     options:
       - *group_option
 
+  edit:
+    syntax: metal edit FILE [options]
+    summary: Opens a rendered file for editing
+    description: >
+      Opens the specified rendered file in the default system text editor.
+      Requires the absolute path to the file to be edited.
+    action: Commands::Edit
+    autocomplete: COMP_FILE::/var/lib/metalware/rendered
+
   hunter:
     syntax: metal hunter [options]
     summary: Detects and caches DHCP discover messages

--- a/src/cli_helper/parser.rb
+++ b/src/cli_helper/parser.rb
@@ -77,6 +77,7 @@ module Metalware
                 subcommand = "#{command} #{subcommand}"
                 parse_command_attributes(subcommand, subattributes)
               end
+            when 'autocomplete'
             else
               c.send("#{a}=", v.respond_to?(:chomp) ? v.chomp : v)
             end

--- a/src/cli_helper/parser.rb
+++ b/src/cli_helper/parser.rb
@@ -78,6 +78,7 @@ module Metalware
                 parse_command_attributes(subcommand, subattributes)
               end
             when 'autocomplete'
+              # Intentionally left blank
             else
               c.send("#{a}=", v.respond_to?(:chomp) ? v.chomp : v)
             end

--- a/src/cli_helper/parser.rb
+++ b/src/cli_helper/parser.rb
@@ -78,7 +78,7 @@ module Metalware
                 parse_command_attributes(subcommand, subattributes)
               end
             when 'autocomplete'
-              # Intentionally left blank
+              # Intentionally left blank as it is used by autocomplete only
             else
               c.send("#{a}=", v.respond_to?(:chomp) ? v.chomp : v)
             end

--- a/src/commands/edit.rb
+++ b/src/commands/edit.rb
@@ -24,16 +24,17 @@
 
 require 'system_command'
 require 'metal_log'
+require 'file_path'
 
 module Metalware
   module Commands
     class Edit < CommandHelpers::BaseCommand
       private
 
-      attr_reader :file
+      attr_reader :relative_file_path
 
       def setup
-        @file = args[0]
+        @relative_file_path = args[0]
       end
 
       def run
@@ -43,9 +44,9 @@ module Metalware
       end
 
       def editor
-        if !system_visual.empty?
+        if system_visual
           system_visual
-        elsif !system_editor.empty?
+        elsif system_editor
           system_editor
         else
           'vi'
@@ -53,11 +54,19 @@ module Metalware
       end
 
       def system_visual
-        @system_visual ||= SystemCommand.run('echo $VISUAL').chomp
+        ENV['VISUAL']
       end
 
       def system_editor
-        @system_editor ||= SystemCommand.run('echo $EDITOR').chomp
+        ENV['EDITOR']
+      end
+
+      def file
+        File.join(file_path.metalware_data, 'rendered', relative_file_path)
+      end
+
+      def file_path
+        @file_path ||= FilePath.new(config)
       end
     end
   end

--- a/src/commands/edit.rb
+++ b/src/commands/edit.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'system_command'
+require 'metal_log'
+
+module Metalware
+  module Commands
+    class Edit < CommandHelpers::BaseCommand
+      private
+
+      attr_reader :file
+
+      def setup
+        @file = args[0]
+      end
+
+      def run
+        cmd = "#{editor} #{file}"
+        MetalLog.info("exec: #{cmd}")
+        exec(cmd)
+      end
+
+      def editor
+        if !system_visual.empty?
+          system_visual
+        elsif !system_editor.empty?
+          system_editor
+        else
+          'vi'
+        end
+      end
+
+      def system_visual
+        @system_visual ||= SystemCommand.run('echo $VISUAL').chomp
+      end
+
+      def system_editor
+        @system_editor ||= SystemCommand.run('echo $EDITOR').chomp
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fairly small PR that implements the edit command. When I was linking in the autocomplete, I couldn't get it working well with relative paths, but I could use absolute. So instead of taking a relative path within the `rendered` directory, the user can tab complete `/var/lib/metalware/rendered` and then select the file from there.

It does mean the edit command can open any file in the filesystem, however this shouldn't be a big deal. Currently it uses the editor defined by VISUAL first or EDITOR as a fallback. If both haven't been set, then `vi` is used. Possible add a message about using `vi`?