### PR TITLE
Display full stack when a parameter is missing

### DIFF
--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -501,7 +501,7 @@ RSpec.describe Metalware::Templater do
         filesystem.test do
           templater = Metalware::Templater.new(config)
           magic_namespace = templater.config.alces
-          expect(magic_namespace.hunter).to eq(Hashie::Mash.new)
+          expect(magic_namespace.hunter.to_h).to eq(Hashie::Mash.new)
         end
       end
     end

--- a/src/templating/renderer.rb
+++ b/src/templating/renderer.rb
@@ -30,7 +30,7 @@ module Metalware
         # Replace all ERB in given template, generating the binding to use from
         # the given parameters.
         def replace_erb(template, template_parameters)
-          parameters_binding = template_parameters.instance_eval { binding }
+          parameters_binding = template_parameters.wrapper_binding
           render_erb_template(template, parameters_binding)
         rescue NoMethodError => e
           # May be useful to include the name of the unset parameter in this error,


### PR DESCRIPTION
This commit causes the entire call stack to be printed when the MissingParameterWrapper returns a nil instead of just the last called method. This is done by wrapping the all return values which tracks the call stack.

See commits for full details of the change