### PR TITLE
Add `configure` `--answers` option

### DIFF
--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -29,4 +29,22 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
   end
 
   include_examples :render_domain_templates, TestCommand
+
+  describe 'option handling' do
+    before :each do
+      SpecUtils.use_mock_genders(self)
+      SpecUtils.mock_validate_genders_success(self)
+    end
+
+    it 'passes answers through to configurator as hash' do
+      FileSystem.test do |fs|
+        fs.with_minimal_repo
+
+        answers = { 'question_1' => 'answer_1' }
+        expect_any_instance_of(Metalware::Configurator).to receive(:configure).with(answers)
+
+        SpecUtils.run_command(TestCommand, answers: answers.to_json)
+      end
+    end
+  end
 end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -481,5 +481,20 @@ RSpec.describe Metalware::Configurator do
         expect(output_lines).to include(question)
       end
     end
+
+    context 'when answers passed to configure' do
+      it 'uses given answers instead of asking questions' do
+        define_questions(test: {
+                           question_q: 'Some question',
+                         })
+        passed_answers = {
+          question_1: 'answer_1',
+        }
+
+        configurator.configure(passed_answers)
+
+        expect(answers).to eq(passed_answers)
+      end
+    end
   end
 end

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -5,6 +5,13 @@ anchor_options:
     description: >
           Switch NODE_IDENTIFIER to specify a gender group rather than a single
           node
+  configure_answers_option: &configure_answers_option
+    tags: [-a ANSWERS_MAPPING, --answers ANSWERS_MAPPING]
+    type: String
+    description: >
+      Given a JSON mapping of question identifiers to answer values, the given
+      answers will be saved instead of asking the configure questions and
+      saving user input.
 
 global_options:
   - tags: [-c FILE, --config FILE]
@@ -27,6 +34,8 @@ subcommands:
       configure the domain for this Metalware installation. The configuration
       answers will then be used when rendering templates.
     action: Commands::Configure::Domain
+    options:
+      - *configure_answers_option
 
   configure_group: &configure_group
     syntax: metal configure group GROUP_NAME [options]
@@ -36,6 +45,8 @@ subcommands:
       configure a group for this Metalware installation. The configuration
       answers will then be used when rendering templates.
     action: Commands::Configure::Group
+    options:
+      - *configure_answers_option
 
   configure_node: &configure_node
     syntax: metal configure node NODE_NAME [options]
@@ -45,6 +56,8 @@ subcommands:
       configure a node for this Metalware installation. The configuration
       answers will then be used when rendering templates.
     action: Commands::Configure::Node
+    options:
+      - *configure_answers_option
 
   configure_rerender: &configure_rerender
     syntax: metal configure rerender [options]

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -46,7 +46,14 @@ module Metalware
       end
 
       def answers
-        JSON.parse(options.answers) if options.answers
+        if options.answers
+          JSON.parse(options.answers)
+        else
+          # The `--answers` option has not been passed; the Configurator will
+          # ask the questions on the command line to get the answers to be
+          # saved.
+          nil
+        end
       end
 
       def handle_interrupt(_e)

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -40,9 +40,13 @@ module Metalware
       EOF
 
       def run
-        configurator.configure
+        configurator.configure(answers)
         custom_configuration
         render_domain_templates
+      end
+
+      def answers
+        JSON.parse(options.answers) if options.answers
       end
 
       def handle_interrupt(_e)

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -46,8 +46,8 @@ module Metalware
       @use_readline = use_readline
     end
 
-    def configure
-      answers = ask_questions
+    def configure(answers = nil)
+      answers ||= ask_questions
       save_answers(answers)
     end
 


### PR DESCRIPTION
This PR adds a `--answers` option to the `configure` commands. Given a JSON mapping of question identifiers to answer values, the given answers will be saved instead of asking the configure questions and saving user input.

This was added to be used by the GUI, but this feature is exposed on the command line firstly because it may be useful, and secondly because we want the GUI features to match those available in the CLI as closely as possible.

Based on https://github.com/alces-software/metalware/pull/188.