### PR TITLE
Fixes Validation::Configure ignore failures bug

### DIFF
--- a/spec/shared_examples/render_domain_templates.rb
+++ b/spec/shared_examples/render_domain_templates.rb
@@ -135,7 +135,7 @@ RSpec.shared_examples :render_domain_templates do |test_command|
         ).to eq(existing_genders_contents)
 
         # Invalid rendered genders available for inspection.
-        expected_invalid_rendered_genders = "some genders template 0"
+        expected_invalid_rendered_genders = 'some genders template 0'
         expect(
           File.read(Metalware::Constants::INVALID_RENDERED_GENDERS_PATH)
         ).to include(expected_invalid_rendered_genders)

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Metalware::Templater do
 
   describe '#render_managed_file' do
     # XXX Similar to above.
-    let :template { "simple template without ERB" }
+    let :template { 'simple template without ERB' }
     let :output_path { '/output' }
     let :output { File.read(output_path) }
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe Metalware::Validation::Configure do
           type: 'integer',
           default: 10,
         },
+        boolean_true: {
+          question: 'Can I have a boolean true (/yes) default?',
+          type: 'boolean',
+          default: 'yes',
+        }
       },
 
       group: {
@@ -54,6 +59,11 @@ RSpec.describe Metalware::Validation::Configure do
           question: 'Am I a integer question without a default?',
           type: 'integer',
         },
+        boolean_false: {
+          question: 'Can I have a boolean false (/no) default?',
+          type: 'boolean',
+          default: 'no',
+        }
       },
 
       node: {
@@ -236,6 +246,19 @@ RSpec.describe Metalware::Validation::Configure do
                                     },
                                   })
       expect(run_configure_validation(h).keys).to eq([:default_integer_type])
+    end
+  end
+
+  context 'with invalid boolean questions' do
+    it 'fails with non-boolean default' do
+      h = correct_hash.deep_merge(node: {
+                                    bad_integer_question: {
+                                      question: 'Do I fail because my default is a string?',
+                                      type: 'boolean',
+                                      default: 'I am not valid',
+                                    },
+                                  })
+      expect(run_configure_validation(h).keys).to eq([:default_boolean_type])
     end
   end
 end

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe Metalware::Validation::Configure do
           type: 'string',
           default: 'yes I am a string',
         },
+        string_empty_default: {
+          question: 'My default is a empty string?',
+          default: '',
+        },
       },
     }
   end
@@ -109,7 +113,7 @@ RSpec.describe Metalware::Validation::Configure do
                                     type: 'string',
                                     default: 'Each field will now be interpreted as a separate question',
                                   })
-      results = run_configure_validation(h)
+      results = build_validator(h).validate.errors
       expect(results.keys).to eq([:parameters])
       expect(results[:parameters][0]).to eq('must be a hash')
     end
@@ -157,17 +161,6 @@ RSpec.describe Metalware::Validation::Configure do
                                   })
       results = run_configure_validation(h)
       expect(results[:parameters].keys).to eq([:type])
-    end
-
-    it 'fails if default is empty' do
-      h = correct_hash.deep_merge(domain: {
-                                    empty_default: {
-                                      question: 'Do I have an empty default?',
-                                      default: '',
-                                    },
-                                  })
-      results = run_configure_validation(h)
-      expect(results[:parameters].keys).to eq([:default])
     end
 
     it 'fails if the optional input is not true or false' do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -66,9 +66,13 @@ RSpec.describe Metalware::Validation::Configure do
     }
   end
 
-  def run_configure_validation(my_hash = {})
+  def build_validator(my_hash = {})
     allow(Metalware::Data).to receive(:load).and_return(my_hash)
-    validator = Metalware::Validation::Configure.new('path/has/been/mocked')
+    Metalware::Validation::Configure.new('path/has/been/mocked')
+  end
+
+  def run_configure_validation(my_hash = {})
+    validator = build_validator(my_hash)
     validator.validate.messages
   end
 
@@ -215,6 +219,17 @@ RSpec.describe Metalware::Validation::Configure do
                                     },
                                   })
       expect(run_configure_validation(h).keys).to eq([:default_string_type])
+    end
+
+    it 'returns a success? status of false' do
+       h = correct_hash.deep_merge(group: {
+                                    bad_string_question: {
+                                      question: "Do I fail because my default isn't a string?",
+                                      type: 'string',
+                                      default: 10,
+                                    },
+                                  })
+       expect(build_validator(h).success?).to eq(false)
     end
   end
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Metalware::Validation::Configure do
           question: 'Can I have a boolean true (/yes) default?',
           type: 'boolean',
           default: 'yes',
-        }
+        },
       },
 
       group: {
@@ -63,7 +63,7 @@ RSpec.describe Metalware::Validation::Configure do
           question: 'Can I have a boolean false (/no) default?',
           type: 'boolean',
           default: 'no',
-        }
+        },
       },
 
       node: {
@@ -225,14 +225,14 @@ RSpec.describe Metalware::Validation::Configure do
     end
 
     it 'returns a success? status of false' do
-       h = correct_hash.deep_merge(group: {
+      h = correct_hash.deep_merge(group: {
                                     bad_string_question: {
                                       question: "Do I fail because my default isn't a string?",
                                       type: 'string',
                                       default: 10,
                                     },
                                   })
-       expect(build_validator(h).success?).to eq(false)
+      expect(build_validator(h).success?).to eq(false)
     end
   end
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -247,6 +247,17 @@ RSpec.describe Metalware::Validation::Configure do
                                   })
       expect(run_configure_validation(h).keys).to eq([:default_integer_type])
     end
+
+    it 'fails if the default is an empty string' do
+      h = correct_hash.deep_merge(node: {
+                                    bad_integer_question: {
+                                      question: 'Do I fail because my default is an empty string?',
+                                      type: 'integer',
+                                      default: '',
+                                    },
+                                  })
+      expect(run_configure_validation(h).keys).to eq([:default_empty_string_type])
+    end
   end
 
   context 'with invalid boolean questions' do

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -85,6 +85,10 @@ module Metalware
           def boolean?(value)
             BOOLEAN_VALUE.include?(value)
           end
+
+          def empty_string?(value)
+            value.is_a?(String) && value.empty?
+          end
         end
 
         validate(valid_top_level_question_keys: :parameters) do |q|
@@ -103,6 +107,11 @@ module Metalware
           # as simple as possible otherwise the error message will be crazy
           rule(default_string_type: [:default, :type]) do |default, type|
             (default.filled? & (type.none? | type.eql?('string'))) > default.str?
+          end
+
+          # Enforces empty string defaults have a string type
+          rule(default_empty_string_type: [:default, :type]) do |default, type|
+            default.empty_string? > (type.none? | type.eql?('string'))
           end
 
           rule(default_integer_type: [:default, :type]) do |default, type|

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -24,6 +24,7 @@
 require 'exceptions'
 require 'data'
 require 'dry-validation'
+require 'active_support/core_ext/module/delegation'
 
 module Metalware
   module Validation
@@ -61,9 +62,7 @@ module Metalware
         end
       end
 
-      def success?
-        validate.success?
-      end
+      delegate :success?, to: :validate
 
       # TODO: make these error messages more descriptive
       def load

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -34,6 +34,7 @@ module Metalware
 
       # NOTE: Supported types in error.yaml message must be updated manually
       SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'choice'].freeze
+      BOOLEAN_VALUE = ['yes', 'no'].freeze
       ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
       def initialize(file)
@@ -80,6 +81,10 @@ module Metalware
           def question_type?(value)
             SUPPORTED_TYPES.include?(value)
           end
+
+          def boolean?(value)
+            BOOLEAN_VALUE.include?(value)
+          end
         end
 
         validate(valid_top_level_question_keys: :parameters) do |q|
@@ -104,9 +109,13 @@ module Metalware
             (default.filled? & type.eql?('integer')) > default.int?
           end
 
-          # Boolean and choice does not currently support default answers
           rule(default_boolean_type: [:default, :type]) do |default, type|
-            default.none? | type.excluded_from?(['boolean', 'choice'])
+            (default.filled? & type.eql?('boolean')) > default.boolean?
+          end
+
+          # Choice does not currently support default answers
+          rule(default_choice_type: [:default, :type]) do |default, type|
+            default.none? | type.excluded_from?(['choice'])
           end
         end
       end

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -90,7 +90,7 @@ module Metalware
         required(:parameters).schema do
           required(:question).value(:str?, :filled?)
           optional(:type).value(:question_type?)
-          optional(:default).value(:filled?)
+          optional(:default) { filled? | str? }
           optional(:optional).value(:bool?)
 
           # NOTE: The crazy logic on the LHS of the then ('>') is because

--- a/src/validation/errors.yaml
+++ b/src/validation/errors.yaml
@@ -16,6 +16,8 @@ en:
           Type mismatch between question 'type' and 'default' value
         boolean?: >
           Boolean defaults must be 'yes' or 'no'
+        empty_string?:
+          Empty string defaults must have a string type
 
       answer:
         missing_questions?: >

--- a/src/validation/errors.yaml
+++ b/src/validation/errors.yaml
@@ -14,6 +14,8 @@ en:
           'default' 'choice', 'optional'
         default_type?: >
           Type mismatch between question 'type' and 'default' value
+        boolean?: >
+          Boolean defaults must be 'yes' or 'no'
 
       answer:
         missing_questions?: >


### PR DESCRIPTION
Previously the `validate` method on `Validation::Configure` would return an object which contains if the validation succeeded or not. However this was not the object that `success?` used. Instead a stale instance variable was used and thus the validation could fail but still return true. This PR fixes the bug by saving the return object of `validate` as the instance variable.

Also added additional validation checks to allow empty strings as a valid default and to allow `Boolean` default values. Previously these caused the validation to fail but it wasn't being detected due to the previously mentioned bug.