### PR TITLE
Create the `configure self` command

### DIFF
--- a/spec/minimal_repo.rb
+++ b/spec/minimal_repo.rb
@@ -41,7 +41,8 @@ module MinimalRepo
       'configure.yaml': YAML.dump(questions: {},
                                   domain: {},
                                   group: {},
-                                  node: {}),
+                                  node: {},
+                                  self: {}),
       # Define the build interface to be whatever the first interface is; this
       # should always be sufficient for testing purposes.
       'server.yaml': YAML.dump(build_interface: NetworkInterface.interfaces.first),

--- a/spec/validation/answer_spec.rb
+++ b/spec/validation/answer_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Metalware::Validation::Answer do
 
       group: {},
       node: {},
+      self: {},
     }
   end
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe Metalware::Validation::Configure do
           default: '',
         },
       },
+
+      self: {},
     }
   end
 

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -69,6 +69,15 @@ subcommands:
       templates themselves.
     action: Commands::Configure::Rerender
 
+  configure_self: &configure_self
+    syntax: metal configure self [options]
+    summary: Configure the master Metalware node
+    description: >
+      Configures the node that metalware is running on. This is treated as the
+      metalware master node. This must be ran to configure metalware to match
+      the system environment. This command is intended to only be ran once.
+    action: Commands::Configure::Self
+
   remove_group: &remove_group
     syntax: metal remove group GROUP_NAME [options]
     summary: Removes a previously configured group
@@ -183,6 +192,7 @@ commands:
       group: *configure_group
       node: *configure_node
       rerender: *configure_rerender
+      self: *configure_self
 
   console:
     syntax: metal console NODE_IDENTIFIER [options]

--- a/src/commands/configure/self.rb
+++ b/src/commands/configure/self.rb
@@ -1,0 +1,21 @@
+
+# frozen_string_literal: true
+
+require 'command_helpers/configure_command'
+require 'constants'
+
+module Metalware
+  module Commands
+    module Configure
+      class Self < CommandHelpers::ConfigureCommand
+        private
+
+        def setup; end
+
+        def answers_file
+          file_path.self_answers
+        end
+      end
+    end
+  end
+end

--- a/src/dependency.rb
+++ b/src/dependency.rb
@@ -72,6 +72,8 @@ module Metalware
 
     def validate_answer_file(relative_path)
       case relative_path
+      when 'self.yaml'
+        loader.self_answers
       when 'domain.yaml'
         loader.domain_answers
       when /^groups\/.+/

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -49,6 +49,10 @@ module Metalware
       config.node_answers_file(node)
     end
 
+    def self_answers
+      File.join(answer_files, 'self.yaml')
+    end
+
     def repo
       config.repo_path
     end
@@ -92,6 +96,10 @@ module Metalware
 
     def repo_template(template_type, node:)
       (node.repo_config[:templates] || {})[template_type]
+    end
+
+    def answer_files
+      config.answer_files_path
     end
   end
 end

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -50,7 +50,7 @@ module Metalware
     end
 
     def self_answers
-      File.join(answer_files, 'self.yaml')
+      File.join(answer_files, 'nodes/self.yaml')
     end
 
     def repo

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -46,7 +46,7 @@ module Metalware
         @validate ||= begin
           configure_results = ConfigureSchema.call(yaml: @yaml)
           if configure_results.success?
-            [:domain, :group, :node].each do |section|
+            [:domain, :group, :node, :self].each do |section|
               @yaml[section].each do |identifier, parameters|
                 payload = {
                   section: section,
@@ -136,7 +136,7 @@ module Metalware
 
         # White-lists the keys allowed in the configure.yaml file
         validate(valid_top_level_keys: :yaml) do |yaml|
-          (yaml.keys - [:domain, :group, :node, :questions]).empty?
+          (yaml.keys - [:domain, :self, :group, :node, :questions]).empty?
         end
 
         required(:yaml).schema do

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -43,6 +43,10 @@ module Metalware
         Data.load(path.group_cache)
       end
 
+      def self_answers
+        answer(path.self_answers, :self)
+      end
+
       def domain_answers
         answer(path.domain_answers, :domain)
       end


### PR DESCRIPTION
Based on the updated Validation. Please merge #178 first.

This is the first step for configuring the node metalware runs on. This will be defined as the `self` node. Currently the command runs the standard domain level template rerender.

However it does not add the `self` node to `/etc/hosts` or the genders file. I am not sure if this will be required so it has not been included in this PR. Future PR's will allow the building of the `self` node.