### PR TITLE
Implement Saver class for file validation

### DIFF
--- a/spec/validation/answer_spec.rb
+++ b/spec/validation/answer_spec.rb
@@ -25,15 +25,10 @@ require 'validation/answer'
 require 'data'
 require 'config'
 require 'filesystem'
-require 'file_path'
 
 RSpec.describe Metalware::Validation::Answer do
   let :config do
     Metalware::Config.new
-  end
-
-  let :file_path do
-    Metalware::FilePath.new(config)
   end
 
   let :configure_data do
@@ -68,11 +63,9 @@ RSpec.describe Metalware::Validation::Answer do
 
   def run_answer_validation(answers)
     FileSystem.test do
-      Metalware::Data.dump(config.domain_answers_file, answers)
       Metalware::Data.dump(config.configure_file, configure_data)
-      domain_file = file_path.domain_answers
       validator = Metalware::Validation::Answer.new(config,
-                                                    domain_file,
+                                                    answers,
                                                     answer_section: :domain)
       [validator.validate, validator]
     end

--- a/spec/validation/saver_spec.rb
+++ b/spec/validation/saver_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'validation/saver'
+require 'config'
+require 'filesystem'
+
+module SaverSpec
+  module TestingMethods
+    def input_test(*a)
+      a
+    end
+
+    def data_test(*_a)
+      data
+    end
+  end
+end
+Metalware::Validation::Saver::Methods.prepend(SaverSpec::TestingMethods)
+
+RSpec.describe Metalware::Validation::Saver do
+  let :config { Metalware::Config.new }
+
+  let :saver do
+    Metalware::Validation::Saver.new(config)
+  end
+
+  let :filesystem do
+    filesystem.setup(&:with_minimal_repo)
+  end
+
+  it 'errors if method is not defined' do
+    expect do
+      saver.not_found_methods('data')
+    end.to raise_error(NoMethodError)
+  end
+
+  it 'errors if data is not included' do
+    expect do
+      saver.domain_answers
+    end.to raise_error(Metalware::SaverNoData)
+  end
+
+  it 'passes an arguments and data to the save method' do
+    inputs = ['arg1', hash: 'value']
+    data = { key: 'data' }
+    expect(
+      saver.input_test(data, *inputs)
+    ).to eq(inputs)
+    expect(
+      saver.data_test(data, *inputs)
+    ).to eq(data)
+  end
+end

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -156,6 +156,13 @@ module Metalware
 
   class EditModeError < MetalwareError
   end
+
+  class MissingExternalDNS < MetalwareError
+  end
+
+  class SaverNoData < MetalwareError
+    def initialize(msg = 'No data provided to Validation::Saver'); end
+  end
 end
 
 

--- a/src/validation/answer.rb
+++ b/src/validation/answer.rb
@@ -74,7 +74,7 @@ module Metalware
         @validation_result.success?
       end
 
-      def load
+      def data
         success? ? answers : (raise ValidationFailure, error_message)
       end
 

--- a/src/validation/answer.rb
+++ b/src/validation/answer.rb
@@ -30,9 +30,9 @@ module Metalware
     class Answer
       ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
-      def initialize(metalware_config, answer_file, answer_section: nil)
+      def initialize(metalware_config, answers, answer_section: nil)
         @config = metalware_config
-        @answer_file_path = answer_file
+        @answers = answers
         @section = answer_section
       end
 
@@ -56,7 +56,7 @@ module Metalware
       def error_message
         validate if @validation_result.nil?
         return '' if @validation_result.success?
-        msg_header = "Failed to validate answers: #{answer_file_path}\n"
+        msg_header = "Failed to validate answers:\n"
         case @last_ran_test
         when :MissingSchema
           "#{msg_header}" \
@@ -80,7 +80,7 @@ module Metalware
 
       private
 
-      attr_reader :config, :answer_file_path, :section
+      attr_reader :config, :section, :answers
 
       def loader
         @loader ||= Validation::Loader.new(config)
@@ -92,10 +92,6 @@ module Metalware
 
       def questions
         loader.configure_data
-      end
-
-      def answers
-        @answers ||= Data.load(answer_file_path)
       end
 
       def validation_hash

--- a/src/validation/load_save_base.rb
+++ b/src/validation/load_save_base.rb
@@ -22,57 +22,36 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
-require 'exceptions'
 require 'file_path'
 require 'validation/answer'
+require 'validation/configure'
 require 'data'
 
 module Metalware
   module Validation
-    class Saver
-      def initialize(metalware_config)
-        @config = metalware_config
+    class LoadSaveBase
+      def initialize(*_a)
+        raise NotImplementedError
       end
 
-      def respond_to_missing?(s, *_a)
-        Methods.instance_methods.include?(s)
+      def domain_answers
+        answer(path.domain_answers, :domain)
       end
 
-      # Enforces the first argument to always be the data
-      def method_missing(s, *a, &b)
-        data = a[0]
-        if respond_to_missing?(s)
-          raise SaverNoData unless data
-          Methods.new(config, data).send(s, *a[1..-1], &b)
-        else
-          super
-        end
+      def group_answers(file)
+        answer(path.group_answers(file), :groups)
+      end
+
+      def node_answers(file)
+        answer(path.node_answers(file), :nodes)
       end
 
       private
 
-      attr_reader :config
+      attr_reader :path, :config
 
-      def method_builder(data)
-        Methods.new(config, data)
-      end
-
-      class Methods < LoadSaveBase
-        def initialize(config, data)
-          @config = config
-          @path = FilePath.new(config)
-          @data = data
-        end
-
-        private
-
-        attr_reader :path, :config, :data
-
-        def answer(save_path, section)
-          valid = Validation::Answer.new(config, data, answer_section: section)
-                                    .data
-          Data.dump(save_path, valid)
-        end
+      def answer(absolute_path, section)
+        raise NotImplementedError
       end
     end
   end

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -68,7 +68,7 @@ module Metalware
         validator = Validation::Answer.new(config,
                                            yaml,
                                            answer_section: section)
-        validator.load
+        validator.data
       end
     end
   end

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -64,8 +64,9 @@ module Metalware
       attr_reader :path, :config
 
       def answer(absolute_path, section)
+        yaml = Data.load(absolute_path)
         validator = Validation::Answer.new(config,
-                                           absolute_path,
+                                           yaml,
                                            answer_section: section)
         validator.load
       end

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -25,11 +25,12 @@
 require 'file_path'
 require 'validation/answer'
 require 'validation/configure'
+require 'validation/load_save_base'
 require 'data'
 
 module Metalware
   module Validation
-    class Loader
+    class Loader < LoadSaveBase
       def initialize(metalware_config)
         @config = metalware_config
         @path = FilePath.new(config)
@@ -41,22 +42,6 @@ module Metalware
 
       def group_cache
         Data.load(path.group_cache)
-      end
-
-      def self_answers
-        answer(path.self_answers, :self)
-      end
-
-      def domain_answers
-        answer(path.domain_answers, :domain)
-      end
-
-      def group_answers(file)
-        answer(path.group_answers(file), :groups)
-      end
-
-      def node_answers(file)
-        answer(path.node_answers(file), :nodes)
       end
 
       private

--- a/src/validation/saver.rb
+++ b/src/validation/saver.rb
@@ -64,11 +64,17 @@ module Metalware
           @data = data
         end
 
-        def domain_answers; end
+        def domain_answers
+          Data.dump(path.domain_answers, validate_answer(:domain))
+        end
 
         private
 
         attr_reader :path, :config, :data
+
+        def validate_answer(section)
+          Validation::Answer.new(config, data, answer_section: section).data
+        end
       end
     end
   end

--- a/src/validation/saver.rb
+++ b/src/validation/saver.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'exceptions'
+require 'file_path'
+require 'validation/answer'
+require 'data'
+
+module Metalware
+  module Validation
+    class Saver
+      def initialize(metalware_config)
+        @config = metalware_config
+      end
+
+      def respond_to_missing?(s, *_a)
+        Methods.instance_methods.include?(s)
+      end
+
+      # Enforces the first argument to always be the data
+      def method_missing(s, *a, &b)
+        data = a[0]
+        if respond_to_missing?(s)
+          raise SaverNoData unless data
+          Methods.new(config, data).send(s, *a[1..-1], &b)
+        else
+          super
+        end
+      end
+
+      private
+
+      attr_reader :config
+
+      def method_builder(data)
+        Methods.new(config, data)
+      end
+
+      class Methods
+        def initialize(config, data)
+          @config = config
+          @path = FilePath.new(config)
+          @data = data
+        end
+
+        def domain_answers; end
+
+        private
+
+        attr_reader :path, :config, :data
+      end
+    end
+  end
+end


### PR DESCRIPTION
It is ideal that we validate answer files before we save them to prevent an error from being saved in the first place.

This PR contains the `Saver` class that broadly operates like the `Loader` class. However it uses some meta programming to insure the first input argument is always the data.

The answer validator had to be updated so it could take a hash directly to validate instead of a file path. Also the shared code between the `Loader` and `Saver` have been extracted to a shared class.

NOTE: This is being merged into the `refactor/configure` branch as it is required by the `Configurator`