### PR TITLE
Support the `build self` command

### DIFF
--- a/spec/answers_table_creator_spec.rb
+++ b/spec/answers_table_creator_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Metalware::AnswersTableCreator do
         question_2: { question: 'question 2', type: 'integer' },
         question_3: { question: 'question 3' },
       },
+      self: {},
     }
   end
 

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -71,13 +71,11 @@ RSpec.describe Metalware::Commands::Build do
   def run_build(node_identifier, **options_hash)
     # Run command in timeout as `build` will wait indefinitely, but want to
     # abort tests if it looks like this is happening.
-    result = Timeout.timeout 0.5 do
+    Timeout.timeout 0.5 do
       Metalware::Utils.run_command(
         Metalware::Commands::Build, node_identifier, **options_hash
       )
     end
-    expect(Thread.list.length).to eq(1)
-    result
   end
 
   # Makes `Node.new` return real `Node`s, but with certain methods stubbed to

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -62,14 +62,22 @@ end
 RSpec.describe Metalware::Commands::Build do
   let :metal_config { Metalware::Config.new }
 
+  before :each do
+    Thread.list.each do |th|
+      th.kill unless th == Thread.main
+    end
+  end
+
   def run_build(node_identifier, **options_hash)
     # Run command in timeout as `build` will wait indefinitely, but want to
     # abort tests if it looks like this is happening.
-    Timeout.timeout 0.5 do
+    result = Timeout.timeout 0.5 do
       Metalware::Utils.run_command(
         Metalware::Commands::Build, node_identifier, **options_hash
       )
     end
+    expect(Thread.list.length).to eq(1)
+    result
   end
 
   # Makes `Node.new` return real `Node`s, but with certain methods stubbed to

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -288,12 +288,12 @@ RSpec.describe Metalware::Node do
     end
 
     context 'with a regular node' do
-      it 'returns the default (/kickstart) build type if not specified' do
+      it 'returns the default (/kickstart) build method if not specified' do
         expected = Metalware::BuildMethods::Kickstarts::Pxelinux
         expect(build_method_class('build_node', nil)).to eq(expected)
       end
 
-      it 'returns the build type if specified' do
+      it 'returns the build method if specified' do
         expected = Metalware::BuildMethods::Basic
         expect(build_method_class('build_node', :basic)).to eq(expected)
       end
@@ -306,17 +306,17 @@ RSpec.describe Metalware::Node do
     end
 
     context "with the 'self' node" do
-      it 'returns the self build type if not specified' do
+      it 'returns the self build method if not specified' do
         expected = Metalware::BuildMethods::Self
         expect(build_method_class('self', nil)).to eq(expected)
       end
 
-      it 'returns the self build type if specified' do
+      it 'returns the self build method if specified' do
         expected = Metalware::BuildMethods::Self
         expect(build_method_class('self', :self)).to eq(expected)
       end
 
-      it 'errors if the build type is not self' do
+      it 'errors if the build method is not self' do
         expect do
           build_method_class('self', :basic)
         end.to raise_error(Metalware::SelfBuildMethodError)

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -296,6 +296,12 @@ RSpec.describe Metalware::Node do
         expected = Metalware::BuildMethods::Basic
         expect(build_method_class('build_node', :basic)).to eq(expected)
       end
+
+      it 'errors if the self build method is used' do
+        expect do
+          build_method_class('build_node', :self)
+        end.to raise_error(Metalware::SelfBuildMethodError)
+      end
     end
 
     context "with the 'self' node" do
@@ -310,7 +316,9 @@ RSpec.describe Metalware::Node do
       end
 
       it 'errors if the build type is not self' do
-        expect { build_method_class('self', :basic) }.to raise_error
+        expect do
+          build_method_class('self', :basic)
+        end.to raise_error(Metalware::SelfBuildMethodError)
       end
     end
   end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe Metalware::Node do
 
     context 'with a regular node' do
       it 'returns the default (/kickstart) build type if not specified' do
-        expected = Metalware::BuildMethods::Kickstart
+        expected = Metalware::BuildMethods::Kickstarts::Pxelinux
         expect(build_method_class('build_node', nil)).to eq(expected)
       end
 

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -221,6 +221,7 @@ RSpec.describe Metalware::Node do
           domain: questions,
           group: questions,
           node: questions,
+          self: {},
         }
         fs.dump(config.configure_file, configure)
       end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Metalware::Repo do
         node: {
           baz: { question: 'baz' },
         },
+        self:{},
       }
       fs.dump('/var/lib/metalware/repo/configure.yaml', configure_data)
     end

--- a/spec/templating/configuration_spec.rb
+++ b/spec/templating/configuration_spec.rb
@@ -1,0 +1,53 @@
+
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'templating/configuration'
+require 'config'
+require 'node'
+
+RSpec.describe Metalware::Templating::Configuration do
+  let :config { Metalware::Config.new }
+  let :testnode do
+    double('Metalware::Node',
+           groups: ['group1', 'group2'],
+           name: 'testnode')
+  end
+
+  def configuration_node(node_name)
+    Metalware::Templating::Configuration.for_node(node_name, config: config)
+  end
+
+  describe '#configs' do
+    it 'returns domain and self for the metalware master node' do
+      expect(configuration_node('self').configs).to eq(['domain', 'self'])
+    end
+
+    it 'returns the configs for a regular node' do
+      allow(Metalware::Node).to receive(:new).and_return(testnode)
+      expected_configs = ['domain', 'group2', 'group1', testnode.name]
+      expect(configuration_node(testnode.name).configs).to eq(expected_configs)
+    end
+  end
+end

--- a/spec/templating/configuration_spec.rb
+++ b/spec/templating/configuration_spec.rb
@@ -35,19 +35,20 @@ RSpec.describe Metalware::Templating::Configuration do
            name: 'testnode')
   end
 
-  def configuration_node(node_name)
+  def node_config(node_name)
     Metalware::Templating::Configuration.for_node(node_name, config: config)
+                                        .configs
   end
 
   describe '#configs' do
     it 'returns domain and self for the metalware master node' do
-      expect(configuration_node('self').configs).to eq(['domain', 'self'])
+      expect(node_config('self')).to eq(['domain', 'self'])
     end
 
     it 'returns the configs for a regular node' do
       allow(Metalware::Node).to receive(:new).and_return(testnode)
       expected_configs = ['domain', 'group2', 'group1', testnode.name]
-      expect(configuration_node(testnode.name).configs).to eq(expected_configs)
+      expect(node_config(testnode.name)).to eq(expected_configs)
     end
   end
 end

--- a/src/build_methods/build_method.rb
+++ b/src/build_methods/build_method.rb
@@ -29,6 +29,12 @@ module Metalware
         end
       end
 
+      def start_build
+        # Runs after the files have been rendered but before build waits for the
+        # nodes to complete. Leave blank if the nodes build need to be started
+        # manually by powering them on.
+      end
+
       private
 
       attr_reader :config, :node

--- a/src/build_methods/build_method.rb
+++ b/src/build_methods/build_method.rb
@@ -41,9 +41,7 @@ module Metalware
 
       def render_template(template_type, parameters:, save_path: nil)
         template_type_path = template_path template_type, node: node
-        save_path ||= File.join(
-          config.rendered_files_path, template_type.to_s, node.name
-        )
+        save_path ||= file_path.template_save_path(template_type, node: node)
         Templater.render_to_file(config, template_type_path, save_path, parameters)
       end
     end

--- a/src/build_methods/self.rb
+++ b/src/build_methods/self.rb
@@ -1,0 +1,18 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  module BuildMethods
+    class Self < BuildMethod
+      TEMPLATES = [:self].freeze
+
+      def render_build_started_templates(parameters)
+        render_template(:self, parameters: parameters)
+      end
+
+      def render_build_complete_templates(_parameters); end
+
+      private
+    end
+  end
+end

--- a/src/build_methods/self.rb
+++ b/src/build_methods/self.rb
@@ -1,6 +1,8 @@
 
 # frozen_string_literal: true
 
+require 'system_command'
+
 module Metalware
   module BuildMethods
     class Self < BuildMethod
@@ -8,6 +10,11 @@ module Metalware
 
       def render_build_started_templates(parameters)
         render_template(:self, parameters: parameters)
+      end
+
+      def start_build
+        rendered_self_template = file_path.template_save_path(:self, node: node)
+        puts SystemCommand.run("bash #{rendered_self_template}")
       end
 
       def render_build_complete_templates(_parameters); end

--- a/src/build_methods/self.rb
+++ b/src/build_methods/self.rb
@@ -11,8 +11,6 @@ module Metalware
       end
 
       def render_build_complete_templates(_parameters); end
-
-      private
     end
   end
 end

--- a/src/build_methods/self.rb
+++ b/src/build_methods/self.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'system_command'
+require 'fileutils'
 
 module Metalware
   module BuildMethods
@@ -14,7 +15,8 @@ module Metalware
 
       def start_build
         rendered_self_template = file_path.template_save_path(:self, node: node)
-        puts SystemCommand.run("bash #{rendered_self_template}")
+        FileUtils.chmod 'u+x', rendered_self_template
+        puts SystemCommand.run(rendered_self_template)
       end
 
       def render_build_complete_templates(_parameters); end

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -155,8 +155,8 @@ commands:
       then waiting for each node to report itself as built and re-rendering its
       'pxelinux' template for permanent booting. The build command will keep
       running until all nodes have reported as built, or until it is
-      interrupted. The 'self' build is a special case that is handled seperately
-      . See below for more details.
+      interrupted. The 'self' build is a special case that is handled separately.
+      See below for more details.
 
 
       The 'files' for each node are specified under the 'files' key in the repo

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -155,7 +155,8 @@ commands:
       then waiting for each node to report itself as built and re-rendering its
       'pxelinux' template for permanent booting. The build command will keep
       running until all nodes have reported as built, or until it is
-      interrupted.
+      interrupted. The 'self' build is a special case that is handled seperately
+      . See below for more details.
 
 
       The 'files' for each node are specified under the 'files' key in the repo
@@ -171,6 +172,14 @@ commands:
       The 'pxelinux' template rendering can be modified using the
       'alces.firstboot' parameter within the template, which will be set to
       'true' the first time this is rendered and 'false' the second.
+
+
+      As the 'build self' command is repsonsible for configuring the metalware
+      master node, it functions differently to the other nodes. The build self
+      command is responsible for starting the http server and thus can not curl
+      for files. Instead it must directly access the file system to obtain the
+      rendered files. Once the build has been completed, it can either curl the
+      build_complete_url or create the build_complete file directly.
 
     action: Commands::Build
     options:

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -60,6 +60,7 @@ module Metalware
           puts(EDIT_START_MSG)
           return
         end
+        start_build
         wait_for_nodes_to_build
         teardown
       rescue
@@ -112,6 +113,10 @@ module Metalware
             Templater.render_to_file(config, file[:template_path], render_path, parameters)
           end
         end
+      end
+
+      def start_build
+        nodes.each(&:start_build)
       end
 
       def wait_for_nodes_to_build

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -116,7 +116,17 @@ module Metalware
       end
 
       def start_build
-        nodes.each(&:start_build)
+        nodes.each do |node|
+          build_threads.add(Thread.new { node.start_build })
+        end
+      end
+
+      def build_threads
+        @build_threads ||= ThreadGroup.new
+      end
+
+      def clear_up_build_threads
+        build_threads.list.map(&:kill)
       end
 
       def wait_for_nodes_to_build
@@ -183,6 +193,7 @@ module Metalware
 
       def teardown
         clear_up_built_node_marker_files
+        clear_up_build_threads
         Output.info 'Done.'
       end
 

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -51,5 +51,7 @@ module Metalware
     NAMED_TEMPLATE_PATH = File.join(METALWARE_INSTALL_PATH, 'templates/named.conf.erb')
     METALWARE_NAMED_PATH = '/etc/named/metalware.conf'
     VAR_NAMED_PATH = '/var/named'
+
+    CONFIGURE_SECTIONS = [:domain, :group, :node, :self].freeze
   end
 end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -163,8 +163,8 @@ module Metalware
   class SelfBuildMethodError < MetalwareError
     def initialize(build_method: nil, building_self_node: true)
       msg = if build_method
-              "The '#{build_method}' build method can not be used for the self" \
-              "node. The self node can only be built with the 'self' build type"
+              "The '#{build_method}' build method can not be used for the self " \
+              "node. The self node can only be built with the 'self' build method"
             elsif building_self_node
               'The self build method has had an unexpected error'
             else

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -161,14 +161,14 @@ module Metalware
   end
 
   class SelfBuildMethodError < MetalwareError
-    def initialize(build_type: nil, building_self_node: true)
-      msg = if build_type
-              "The '#{build_type}' build type can not be used for the self" \
+    def initialize(build_method: nil, building_self_node: true)
+      msg = if build_method
+              "The '#{build_method}' build method can not be used for the self" \
               "node. The self node can only be built with the 'self' build type"
             elsif building_self_node
-              'The self build type has had an unexpected error'
+              'The self build method has had an unexpected error'
             else
-              "The self build type can not be used for non 'self' nodes"
+              "The self build method can not be used for non 'self' nodes"
             end
       super(msg)
     end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -156,8 +156,24 @@ module Metalware
 
   class EditModeError < MetalwareError
   end
-end
 
+  class MissingExternalDNS < MetalwareError
+  end
+
+  class SelfBuildMethodError < MetalwareError
+    def initialize(build_type: nil, building_self_node: true)
+      msg = if build_type
+              "The '#{build_type}' build type can not be used for the self" \
+              "node. The self node can only be built with the 'self' build type"
+            elsif building_self_node
+              'The self build type has had an unexpected error'
+            else
+              "The self build type can not be used for non 'self' nodes"
+            end
+      super(msg)
+    end
+  end
+end
 
 # Alias for Exception to use to indicate we want to catch everything, and to
 # also tell Rubocop to be quiet about this.

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -71,6 +71,15 @@ module Metalware
       )
     end
 
+    def template_save_path(template_type, node: nil)
+      node = Node.new(config, nil) if node.nil?
+      File.join(
+        config.rendered_files_path,
+        template_type.to_s,
+        node.name
+      )
+    end
+
     def named_zone(zone)
       File.join(var_named, zone)
     end

--- a/src/node.rb
+++ b/src/node.rb
@@ -188,7 +188,7 @@ module Metalware
       validate_build_method
 
       case repo_build_method
-      when :uefi
+      when :'uefi-kickstart'
         BuildMethods::Kickstarts::UEFI
       when :basic
         BuildMethods::Basic

--- a/src/node.rb
+++ b/src/node.rb
@@ -184,13 +184,25 @@ module Metalware
     end
 
     def build_method_class
-      case repo_config[:build_method]&.to_sym
-      when :uefi
-        BuildMethods::Kickstarts::UEFI
-      when :basic
-        BuildMethods::Basic
+      repo_build = repo_config[:build_method]&.to_sym
+      if name == 'self'
+        case repo_build
+        when 'self' || nil
+          BuildMethods::Self
+        else
+          raise SelfBuildMethodError, build_type: repo_build
+        end
       else
-        BuildMethods::Kickstarts::Pxelinux
+        case repo_build
+        when :uefi
+          BuildMethods::Kickstarts::UEFI
+        when :basic
+          BuildMethods::Basic
+        when :self
+          raise SelfBuildMethodError, building_self_node: false
+        else
+          BuildMethods::Kickstarts::Pxelinux
+        end
       end
     end
   end

--- a/src/node.rb
+++ b/src/node.rb
@@ -44,6 +44,7 @@ module Metalware
 
     delegate :render_build_started_templates,
              :render_build_complete_templates,
+             :start_build,
              to: :build_method
 
     def initialize(metalware_config, name, should_be_configured: false)

--- a/src/node.rb
+++ b/src/node.rb
@@ -191,7 +191,7 @@ module Metalware
         when :self, nil
           BuildMethods::Self
         else
-          raise SelfBuildMethodError, build_type: repo_build
+          raise SelfBuildMethodError, build_method: repo_build
         end
       else
         case repo_build

--- a/src/node.rb
+++ b/src/node.rb
@@ -187,7 +187,7 @@ module Metalware
       repo_build = repo_config[:build_method]&.to_sym
       if name == 'self'
         case repo_build
-        when 'self' || nil
+        when :self, nil
           BuildMethods::Self
         else
           raise SelfBuildMethodError, build_type: repo_build

--- a/src/repo.rb
+++ b/src/repo.rb
@@ -1,10 +1,10 @@
 
 # frozen_string_literal: true
 
+require 'constants'
+
 module Metalware
   class Repo
-    CONFIGURE_SECTIONS = [:domain, :group, :node].freeze
-
     def initialize(config)
       @config = config
     end
@@ -24,7 +24,7 @@ module Metalware
     end
 
     def configure_data_sections
-      CONFIGURE_SECTIONS.map { |section| configure_data[section] }
+      Constants::CONFIGURE_SECTIONS.map { |section| configure_data[section] }
     end
 
     attr_reader :config

--- a/src/system_command.rb
+++ b/src/system_command.rb
@@ -24,6 +24,7 @@
 
 require 'exceptions'
 require 'open3'
+require 'metal_log'
 
 module Metalware
   module SystemCommand
@@ -35,7 +36,7 @@ module Metalware
       # `format_error` option specifies whether any error produced should be
       # formatted suitably for displaying to a user.
       def run(command, format_error: true)
-        stdout, stderr, status = Open3.capture3(command)
+        stdout, stderr, status = capture3(command)
         if status.exitstatus != 0
           handle_error(command, stderr, format_error: format_error)
         else
@@ -44,7 +45,7 @@ module Metalware
       end
 
       def run_raw(command)
-        stdout, stderr, status = Open3.capture3(command)
+        stdout, stderr, status = capture3(command)
         {
           stdout: stdout,
           stderr: stderr,
@@ -53,6 +54,11 @@ module Metalware
       end
 
       private
+
+      def capture3(command)
+        MetalLog.info("SystemCommand: #{command}")
+        Open3.capture3(command)
+      end
 
       def handle_error(command, stderr, format_error:)
         stderr = stderr.strip

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -25,6 +25,7 @@ require 'exceptions'
 require 'data'
 require 'dry-validation'
 require 'active_support/core_ext/module/delegation'
+require 'constants'
 
 module Metalware
   module Validation
@@ -46,7 +47,7 @@ module Metalware
         @validate ||= begin
           configure_results = ConfigureSchema.call(yaml: @yaml)
           if configure_results.success?
-            [:domain, :group, :node, :self].each do |section|
+            Constants::CONFIGURE_SECTIONS.each do |section|
               @yaml[section].each do |identifier, parameters|
                 payload = {
                   section: section,


### PR DESCRIPTION
This PR is based of #180. Please merge it first.
Fixes #141 

The `build` command now supports the `self` build type. This `self` build operates the same manner as a regular `basic` node build with a few exceptions. 

When building the `self` node, only the self `build_type` can be used. If the `build_type` is not included, `self` will be implicitly used (without a warning). However if `build_type` is set to anything other than `self`, it will result in an error. Similarly if a regular node tries to use the `self` build type, this will also result in an error.
**tl;dr** Self nodes must use the self build_type. Regular nodes can not use the self build_type

The self build_type, uses the `repo/self/default` template. This can be override in `template` section in the config same as any other template using the `self` key.

This PR also contains a commit (8c200ff), for dynamically requiring a directory. This is now being used in a few places, so the code has been included as a utility. It will require any file in a directory relative to the calling file.