### PR TITLE
GUI supporting refactoring

### DIFF
--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
         answers = { 'question_1' => 'answer_1' }
         expect_any_instance_of(Metalware::Configurator).to receive(:configure).with(answers)
 
-        SpecUtils.run_command(TestCommand, answers: answers.to_json)
+        Metalware::Utils.run_command(TestCommand, answers: answers.to_json)
       end
     end
   end

--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -17,14 +17,18 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
 
     # Overridden to be three element array with third a valid `configure.yaml`
     # questions section; `BaseCommand` expects command classes to be namespaced
-    # by two modules, and `ConfigureCommand` determines questions section,
-    # which must be valid, from the class name.
+    # by two modules.
     def class_name_parts
-      [:some, :namespace, :domain]
+      [:some, :namespace, :test]
     end
 
-    def answers_file
-      '/var/lib/metalware/answers/some_file.yaml'
+    def configurator
+      Metalware::Configurator.new(
+        configure_file: config.configure_file,
+        questions_section: :domain,
+        answers_file: '/var/lib/metalware/answers/some_file.yaml',
+        higher_level_answer_files: []
+      )
     end
   end
 

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Metalware::Commands::Build do
     # Run command in timeout as `build` will wait indefinitely, but want to
     # abort tests if it looks like this is happening.
     Timeout.timeout 0.5 do
-      SpecUtils.run_command(
+      Metalware::Utils.run_command(
         Metalware::Commands::Build, node_identifier, **options_hash
       )
     end

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -6,7 +6,7 @@ require 'filesystem'
 
 RSpec.describe Metalware::Commands::Configure::Domain do
   def run_configure_domain
-    SpecUtils.run_command(
+    Metalware::Utils.run_command(
       Metalware::Commands::Configure::Domain
     )
   end

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -28,7 +28,7 @@ require 'group_cache'
 
 RSpec.describe Metalware::Commands::Configure::Group do
   def run_configure_group(group)
-    SpecUtils.run_command(
+    Metalware::Utils.run_command(
       Metalware::Commands::Configure::Group, group
     )
   end

--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -6,7 +6,7 @@ require 'filesystem'
 
 RSpec.describe Metalware::Commands::Configure::Node do
   def run_configure_node(node)
-    SpecUtils.run_command(
+    Metalware::Utils.run_command(
       Metalware::Commands::Configure::Node, node
     )
   end

--- a/spec/commands/render_spec.rb
+++ b/spec/commands/render_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Metalware::Commands::Render do
       config = Metalware::Config.new(nil)
       path = File.join(config.repo_path, 'dhcp/default')
       expect do
-        SpecUtils.run_command(
+        Metalware::Utils.run_command(
           Metalware::Commands::Render, path, strict: true
         )
       end.to raise_error(Metalware::StrictWarningError)

--- a/spec/shared_examples/render_domain_templates.rb
+++ b/spec/shared_examples/render_domain_templates.rb
@@ -66,7 +66,7 @@ RSpec.shared_examples :render_domain_templates do |test_command|
         Metalware::Constants::HOSTS_PATH
       ).ordered.and_call_original
 
-      SpecUtils.run_command(test_command)
+      Metalware::Utils.run_command(test_command)
     end
   end
 
@@ -91,7 +91,7 @@ RSpec.shared_examples :render_domain_templates do |test_command|
     it 'does not render hosts and genders files and gives error' do
       filesystem.test do
         expect do
-          SpecUtils.run_command(test_command)
+          Metalware::Utils.run_command(test_command)
         end.to raise_error(Metalware::DomainTemplatesInternalError)
 
         # `server.yaml` and `hosts` not rendered.
@@ -123,7 +123,7 @@ RSpec.shared_examples :render_domain_templates do |test_command|
     it 'does not render hosts file and gives error' do
       filesystem.test do
         expect do
-          SpecUtils.run_command(test_command)
+          Metalware::Utils.run_command(test_command)
         end.to raise_error(Metalware::DomainTemplatesInternalError)
 
         # `hosts` not rendered as `genders` invalid.

--- a/spec/spec_utils.rb
+++ b/spec/spec_utils.rb
@@ -97,16 +97,6 @@ module SpecUtils
 
     # Other shared utils.
 
-    def run_command(command_class, *args, **options_hash)
-      options = Commander::Command::Options.new
-      options_hash.map do |option, value|
-        option_setter = (option.to_s + '=').to_sym
-        options.__send__(option_setter, value)
-      end
-
-      command_class.new(args, options)
-    end
-
     def fixtures_config(config_file)
       File.join(FIXTURES_PATH, 'configs', config_file)
     end

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -32,6 +32,8 @@ module Metalware
     class ConfigureCommand < BaseCommand
       private
 
+      delegate :answers_file, to: :configurator
+
       GENDERS_INVALID_MESSAGE = <<-EOF.strip_heredoc
         You should be able to fix this error by re-running the `configure`
         command and correcting the invalid input, or by manually editing the
@@ -69,14 +71,6 @@ module Metalware
         answers_file.sub("#{config.answer_files_path}/", '')
       end
 
-      def answers_file
-        raise NotImplementedError
-      end
-
-      def higher_level_answer_files
-        []
-      end
-
       def dependency_hash
         {
           repo: ['configure.yaml'],
@@ -87,16 +81,7 @@ module Metalware
       end
 
       def configurator
-        Configurator.new(
-          configure_file: config.configure_file,
-          questions_section: questions_section,
-          answers_file: answers_file,
-          higher_level_answer_files: higher_level_answer_files
-        )
-      end
-
-      def questions_section
-        class_name_parts.last
+        raise NotImplementedError
       end
 
       # Render the templates which are relevant across the whole domain; these

--- a/src/commands/configure/domain.rb
+++ b/src/commands/configure/domain.rb
@@ -14,7 +14,7 @@ module Metalware
 
         def configurator
           @configurator ||=
-            Configurator.for_domain(file_path: file_path)
+            Configurator.for_domain(config: config)
         end
       end
     end

--- a/src/commands/configure/domain.rb
+++ b/src/commands/configure/domain.rb
@@ -12,8 +12,9 @@ module Metalware
 
         def setup; end
 
-        def answers_file
-          config.domain_answers_file
+        def configurator
+          @configurator ||=
+            Configurator.for_domain(file_path: file_path)
         end
       end
     end

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -39,16 +39,13 @@ module Metalware
           @cache = GroupCache.new(config)
         end
 
+        def configurator
+          @configurator ||=
+            Configurator.for_group(group_name, file_path: file_path)
+        end
+
         def custom_configuration
           record_primary_group
-        end
-
-        def answers_file
-          config.group_answers_file(group_name)
-        end
-
-        def higher_level_answer_files
-          [config.domain_answers_file]
         end
 
         def record_primary_group

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -41,7 +41,7 @@ module Metalware
 
         def configurator
           @configurator ||=
-            Configurator.for_group(group_name, file_path: file_path)
+            Configurator.for_group(group_name, config: config)
         end
 
         def custom_configuration

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -18,7 +18,7 @@ module Metalware
 
         def configurator
           @configurator ||=
-            Configurator.for_node(node, file_path: file_path)
+            Configurator.for_node(node, config: config)
         end
 
         def node

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -16,15 +16,9 @@ module Metalware
           @node_name = args.first
         end
 
-        def answers_file
-          config.node_answers_file(node_name)
-        end
-
-        def higher_level_answer_files
-          [
-            config.domain_answers_file,
-            config.group_answers_file(node.primary_group),
-          ]
+        def configurator
+          @configurator ||=
+            Configurator.for_node(node, file_path: file_path)
         end
 
         def node

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -30,6 +30,43 @@ HighLine::Question.prepend Metalware::Patches::HighLine::Questions
 
 module Metalware
   class Configurator
+    class << self
+      def for_domain(file_path:)
+        new(
+          configure_file: file_path.configure_file,
+          questions_section: :domain,
+          answers_file: file_path.domain_answers,
+          higher_level_answer_files: []
+        )
+      end
+
+      def for_group(group_name, file_path:)
+        new(
+          configure_file: file_path.configure_file,
+          questions_section: :group,
+          answers_file: file_path.group_answers(group_name),
+          higher_level_answer_files: [file_path.domain_answers]
+        )
+      end
+
+      # Note: This is slightly inconsistent with `for_group`, as that just
+      # takes a group name and this takes a Node object (as we need to be able
+      # to access the Node's primary group).
+      def for_node(node, file_path:)
+        new(
+          configure_file: file_path.configure_file,
+          questions_section: :node,
+          answers_file: file_path.node_answers(node.name),
+          higher_level_answer_files: [
+            file_path.domain_answers,
+            file_path.group_answers(node.primary_group),
+          ]
+        )
+      end
+    end
+
+    attr_reader :answers_file
+
     def initialize(
       highline: HighLine.new,
       configure_file:,
@@ -56,7 +93,6 @@ module Metalware
     attr_reader :highline,
                 :configure_file,
                 :questions_section,
-                :answers_file,
                 :higher_level_answer_files,
                 :use_readline
 

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -212,10 +212,18 @@ module Metalware
 
           if default_input
             highline_question.default = default_input
-          elsif required
+          elsif answer_required?
             highline_question.validate = ensure_answer_given
           end
         end
+      end
+
+      # Whether an answer to this question is required at this level; an answer
+      # will not be required if there is already an answer from the question
+      # default or a higher level answer file (the `default`), or if the
+      # question is not `required`.
+      def answer_required?
+        !default && required
       end
 
       private
@@ -228,14 +236,18 @@ module Metalware
       end
 
       def default_input
-        default_input = old_answer.nil? ? default : old_answer
-        if !default_input.nil? && type == :boolean
+        if !current_answer_value.nil? && type == :boolean
           # Default for a boolean question needs to be set to the input
           # HighLine's `agree` expects, i.e. 'yes' or 'no'.
-          default_input ? 'yes' : 'no'
+          current_answer_value ? 'yes' : 'no'
         else
-          default_input
+          current_answer_value
         end
+      end
+
+      # The answer value this question at this level would currently take.
+      def current_answer_value
+        old_answer.nil? ? default : old_answer
       end
 
       def ask_boolean_question(highline)

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -31,7 +31,8 @@ HighLine::Question.prepend Metalware::Patches::HighLine::Questions
 module Metalware
   class Configurator
     class << self
-      def for_domain(file_path:)
+      def for_domain(config:)
+        file_path = FilePath.new(config)
         new(
           configure_file: file_path.configure_file,
           questions_section: :domain,
@@ -40,7 +41,8 @@ module Metalware
         )
       end
 
-      def for_group(group_name, file_path:)
+      def for_group(group_name, config:)
+        file_path = FilePath.new(config)
         new(
           configure_file: file_path.configure_file,
           questions_section: :group,
@@ -52,7 +54,8 @@ module Metalware
       # Note: This is slightly inconsistent with `for_group`, as that just
       # takes a group name and this takes a Node object (as we need to be able
       # to access the Node's primary group).
-      def for_node(node, file_path:)
+      def for_node(node, config:)
+        file_path = FilePath.new(config)
         new(
           configure_file: file_path.configure_file,
           questions_section: :node,

--- a/src/utils.rb
+++ b/src/utils.rb
@@ -14,6 +14,16 @@ module Metalware
           .join("\n")
       end
 
+      def run_command(command_class, *args, **options_hash)
+        options = Commander::Command::Options.new
+        options_hash.map do |option, value|
+          option_setter = (option.to_s + '=').to_sym
+          options.__send__(option_setter, value)
+        end
+
+        command_class.new(args, options)
+      end
+
       private
 
       # From


### PR DESCRIPTION
This PR contains some refactoring to restructure some parts of the CLI to be more usable from the Metalware GUI. From the CLI perspective this should not contain any behaviour changes, but this makes several functions available in a few places which are needed by the GUI.

Based on https://github.com/alces-software/metalware/pull/189.