### PR TITLE
Restart named after each update

### DIFF
--- a/spec/dns/named_spec.rb
+++ b/spec/dns/named_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Metalware::DNS::Named do
       allow(named).to receive(:setup?).and_return(false)
       # Prevents restart_named from running as the bash commands can't be mocked
       allow(named).to receive(:restart_named)
+      allow(named).to receive(:start_named)
     end
 
     it "errors if external dns isn't set" do
@@ -74,7 +75,8 @@ RSpec.describe Metalware::DNS::Named do
     before :each do
       allow(named).to receive(:setup?).and_return(true)
       # Prevents restart_named from accidentally running, DANGEROUS
-      expect(named).not_to receive(:restart_named)
+      expect(named).not_to receive(:start_named)
+      expect(named).to receive(:restart_named)
     end
 
     it 'skips setup but updates named server' do

--- a/spec/dns/named_spec.rb
+++ b/spec/dns/named_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Metalware::DNS::Named do
   context 'with a setup named server' do
     before :each do
       allow(named).to receive(:setup?).and_return(true)
-      # Prevents restart_named from accidentally running, DANGEROUS
+      # Checks the bash commands run without running them
       expect(named).not_to receive(:start_named)
       expect(named).to receive(:restart_named)
     end

--- a/src/dns/named.rb
+++ b/src/dns/named.rb
@@ -45,6 +45,7 @@ module Metalware
           render_zone_template('forward', zone, net)
           render_zone_template('reverse', zone, net)
         end
+        restart_named
       end
 
       private
@@ -58,7 +59,7 @@ module Metalware
       def setup
         check_external_dns_is_set
         render_base_named_conf
-        restart_named
+        start_named
       end
 
       def setup?
@@ -96,18 +97,22 @@ module Metalware
 
       # TODO: These commands will break hosts DNS. Might be a good idea to run
       # similar commands for hosts
-      RESTART_NAMED_CMDS = [
+      START_NAMED_CMDS = [
         'systemctl disable dnsmasq',
         'systemctl stop dnsmasq',
         'systemctl enable named',
-        'systemctl restart named',
       ].freeze
 
-      def restart_named
+      def start_named
         MetalLog.info 'Restarting named'
-        RESTART_NAMED_CMDS.each do |cmd|
+        START_NAMED_CMDS.each do |cmd|
           SystemCommand.run(cmd)
         end
+        restart_named
+      end
+
+      def restart_named
+        SystemCommand.run('systemctl restart named')
       end
 
       def each_network

--- a/src/dns/named.rb
+++ b/src/dns/named.rb
@@ -97,22 +97,30 @@ module Metalware
 
       # TODO: These commands will break hosts DNS. Might be a good idea to run
       # similar commands for hosts
+      RESTART_NAMED_CMDS = [
+        'systemctl restart named',
+      ].freeze
+
       START_NAMED_CMDS = [
         'systemctl disable dnsmasq',
         'systemctl stop dnsmasq',
         'systemctl enable named',
-      ].freeze
+      ].concat(RESTART_NAMED_CMDS).freeze
 
       def start_named
-        MetalLog.info 'Restarting named'
-        START_NAMED_CMDS.each do |cmd|
-          SystemCommand.run(cmd)
-        end
-        restart_named
+        MetalLog.info 'Starting named'
+        loop_system_command(START_NAMED_CMDS)
       end
 
       def restart_named
-        SystemCommand.run('systemctl restart named')
+        MetalLog.info 'Restarting named'
+        loop_system_command(RESTART_NAMED_CMDS)
+      end
+
+      def loop_system_command(cmds)
+        cmds.each do |cmd|
+          SystemCommand.run(cmd)
+        end
       end
 
       def each_network


### PR DESCRIPTION
Fixes the issue logged in #108 

Named needs to be restarted when ever an update command is ran, not
only when it is started.

The methods have been slightly renamed. During setup, start_named is
called to run the bash commands which end with restart_named. But if
named, has already been setup, then restart_named is called only.

The test have been updated to reflect this