### PR TITLE
Refactor Configurator and change data structure

### DIFF
--- a/spec/answers_table_creator_spec.rb
+++ b/spec/answers_table_creator_spec.rb
@@ -27,12 +27,14 @@ require 'spec_utils'
 
 require 'filesystem'
 require 'answers_table_creator'
+require 'config'
+require 'validation/loader'
 
 RSpec.describe Metalware::AnswersTableCreator do
   subject do
     Metalware::AnswersTableCreator.new(Metalware::Config.new)
   end
-
+  let :config { Metalware::Config.new }
   let :configure_data do
     {
       domain: {
@@ -50,6 +52,7 @@ RSpec.describe Metalware::AnswersTableCreator do
       self: {},
     }
   end
+  let :loader { Metalware::Validation::Loader.new(config) }
 
   let :domain_answers do
     { question_1: 'domain question 1' }
@@ -73,7 +76,6 @@ RSpec.describe Metalware::AnswersTableCreator do
 
   let :filesystem do
     FileSystem.setup do |fs|
-      fs.dump('/var/lib/metalware/repo/configure.yaml', configure_data)
       fs.dump('/var/lib/metalware/answers/domain.yaml', domain_answers)
       fs.dump("/var/lib/metalware/answers/groups/#{group_name}.yaml", group_answers)
       fs.dump("/var/lib/metalware/answers/nodes/#{node_name}.yaml", node_answers)
@@ -82,6 +84,11 @@ RSpec.describe Metalware::AnswersTableCreator do
 
   before do
     SpecUtils.use_mock_genders(self)
+  end
+
+  before :each do
+    allow(loader).to receive(:configure_data).and_return(configure_data)
+    allow(Metalware::Validation::Loader).to receive(:new).and_return(loader)
   end
 
   describe '#domain_table' do

--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
     def configurator
       Metalware::Configurator.new(
         config: config,
-        questions_section: :domain,
-        higher_level_answer_files: []
+        questions_section: :domain
       )
     end
   end

--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -1,6 +1,7 @@
 
 # frozen_string_literal: true
 
+require 'config'
 require 'filesystem'
 require 'spec_utils'
 require 'shared_examples/render_domain_templates'
@@ -22,11 +23,14 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
       [:some, :namespace, :test]
     end
 
+    def answer_file
+      file_path.domain_answers
+    end
+
     def configurator
       Metalware::Configurator.new(
-        configure_file: config.configure_file,
+        config: config,
         questions_section: :domain,
-        answers_file: '/var/lib/metalware/answers/some_file.yaml',
         higher_level_answer_files: []
       )
     end

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -3,6 +3,7 @@
 
 require 'spec_utils'
 require 'filesystem'
+require 'config'
 
 RSpec.describe Metalware::Commands::Configure::Domain do
   def run_configure_domain
@@ -24,9 +25,8 @@ RSpec.describe Metalware::Commands::Configure::Domain do
   it 'creates correct configurator' do
     filesystem.test do
       expect(Metalware::Configurator).to receive(:new).with(
-        configure_file: config.configure_file,
+        config: instance_of(Metalware::Config),
         questions_section: :domain,
-        answers_file: config.domain_answers_file,
         higher_level_answer_files: []
       ).and_call_original
 

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Metalware::Commands::Configure::Domain do
     filesystem.test do
       expect(Metalware::Configurator).to receive(:new).with(
         config: instance_of(Metalware::Config),
-        questions_section: :domain,
-        higher_level_answer_files: []
+        questions_section: :domain
       ).and_call_original
 
       run_configure_domain

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Metalware::Commands::Configure::Group do
   it 'creates correct configurator' do
     filesystem.test do
       expect(Metalware::Configurator).to receive(:new).with(
-        configure_file: config.configure_file,
+        config: instance_of(Metalware::Config),
         questions_section: :group,
-        answers_file: config.group_answers_file('testnodes'),
+        name: 'testnodes',
         higher_level_answer_files: [config.domain_answers_file]
       ).and_call_original
 

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -49,8 +49,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
       expect(Metalware::Configurator).to receive(:new).with(
         config: instance_of(Metalware::Config),
         questions_section: :group,
-        name: 'testnodes',
-        higher_level_answer_files: [config.domain_answers_file]
+        name: 'testnodes'
       ).and_call_original
 
       run_configure_group 'testnodes'

--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -31,11 +31,7 @@ RSpec.describe Metalware::Commands::Configure::Node do
       expect(Metalware::Configurator).to receive(:new).with(
         config: instance_of(Metalware::Config),
         questions_section: :node,
-        name:'testnode01',
-        higher_level_answer_files: [
-          config.domain_answers_file,
-          config.group_answers_file('testnodes'),
-        ]
+        name:'testnode01'
       ).and_call_original
 
       run_configure_node 'testnode01'

--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Metalware::Commands::Configure::Node do
   it 'creates correct configurator' do
     filesystem.test do
       expect(Metalware::Configurator).to receive(:new).with(
-        configure_file: config.configure_file,
+        config: instance_of(Metalware::Config),
         questions_section: :node,
-        answers_file: config.node_answers_file('testnode01'),
+        name:'testnode01',
         higher_level_answer_files: [
           config.domain_answers_file,
           config.group_answers_file('testnodes'),

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -173,7 +173,6 @@ RSpec.describe Metalware::Configurator do
       define_questions(domain: {
                          choice_q: {
                            question: 'What choice would you like?',
-                           type: 'choice',
                            choices: ['foo', 'bar'],
                          },
                        })

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -53,9 +53,8 @@ RSpec.describe Metalware::Configurator do
   let :loader { Metalware::Validation::Loader.new(config) }
 
   def define_higher_level_answer_files(answer_file_hashes)
-    answer_file_hashes.map do |answers|
-      Tempfile.new.path.tap { |path| Metalware::Data.dump(path, answers) }
-    end
+    allow(configurator).to \
+      receive(:higher_level_answer_data).and_return(answer_file_hashes)
   end
 
   let :configurator do
@@ -67,8 +66,7 @@ RSpec.describe Metalware::Configurator do
     allow(HighLine).to receive(:new).and_return(highline)
     Metalware::Configurator.new(
       config: config,
-      questions_section: :domain,
-      higher_level_answer_files: higher_level_answer_files,
+      questions_section: :domain
     )
   end
 
@@ -304,7 +302,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     context 'when higher level answer files provided' do
-      let :higher_level_answer_files do
+      before do
         define_higher_level_answer_files(
           [
             {
@@ -318,9 +316,7 @@ RSpec.describe Metalware::Configurator do
             },
           ]
         )
-      end
 
-      before do
         define_questions(domain: {
                            default_q: {
                              question: 'default_q',
@@ -363,15 +359,13 @@ RSpec.describe Metalware::Configurator do
     end
 
     context 'with boolean question answered at higher level' do
-      let :higher_level_answer_files do
+      it 'correctly inherits false default' do
         define_higher_level_answer_files(
           [
             { false_boolean_q: false },
           ]
         )
-      end
 
-      it 'correctly inherits false default' do
         define_questions(domain: {
                            false_boolean_q: {
                              question: 'Boolean?',

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -276,8 +276,8 @@ RSpec.describe Metalware::Configurator do
                            default: false,
                          },
                          should_keep_old_answer: {
-                          question: 'Did I keep my old answer?'
-                         }
+                           question: 'Did I keep my old answer?',
+                         },
                        })
 
       original_answers = {
@@ -369,11 +369,11 @@ RSpec.describe Metalware::Configurator do
 
       it 'correctly inherits false default' do
         define_questions(domain: {
-          false_boolean_q: {
-            question: 'Boolean?',
-            type: 'boolean',
-          },
-        })
+                           false_boolean_q: {
+                             question: 'Boolean?',
+                             type: 'boolean',
+                           },
+                         })
 
         configure_with_answers([''])
 
@@ -457,7 +457,9 @@ RSpec.describe Metalware::Configurator do
     context 'when answers passed to configure' do
       it 'uses given answers instead of asking questions' do
         define_questions(domain: {
-                           question_q: 'Some question',
+                           question_1: {
+                             question: 'Some question',
+                           },
                          })
         passed_answers = {
           question_1: 'answer_1',

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -43,14 +43,6 @@ RSpec.describe Metalware::Configurator do
     HighLine.new(input, output)
   end
 
-  let :configure_file do
-    Tempfile.new('configure.yaml')
-  end
-
-  let :configure_file_path do
-    configure_file.path
-  end
-
   let :answers_file_path do
     Tempfile.new('test.yaml').path
   end
@@ -229,27 +221,6 @@ RSpec.describe Metalware::Configurator do
         string_q: 'Some string',
         integer_q: 11,
         boolean_q: false
-      )
-    end
-
-    it 'fails fast for question with unknown type' do
-      define_questions(test: {
-                         # This question
-                         string_q: {
-                           question: 'String?',
-                           type: 'string',
-                         },
-                         unknown_q: {
-                           question: 'Something odd?',
-                           type: 'foobar',
-                         },
-                       })
-
-      expect do
-        configurator.send(:questions)
-      end.to raise_error(
-        Metalware::UnknownQuestionTypeError,
-        /'foobar'.*test\.unknown_q.*#{configure_file_path}/
       )
     end
 

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -43,12 +43,8 @@ RSpec.describe Metalware::Configurator do
     HighLine.new(input, output)
   end
 
-  let :answers_file_path do
-    Tempfile.new('test.yaml').path
-  end
-
   let :answers do
-    Metalware::Data.load(answers_file_path)
+    loader.domain_answers
   end
 
   let :higher_level_answer_files { [] }
@@ -70,8 +66,7 @@ RSpec.describe Metalware::Configurator do
     Metalware::Configurator.new(
       highline: hl,
       config: config,
-      questions_section: :test,
-      answers_file: answers_file_path,
+      questions_section: :domain,
       higher_level_answer_files: higher_level_answer_files,
       # Do not want to use readline to get input in tests as tests will then
       # hang waiting for input.
@@ -116,7 +111,7 @@ RSpec.describe Metalware::Configurator do
 
   describe '#configure' do
     it 'asks questions with type `string`' do
-      define_questions(test: {
+      define_questions(domain: {
                          string_q: {
                            question: 'Can you enter a string?',
                            type: 'string',
@@ -129,7 +124,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it 'asks questions with no `type` as `string`' do
-      define_questions(test: {
+      define_questions(domain: {
                          string_q: {
                            question: 'Can you enter a string?',
                          },
@@ -141,7 +136,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it 'asks questions with type `integer`' do
-      define_questions(test: {
+      define_questions(domain: {
                          integer_q: {
                            question: 'Can you enter an integer?',
                            type: 'integer',
@@ -154,7 +149,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it "uses confirmation for questions with type 'boolean'" do
-      define_questions(test: {
+      define_questions(domain: {
                          boolean_q: {
                            question: 'Should this cluster be awesome?',
                            type: 'boolean',
@@ -175,7 +170,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it "offers choices for question with type 'choice'" do
-      define_questions(test: {
+      define_questions(domain: {
                          choice_q: {
                            question: 'What choice would you like?',
                            type: 'choice',
@@ -195,7 +190,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it 'asks all questions in order' do
-      define_questions(test: {
+      define_questions(domain: {
                          string_q: {
                            question: 'String?',
                            type: 'string',
@@ -228,7 +223,7 @@ RSpec.describe Metalware::Configurator do
       str_ans = 'I am a little teapot!!'
       erb_ans = '<%= I_am_an_erb_tag %>'
 
-      define_questions(test: {
+      define_questions(domain: {
                          string_q: {
                            question: 'String?',
                            type: 'string',
@@ -261,7 +256,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it 're-saves the old answers if new answers not provided' do
-      define_questions(test: {
+      define_questions(domain: {
                          string_q: {
                            question: 'String?',
                            default: 'This is the wrong string',
@@ -321,7 +316,7 @@ RSpec.describe Metalware::Configurator do
       end
 
       before do
-        define_questions(test: {
+        define_questions(domain: {
                            default_q: {
                              question: 'default_q',
                              default: 'default_answer',
@@ -372,7 +367,7 @@ RSpec.describe Metalware::Configurator do
       end
 
       it 'correctly inherits false default' do
-        define_questions(test: {
+        define_questions(domain: {
           false_boolean_q: {
             question: 'Boolean?',
             type: 'boolean',
@@ -387,7 +382,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it 're-asks the required questions if no answer is given' do
-      define_questions(test: {
+      define_questions(domain: {
                          string_q: {
                            question: 'I should be re-asked',
                          },
@@ -415,7 +410,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it 'allows optional questions to have empty answers' do
-      define_questions(test: {
+      define_questions(domain: {
                          string_q: {
                            question: 'I should NOT be re-asked',
                            optional: true,
@@ -430,7 +425,7 @@ RSpec.describe Metalware::Configurator do
     end
 
     it 'indicates how far through questions you are' do
-      define_questions(test: {
+      define_questions(domain: {
                          question_1: {
                            question: 'String question',
                          },
@@ -460,7 +455,7 @@ RSpec.describe Metalware::Configurator do
 
     context 'when answers passed to configure' do
       it 'uses given answers instead of asking questions' do
-        define_questions(test: {
+        define_questions(domain: {
                            question_q: 'Some question',
                          })
         passed_answers = {

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -62,9 +62,10 @@ RSpec.describe Metalware::Configurator do
     make_configurator
   end
 
-  def make_configurator(hl = highline)
+  def make_configurator
+    # Spoofs HighLine to always return the testing version of highline
+    allow(HighLine).to receive(:new).and_return(highline)
     Metalware::Configurator.new(
-      highline: hl,
       config: config,
       questions_section: :domain,
       higher_level_answer_files: higher_level_answer_files,
@@ -290,7 +291,7 @@ RSpec.describe Metalware::Configurator do
 
       first_run_configure = nil
       redirect_stdout do
-        first_run_configure = make_configurator(HighLine.new)
+        first_run_configure = make_configurator
         first_run_configure.send(:save_answers, original_answers)
       end
       expect(first_run_configure.send(:old_answers)).to eq(original_answers)

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -69,9 +69,6 @@ RSpec.describe Metalware::Configurator do
       config: config,
       questions_section: :domain,
       higher_level_answer_files: higher_level_answer_files,
-      # Do not want to use readline to get input in tests as tests will then
-      # hang waiting for input.
-      use_readline: false
     )
   end
 
@@ -108,6 +105,12 @@ RSpec.describe Metalware::Configurator do
   def configure_with_answers(answers)
     # Each answer must be entered followed by a newline to terminate it.
     configure_with_input(answers.join("\n") + "\n")
+  end
+
+  # Do not want to use readline to get input in tests as tests will then
+  # hang waiting for input.
+  before :each do
+    allow(Metalware::Configurator).to receive(:use_readline).and_return(false)
   end
 
   describe '#configure' do

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -275,26 +275,28 @@ RSpec.describe Metalware::Configurator do
                            type: 'boolean',
                            default: false,
                          },
+                         should_keep_old_answer: {
+                          question: 'Did I keep my old answer?'
+                         }
                        })
 
-      old_answers = {
+      original_answers = {
         string_q: 'CORRECT',
         integer_q: -100,
         false_saved_boolean_q: false,
         true_saved_boolean_q: true,
-        should_not_see_me: 'OHHH SNAP',
+        should_keep_old_answer: 'old answer',
       }
-      new_answers = old_answers.dup.tap { |h| h.delete(:should_not_see_me) }
 
       first_run_configure = nil
       redirect_stdout do
         first_run_configure = make_configurator(HighLine.new)
-        first_run_configure.send(:save_answers, old_answers)
+        first_run_configure.send(:save_answers, original_answers)
       end
-      expect(first_run_configure.send(:old_answers)).to eq(old_answers)
+      expect(first_run_configure.send(:old_answers)).to eq(original_answers)
 
-      configure_with_answers([''] * 4)
-      expect(answers).to eq(new_answers)
+      configure_with_answers([''] * 5)
+      expect(answers).to eq(original_answers)
     end
 
     context 'when higher level answer files provided' do

--- a/spec/minimal_repo.rb
+++ b/spec/minimal_repo.rb
@@ -38,11 +38,11 @@ module MinimalRepo
       'genders/default': '',
       'dhcp/default': '',
       'config/domain.yaml': '',
-      'configure.yaml': YAML.dump(questions: {},
-                                  domain: {},
-                                  group: {},
-                                  node: {},
-                                  self: {}),
+      'configure.yaml': YAML.dump(questions: [],
+                                  domain: [],
+                                  group: [],
+                                  node: [],
+                                  self: []),
       # Define the build interface to be whatever the first interface is; this
       # should always be sufficient for testing purposes.
       'server.yaml': YAML.dump(build_interface: NetworkInterface.interfaces.first),

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Metalware::Repo do
         node: {
           baz: { question: 'baz' },
         },
-        self:{},
+        self: {},
       }
       fs.dump('/var/lib/metalware/repo/configure.yaml', configure_data)
     end

--- a/spec/templating/group_namespace_spec.rb
+++ b/spec/templating/group_namespace_spec.rb
@@ -25,6 +25,7 @@
 
 require 'templating/group_namespace'
 require 'filesystem'
+require 'spec_utils'
 
 RSpec.describe Metalware::Templating::GroupNamespace do
   subject do

--- a/spec/validation/answer_spec.rb
+++ b/spec/validation/answer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Metalware::Validation::Answer do
 
   let :configure_data do
     {
-      domain:[
+      domain: [
         {
           identifier: 'string_question',
           question: 'Am I a string?',

--- a/spec/validation/answer_spec.rb
+++ b/spec/validation/answer_spec.rb
@@ -25,15 +25,10 @@ require 'validation/answer'
 require 'data'
 require 'config'
 require 'filesystem'
-require 'file_path'
 
 RSpec.describe Metalware::Validation::Answer do
   let :config do
     Metalware::Config.new
-  end
-
-  let :file_path do
-    Metalware::FilePath.new(config)
   end
 
   let :configure_data do
@@ -68,11 +63,9 @@ RSpec.describe Metalware::Validation::Answer do
 
   def run_answer_validation(answers)
     FileSystem.test do
-      Metalware::Data.dump(config.domain_answers_file, answers)
       Metalware::Data.dump(config.configure_file, configure_data)
-      domain_file = file_path.domain_answers
       validator = Metalware::Validation::Answer.new(config,
-                                                    domain_file,
+                                                    answers,
                                                     answer_section: :domain)
       [validator.validate, validator]
     end

--- a/spec/validation/answer_spec.rb
+++ b/spec/validation/answer_spec.rb
@@ -33,23 +33,26 @@ RSpec.describe Metalware::Validation::Answer do
 
   let :configure_data do
     {
-      domain: {
-        string_question: {
+      domain:[
+        {
+          identifier: 'string_question',
           question: 'Am I a string?',
         },
-        integer_question: {
+        {
+          identifier: 'integer_question',
           question: 'Am I a integer',
           type: 'integer',
         },
-        bool_question: {
+        {
+          identifier: 'bool_question',
           question: 'Am I a boolean',
           type: 'boolean',
         },
-      },
+      ],
 
-      group: {},
-      node: {},
-      self: {},
+      group: [],
+      node: [],
+      self: [],
     }
   end
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Metalware::Validation::Configure do
   end
 
   def run_configure_validation(my_hash = {})
-    Metalware::Validation::Configure.new(config, my_hash).data
+    Metalware::Validation::Configure.new(config, my_hash).data(raw: true)
   end
 
   def expect_validation_failure(my_hash, msg_regex)

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -172,24 +172,34 @@ RSpec.describe Metalware::Validation::Configure do
   end
 
   context 'with invalid question fields' do
-    it 'fails if the question is missing or empty identifier' do
-      h = correct_hash.deep_merge(self: [{ question: 'I have no identifier' }])
-      expect_validation_failure(h, /is missing/)
-      h = correct_hash.deep_merge(self: [{
-                                    question: 'I have no identifier',
-                                    identifier: '',
-                                  }])
-      expect_validation_failure(h, /must be filled/)
+    context 'with invalid identifier' do
+      it 'fails when missing' do
+        h = correct_hash.deep_merge(self: [{ question: 'I have no identifier' }])
+        expect_validation_failure(h, /is missing/)
+      end
+
+      it 'fails when empty' do
+        h = correct_hash.deep_merge(self: [{
+                                      question: 'I have no identifier',
+                                      identifier: '',
+                                    }])
+        expect_validation_failure(h, /must be filled/)
+      end
     end
 
-    it 'fails if question is missing or empty' do
-      h = correct_hash.deep_merge(self: [{ identifier: 'missing_question' }])
-      expect_validation_failure(h, /is missing/)
-      h = correct_hash.deep_merge(self: [{
-                                    question: '',
-                                    identifier: 'no_question',
-                                  }])
-      expect_validation_failure(h, /must be filled/)
+    context 'with invalid question' do
+      it 'fails when missing' do
+        h = correct_hash.deep_merge(self: [{ identifier: 'missing_question' }])
+        expect_validation_failure(h, /is missing/)
+      end
+
+      it 'fails when empty' do
+        h = correct_hash.deep_merge(self: [{
+                                      question: '',
+                                      identifier: 'no_question',
+                                    }])
+        expect_validation_failure(h, /must be filled/)
+      end
     end
 
     it "fails if type isn't supported" do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -25,253 +25,242 @@ require 'validation/configure'
 require 'data'
 
 RSpec.describe Metalware::Validation::Configure do
-  let :correct_hash do
-    {
-      questions: {
-        questions: 'Are not part of the specification of a correct file.',
-        note: 'However they are very commonly associated with configure files',
-        note2: 'All other top level keys apart from questions, domain, group' \
-               'and node will cause an error.',
-      },
+  # let :correct_hash do
+  #   {
+  #     questions: {
+  #       questions: 'Are not part of the specification of a correct file.',
+  #       note: 'However they are very commonly associated with configure files',
+  #       note2: 'All other top level keys apart from questions, domain, group' \
+  #              'and node will cause an error.',
+  #     },
 
-      domain: {
-        string_question: {
-          question: 'Am I a string question without a default and type?',
-        },
-        integer_question: {
-          question: 'Am I an integer question with a default?',
-          type: 'integer',
-          default: 10,
-        },
-        boolean_true: {
-          question: 'Can I have a boolean true (/yes) default?',
-          type: 'boolean',
-          default: 'yes',
-        },
-      },
+  #     domain: {
+  #       string_question: {
+  #         question: 'Am I a string question without a default and type?',
+  #       },
+  #       integer_question: {
+  #         question: 'Am I an integer question with a default?',
+  #         type: 'integer',
+  #         default: 10,
+  #       },
+  #       boolean_true: {
+  #         question: 'Can I have a boolean true (/yes) default?',
+  #         type: 'boolean',
+  #         default: 'yes',
+  #       },
+  #     },
 
-      group: {
-        string_question: {
-          question: 'Am I a string question without a type but with a default?',
-          default: 'yes I am a string',
-        },
-        integer_question: {
-          question: 'Am I a integer question without a default?',
-          type: 'integer',
-        },
-        boolean_false: {
-          question: 'Can I have a boolean false (/no) default?',
-          type: 'boolean',
-          default: 'no',
-        },
-      },
+  #     group: {
+  #       string_question: {
+  #         question: 'Am I a string question without a type but with a default?',
+  #         default: 'yes I am a string',
+  #       },
+  #       integer_question: {
+  #         question: 'Am I a integer question without a default?',
+  #         type: 'integer',
+  #       },
+  #       boolean_false: {
+  #         question: 'Can I have a boolean false (/no) default?',
+  #         type: 'boolean',
+  #         default: 'no',
+  #       },
+  #     },
 
-      node: {
-        string_question: {
-          question: 'Am I a string question with a type and default?',
-          type: 'string',
-          default: 'yes I am a string',
-        },
-        string_empty_default: {
-          question: 'My default is a empty string?',
-          default: '',
-        },
-      },
+  #     node: {
+  #       string_question: {
+  #         question: 'Am I a string question with a type and default?',
+  #         type: 'string',
+  #         default: 'yes I am a string',
+  #       },
+  #       string_empty_default: {
+  #         question: 'My default is a empty string?',
+  #         default: '',
+  #       },
+  #     },
 
-      self: {},
-    }
-  end
+  #     self: {},
+  #   }
+  # end
 
-  def build_validator(my_hash = {})
-    allow(Metalware::Data).to receive(:load).and_return(my_hash)
-    Metalware::Validation::Configure.new('path/has/been/mocked')
-  end
+  # def build_validator(my_hash = {})
+  #   allow(Metalware::Data).to receive(:load).and_return(my_hash)
+  #   Metalware::Validation::Configure.new('path/has/been/mocked')
+  # end
 
-  def run_configure_validation(my_hash = {})
-    validator = build_validator(my_hash)
-    validator.validate.messages
-  end
+  # def run_configure_validation(my_hash = {})
+  #   validator = build_validator(my_hash)
+  #   validator.validate.messages
+  # end
 
-  context 'with a valid input' do
-    it 'passes with questions key' do
-      expect(run_configure_validation(correct_hash)).to be_empty
-    end
+  # context 'with a valid input' do
+  #   it 'passes with questions key' do
+  #     expect(run_configure_validation(correct_hash)).to be_empty
+  #   end
 
-    it 'passes without questions key' do
-      correct_hash.delete(:questions)
-      expect(run_configure_validation(correct_hash)).to be_empty
-    end
+  #   it 'passes without questions key' do
+  #     correct_hash.delete(:questions)
+  #     expect(run_configure_validation(correct_hash)).to be_empty
+  #   end
 
-    it 'checks that deep merged hashes pass (tests the testing)' do
-      h = correct_hash.deep_merge(domain: {
-                                    check_string_question: {
-                                      question: 'Am I deep merged into the domain?',
-                                      default: 'I sure hope so',
-                                    },
-                                  })
-      expect(run_configure_validation(h)).to be_empty
-    end
-  end
+  #   it 'checks that deep merged hashes pass (tests the testing)' do
+  #     h = correct_hash.deep_merge(domain: {
+  #                                   check_string_question: {
+  #                                     question: 'Am I deep merged into the domain?',
+  #                                     default: 'I sure hope so',
+  #                                   },
+  #                                 })
+  #     expect(run_configure_validation(h)).to be_empty
+  #   end
+  # end
 
-  context 'with general invalid inputs' do
-    it 'fails with invalid top level keys' do
-      h = correct_hash.deep_merge(invalid_key: true)
-      expect(run_configure_validation(h).keys).to eq([:valid_top_level_keys])
-    end
+  # context 'with general invalid inputs' do
+  #   it 'fails with invalid top level keys' do
+  #     h = correct_hash.deep_merge(invalid_key: true)
+  #     expect(run_configure_validation(h).keys).to eq([:valid_top_level_keys])
+  #   end
 
-    it 'fails if question is not a hash' do
-      h = correct_hash.deep_merge(group: {
-                                    question: 'Am I missing my mid level question key?',
-                                    type: 'string',
-                                    default: 'Each field will now be interpreted as a separate question',
-                                  })
-      results = build_validator(h).validate.errors
-      expect(results.keys).to eq([:parameters])
-      expect(results[:parameters][0]).to eq('must be a hash')
-    end
-  end
+  #   it 'fails if question is not a hash' do
+  #     h = correct_hash.deep_merge(group: {
+  #                                   question: 'Am I missing my mid level question key?',
+  #                                   type: 'string',
+  #                                   default: 'Each field will now be interpreted as a separate question',
+  #                                 })
+  #     results = build_validator(h).validate.errors
+  #     expect(results.keys).to eq([:parameters])
+  #     expect(results[:parameters][0]).to eq('must be a hash')
+  #   end
+  # end
 
-  context 'with invalid question fields' do
-    it 'fails if unrecognized fields in a question' do
-      h = correct_hash.deep_merge(domain: {
-                                    invalid_field_question: {
-                                      question: 'Do I have have an unrecognized field?',
-                                      default: 'I do',
-                                      invalid_filed: true,
-                                    },
-                                  })
-      expect(run_configure_validation(h).keys).to eq([:valid_top_level_question_keys])
-    end
+  # context 'with invalid question fields' do
+  #   it 'fails if unrecognized fields in a question' do
+  #     h = correct_hash.deep_merge(domain: {
+  #                                   invalid_field_question: {
+  #                                     question: 'Do I have have an unrecognized field?',
+  #                                     default: 'I do',
+  #                                     invalid_filed: true,
+  #                                   },
+  #                                 })
+  #     expect(run_configure_validation(h).keys).to eq([:valid_top_level_question_keys])
+  #   end
 
-    it 'fails if question is missing a title' do
-      h = correct_hash.deep_merge(domain: {
-                                    missing_title_question: {
-                                      default: 'I am missing my question!',
-                                    },
-                                  })
-      results = run_configure_validation(h)
-      expect(results[:parameters][:question][0]).to eq('is missing')
-    end
+  #   it 'fails if question is missing a title' do
+  #     h = correct_hash.deep_merge(domain: {
+  #                                   missing_title_question: {
+  #                                     default: 'I am missing my question!',
+  #                                   },
+  #                                 })
+  #     results = run_configure_validation(h)
+  #     expect(results[:parameters][:question][0]).to eq('is missing')
+  #   end
 
-    it 'fails if question if the title is empty' do
-      h = correct_hash.deep_merge(node: {
-                                    missing_title_question: {
-                                      question: '',
-                                      default: 'I am missing my question!',
-                                    },
-                                  })
-      results = run_configure_validation(h)
-      expect(results[:parameters][:question][0]).to eq('must be filled')
-    end
+  #   it 'fails if question if the title is empty' do
+  #     h = correct_hash.deep_merge(node: {
+  #                                   missing_title_question: {
+  #                                     question: '',
+  #                                     default: 'I am missing my question!',
+  #                                   },
+  #                                 })
+  #     results = run_configure_validation(h)
+  #     expect(results[:parameters][:question][0]).to eq('must be filled')
+  #   end
 
-    it "fails if type isn't supported" do
-      h = correct_hash.deep_merge(group: {
-                                    unsupported_type: {
-                                      question: 'Do I have an unsupported type?',
-                                      type: 'Unsupported',
-                                    },
-                                  })
-      results = run_configure_validation(h)
-      expect(results[:parameters].keys).to eq([:type])
-    end
+  #   it "fails if type isn't supported" do
+  #     h = correct_hash.deep_merge(group: {
+  #                                   unsupported_type: {
+  #                                     question: 'Do I have an unsupported type?',
+  #                                     type: 'Unsupported',
+  #                                   },
+  #                                 })
+  #     results = run_configure_validation(h)
+  #     expect(results[:parameters].keys).to eq([:type])
+  #   end
 
-    it 'fails if the optional input is not true or false' do
-      h = correct_hash.deep_merge(group: {
-                                    invalid_optional_flag: {
-                                      question: 'Do I have a boolean optional input?',
-                                      optional: 'I should be true or false',
-                                    },
-                                  })
-      results = run_configure_validation(h)
-      expect(results[:parameters].keys).to eq([:optional])
-    end
-  end
+  #   it 'fails if the optional input is not true or false' do
+  #     h = correct_hash.deep_merge(group: {
+  #                                   invalid_optional_flag: {
+  #                                     question: 'Do I have a boolean optional input?',
+  #                                     optional: 'I should be true or false',
+  #                                   },
+  #                                 })
+  #     results = run_configure_validation(h)
+  #     expect(results[:parameters].keys).to eq([:optional])
+  #   end
+  # end
 
-  context 'with missing question blocks' do
-    it 'fails when domain is missing' do
-      correct_hash.delete(:domain)
-      expect(run_configure_validation(correct_hash)).not_to be_empty
-    end
+  # context 'with missing question blocks' do
+  #   it 'fails when domain is missing' do
+  #     correct_hash.delete(:domain)
+  #     expect(run_configure_validation(correct_hash)).not_to be_empty
+  #   end
 
-    it 'fails when group is missing' do
-      correct_hash.delete(:group)
-      expect(run_configure_validation(correct_hash)).not_to be_empty
-    end
+  #   it 'fails when group is missing' do
+  #     correct_hash.delete(:group)
+  #     expect(run_configure_validation(correct_hash)).not_to be_empty
+  #   end
 
-    it 'fails when node is missing' do
-      correct_hash.delete(:node)
-      expect(run_configure_validation(correct_hash)).not_to be_empty
-    end
-  end
+  #   it 'fails when node is missing' do
+  #     correct_hash.delete(:node)
+  #     expect(run_configure_validation(correct_hash)).not_to be_empty
+  #   end
+  # end
 
-  context 'with invalid string questions' do
-    it 'fails with a non-string default with no type specified' do
-      h = correct_hash.deep_merge(domain: {
-                                    bad_string_question: {
-                                      question: "Do I fail because my default isn't a string?",
-                                      default: 10,
-                                    },
-                                  })
-      expect(run_configure_validation(h).keys).to eq([:default_string_type])
-    end
+  # context 'with invalid string questions' do
+  #   it 'fails with a non-string default with no type specified' do
+  #     h = correct_hash.deep_merge(domain: {
+  #                                   bad_string_question: {
+  #                                     question: "Do I fail because my default isn't a string?",
+  #                                     default: 10,
+  #                                   },
+  #                                 })
+  #     expect(run_configure_validation(h).keys).to eq([:default_string_type])
+  #   end
 
-    it 'fails with a non-string default with a type specified' do
-      h = correct_hash.deep_merge(group: {
-                                    bad_string_question: {
-                                      question: "Do I fail because my default isn't a string?",
-                                      type: 'string',
-                                      default: 10,
-                                    },
-                                  })
-      expect(run_configure_validation(h).keys).to eq([:default_string_type])
-    end
+  #   it 'fails with a non-string default with a type specified' do
+  #     h = correct_hash.deep_merge(group: {
+  #                                   bad_string_question: {
+  #                                     question: "Do I fail because my default isn't a string?",
+  #                                     type: 'string',
+  #                                     default: 10,
+  #                                   },
+  #                                 })
+  #     expect(run_configure_validation(h).keys).to eq([:default_string_type])
+  #   end
 
-    it 'returns a success? status of false' do
-      h = correct_hash.deep_merge(group: {
-                                    bad_string_question: {
-                                      question: "Do I fail because my default isn't a string?",
-                                      type: 'string',
-                                      default: 10,
-                                    },
-                                  })
-      expect(build_validator(h).success?).to eq(false)
-    end
-  end
+  #   it 'returns a success? status of false' do
+  #     h = correct_hash.deep_merge(group: {
+  #                                   bad_string_question: {
+  #                                     question: "Do I fail because my default isn't a string?",
+  #                                     type: 'string',
+  #                                     default: 10,
+  #                                   },
+  #                                 })
+  #     expect(build_validator(h).success?).to eq(false)
+  #   end
+  # end
 
-  context 'with invalid integer questions' do
-    it 'fails with non-integer default' do
-      h = correct_hash.deep_merge(node: {
-                                    bad_integer_question: {
-                                      question: 'Do I fail because my default is a string?',
-                                      type: 'integer',
-                                      default: '10',
-                                    },
-                                  })
-      expect(run_configure_validation(h).keys).to eq([:default_integer_type])
-    end
+  # context 'with invalid integer questions' do
+  #   it 'fails with non-integer default' do
+  #     h = correct_hash.deep_merge(node: {
+  #                                   bad_integer_question: {
+  #                                     question: 'Do I fail because my default is a string?',
+  #                                     type: 'integer',
+  #                                     default: '10',
+  #                                   },
+  #                                 })
+  #     expect(run_configure_validation(h).keys).to eq([:default_integer_type])
+  #   end
+  # end
 
-    it 'fails if the default is an empty string' do
-      h = correct_hash.deep_merge(node: {
-                                    bad_integer_question: {
-                                      question: 'Do I fail because my default is an empty string?',
-                                      type: 'integer',
-                                      default: '',
-                                    },
-                                  })
-      expect(run_configure_validation(h).keys).to eq([:default_empty_string_type])
-    end
-  end
-
-  context 'with invalid boolean questions' do
-    it 'fails with non-boolean default' do
-      h = correct_hash.deep_merge(node: {
-                                    bad_integer_question: {
-                                      question: 'Do I fail because my default is a string?',
-                                      type: 'boolean',
-                                      default: 'I am not valid',
-                                    },
-                                  })
-      expect(run_configure_validation(h).keys).to eq([:default_boolean_type])
-    end
-  end
+  # context 'with invalid boolean questions' do
+  #   it 'fails with non-boolean default' do
+  #     h = correct_hash.deep_merge(node: {
+  #                                   bad_integer_question: {
+  #                                     question: 'Do I fail because my default is a string?',
+  #                                     type: 'boolean',
+  #                                     default: 'I am not valid',
+  #                                   },
+  #                                 })
+  #     expect(run_configure_validation(h).keys).to eq([:default_boolean_type])
+  #   end
+  # end
 end

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Metalware::Validation::Configure do
   end
 
   context 'with a hash input' do
-    it 'uses the has as the data input' do
+    it 'uses the hash as the data input' do
       v = Metalware::Validation::Configure.new(config, correct_hash)
       expect(v.send(:raw_data)).to eq(correct_hash)
     end
@@ -141,7 +141,7 @@ RSpec.describe Metalware::Validation::Configure do
     Metalware::Validation::Configure.new(config, my_hash).data
   end
 
-  def expect_configure_error(my_hash, msg_regex)
+  def expect_validation_failure(my_hash, msg_regex)
     expect do
       run_configure_validation(my_hash)
     end.to raise_error(Metalware::ValidationFailure, msg_regex)
@@ -161,34 +161,34 @@ RSpec.describe Metalware::Validation::Configure do
   context 'with general invalid inputs' do
     it 'fails with invalid top level keys' do
       h = correct_hash.deep_merge(invalid_key: true)
-      expect_configure_error(h, /invalid top level key/)
+      expect_validation_failure(h, /invalid top level key/)
     end
 
     it 'fails if sections are not an array' do
       h = correct_hash.deep_merge(group: { key: 'I am not an array' })
-      expect_configure_error(h, /must be an array/)
+      expect_validation_failure(h, /must be an array/)
     end
   end
 
   context 'with invalid question fields' do
     it 'fails if the question is missing or empty identifier' do
       h = correct_hash.deep_merge(self: [{ question: 'I have no identifier' }])
-      expect_configure_error(h, /is missing/)
+      expect_validation_failure(h, /is missing/)
       h = correct_hash.deep_merge(self: [{
                                     question: 'I have no identifier',
                                     identifier: '',
                                   }])
-      expect_configure_error(h, /must be filled/)
+      expect_validation_failure(h, /must be filled/)
     end
 
     it 'fails if question is missing or empty' do
       h = correct_hash.deep_merge(self: [{ identifier: 'missing_question' }])
-      expect_configure_error(h, /is missing/)
+      expect_validation_failure(h, /is missing/)
       h = correct_hash.deep_merge(self: [{
                                     question: '',
                                     identifier: 'no_question',
                                   }])
-      expect_configure_error(h, /must be filled/)
+      expect_validation_failure(h, /must be filled/)
     end
 
     it "fails if type isn't supported" do
@@ -197,7 +197,7 @@ RSpec.describe Metalware::Validation::Configure do
                                     question: 'Do I have an unsupported type?',
                                     type: 'Unsupported',
                                   }])
-      expect_configure_error(h, /Is an unsupported question type/)
+      expect_validation_failure(h, /Is an unsupported question type/)
     end
 
     it 'fails if the optional input is not true or false' do
@@ -206,29 +206,29 @@ RSpec.describe Metalware::Validation::Configure do
                                     question: 'Do I have a boolean optional input?',
                                     optional: 'I should be true or false',
                                   }])
-      expect_configure_error(h, /must be boolean/)
+      expect_validation_failure(h, /must be boolean/)
     end
   end
 
   context 'with missing question blocks' do
     it 'fails when domain is missing' do
       correct_hash.delete(:domain)
-      expect_configure_error(correct_hash, /is missing/)
+      expect_validation_failure(correct_hash, /is missing/)
     end
 
     it 'fails when group is missing' do
       correct_hash.delete(:group)
-      expect_configure_error(correct_hash, /is missing/)
+      expect_validation_failure(correct_hash, /is missing/)
     end
 
     it 'fails when node is missing' do
       correct_hash.delete(:node)
-      expect_configure_error(correct_hash, /is missing/)
+      expect_validation_failure(correct_hash, /is missing/)
     end
 
     it 'fails when self is missing' do
       correct_hash.delete(:self)
-      expect_configure_error(correct_hash, /is missing/)
+      expect_validation_failure(correct_hash, /is missing/)
     end
   end
 
@@ -239,7 +239,7 @@ RSpec.describe Metalware::Validation::Configure do
                                     question: "Do I fail because my default isn't a string?",
                                     default: 10,
                                   }])
-      expect_configure_error(h, /question type/)
+      expect_validation_failure(h, /question type/)
     end
 
     it 'fails with a non-string default with a type specified' do
@@ -249,7 +249,7 @@ RSpec.describe Metalware::Validation::Configure do
                                     type: 'string',
                                     default: 10,
                                   }])
-      expect_configure_error(h, /question type/)
+      expect_validation_failure(h, /question type/)
     end
   end
 
@@ -261,7 +261,7 @@ RSpec.describe Metalware::Validation::Configure do
                                     type: 'integer',
                                     default: '10',
                                   }])
-      expect_configure_error(h, /question type/)
+      expect_validation_failure(h, /question type/)
     end
   end
 
@@ -273,7 +273,7 @@ RSpec.describe Metalware::Validation::Configure do
                                     type: 'boolean',
                                     default: 'I am not valid',
                                   }])
-      expect_configure_error(h, /question type/)
+      expect_validation_failure(h, /question type/)
     end
   end
 
@@ -289,7 +289,7 @@ RSpec.describe Metalware::Validation::Configure do
                                     ],
                                     default: 'not in list',
                                   }])
-      expect_configure_error(h, /choice list/)
+      expect_validation_failure(h, /choice list/)
     end
 
     it 'fails with inconsistent choice types' do
@@ -302,7 +302,7 @@ RSpec.describe Metalware::Validation::Configure do
                                       'choice3',
                                     ],
                                   }])
-      expect_configure_error(h, /match the question type/)
+      expect_validation_failure(h, /match the question type/)
     end
   end
 end

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Metalware::Validation::Configure do
   end
 
   context 'with invalid choice options' do
-    it 'the default is not in the choice list' do
+    it 'fail when the default is not in the choice list' do
       h = correct_hash.deep_merge(self: [{
                                     identifier: 'choice_question_no_bad_default',
                                     question: 'Is my default valid?',
@@ -287,6 +287,19 @@ RSpec.describe Metalware::Validation::Configure do
                                     default: 'not in list',
                                   }])
       expect_configure_error(h, /choice list/)
+    end
+
+    it 'fails with inconsistent choice types' do
+      h = correct_hash.deep_merge(self: [{
+                                    identifier: 'choice_question_no_bad_type',
+                                    question: 'Are my choice types valid?',
+                                    choice: [
+                                      'choice1',
+                                      100,
+                                      'choice3',
+                                    ],
+                                  }])
+      expect_configure_error(h, /match the question type/)
     end
   end
 end

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -168,16 +168,14 @@ RSpec.describe Metalware::Validation::Configure do
       expect_configure_error(h, /must be filled/)
     end
 
-    # it "fails if type isn't supported" do
-    #   h = correct_hash.deep_merge(group: {
-    #                                 unsupported_type: {
-    #                                   question: 'Do I have an unsupported type?',
-    #                                   type: 'Unsupported',
-    #                                 },
-    #                               })
-    #   results = run_configure_validation(h)
-    #   expect(results[:parameters].keys).to eq([:type])
-    # end
+    it "fails if type isn't supported" do
+      h = correct_hash.deep_merge(group: [{
+                                    identifier: 'unsupported_type',
+                                    question: 'Do I have an unsupported type?',
+                                    type: 'Unsupported',
+                                  }])
+    expect_configure_error(h, /Is an unsupported question type/)
+    end
 
     it 'fails if the optional input is not true or false' do
       h = correct_hash.deep_merge(group: [{
@@ -211,39 +209,38 @@ RSpec.describe Metalware::Validation::Configure do
     end
   end
 
-  # context 'with invalid string questions' do
-  #   it 'fails with a non-string default with no type specified' do
-  #     h = correct_hash.deep_merge(domain: {
-  #                                   bad_string_question: {
-  #                                     question: "Do I fail because my default isn't a string?",
-  #                                     default: 10,
-  #                                   },
-  #                                 })
-  #     expect(run_configure_validation(h).keys).to eq([:default_string_type])
-  #   end
+  context 'with invalid string questions' do
+    # it 'fails with a non-string default with no type specified' do
+    #   h = correct_hash.deep_merge(domain: [{
+    #                                 identifier: 'bad_string_question',
+    #                                 question: "Do I fail because my default isn't a string?",
+    #                                 default: 10,
+    #                               }])
+    #   expect(run_configure_validation(h).keys).to eq([:default_string_type])
+    # end
 
-  #   it 'fails with a non-string default with a type specified' do
-  #     h = correct_hash.deep_merge(group: {
-  #                                   bad_string_question: {
-  #                                     question: "Do I fail because my default isn't a string?",
-  #                                     type: 'string',
-  #                                     default: 10,
-  #                                   },
-  #                                 })
-  #     expect(run_configure_validation(h).keys).to eq([:default_string_type])
-  #   end
+    # it 'fails with a non-string default with a type specified' do
+    #   h = correct_hash.deep_merge(group: {
+    #                                 bad_string_question: {
+    #                                   question: "Do I fail because my default isn't a string?",
+    #                                   type: 'string',
+    #                                   default: 10,
+    #                                 },
+    #                               })
+    #   expect(run_configure_validation(h).keys).to eq([:default_string_type])
+    # end
 
-  #   it 'returns a success? status of false' do
-  #     h = correct_hash.deep_merge(group: {
-  #                                   bad_string_question: {
-  #                                     question: "Do I fail because my default isn't a string?",
-  #                                     type: 'string',
-  #                                     default: 10,
-  #                                   },
-  #                                 })
-  #     expect(build_validator(h).success?).to eq(false)
-  #   end
-  # end
+    # it 'returns a success? status of false' do
+    #   h = correct_hash.deep_merge(group: {
+    #                                 bad_string_question: {
+    #                                   question: "Do I fail because my default isn't a string?",
+    #                                   type: 'string',
+    #                                   default: 10,
+    #                                 },
+    #                               })
+    #   expect(build_validator(h).success?).to eq(false)
+    # end
+  end
 
   # context 'with invalid integer questions' do
   #   it 'fails with non-integer default' do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Metalware::Validation::Configure do
           identifier: 'boolean_true',
           question: 'Can I have a boolean true (/yes) default?',
           type: 'boolean',
-          default: 'yes',
+          default: true,
         },
       ],
 
@@ -75,7 +75,7 @@ RSpec.describe Metalware::Validation::Configure do
           identifier: 'boolean_false',
           question: 'Can I have a boolean false (/no) default?',
           type: 'boolean',
-          default: 'no',
+          default: false,
         },
       ],
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -34,11 +34,15 @@ RSpec.describe Metalware::Validation::Configure do
 
   let :correct_hash do
     {
+      ##
+      # Questions are not part of the specification for a valid configure.yaml
+      # file. However they have been white listed as a valid top level key. This
+      # means the 'questions' block can be used to store references to questions
+      # using YAML anchors in any layout of the users choosing. (As long as the
+      # other question blocks are valid)
+      #
       questions: {
-        questions: 'Are not part of the specification of a correct file.',
-        note: 'However they are very commonly associated with configure files',
-        note2: 'All other top level keys apart from questions, domain, group' \
-               'and node will cause an error.',
+        questions: 'Not part of the specification for a valid file',
       },
 
       domain: [

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -210,36 +210,24 @@ RSpec.describe Metalware::Validation::Configure do
   end
 
   context 'with invalid string questions' do
-    # it 'fails with a non-string default with no type specified' do
-    #   h = correct_hash.deep_merge(domain: [{
-    #                                 identifier: 'bad_string_question',
-    #                                 question: "Do I fail because my default isn't a string?",
-    #                                 default: 10,
-    #                               }])
-    #   expect(run_configure_validation(h).keys).to eq([:default_string_type])
-    # end
+    it 'fails with a non-string default with no type specified' do
+      h = correct_hash.deep_merge(domain: [{
+                                    identifier: 'bad_string_question',
+                                    question: "Do I fail because my default isn't a string?",
+                                    default: 10,
+                                  }])
+      expect_configure_error(h, /question type/)
+    end
 
-    # it 'fails with a non-string default with a type specified' do
-    #   h = correct_hash.deep_merge(group: {
-    #                                 bad_string_question: {
-    #                                   question: "Do I fail because my default isn't a string?",
-    #                                   type: 'string',
-    #                                   default: 10,
-    #                                 },
-    #                               })
-    #   expect(run_configure_validation(h).keys).to eq([:default_string_type])
-    # end
-
-    # it 'returns a success? status of false' do
-    #   h = correct_hash.deep_merge(group: {
-    #                                 bad_string_question: {
-    #                                   question: "Do I fail because my default isn't a string?",
-    #                                   type: 'string',
-    #                                   default: 10,
-    #                                 },
-    #                               })
-    #   expect(build_validator(h).success?).to eq(false)
-    # end
+    it 'fails with a non-string default with a type specified' do
+      h = correct_hash.deep_merge(group: [{
+                                    identifier: 'bad_string_question',
+                                    question: "Do I fail because my default isn't a string?",
+                                    type: 'string',
+                                    default: 10,
+                                  }])
+      expect_configure_error(h, /question type/)
+    end
   end
 
   # context 'with invalid integer questions' do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -93,7 +93,27 @@ RSpec.describe Metalware::Validation::Configure do
         },
       ],
 
-      self: [],
+      self: [
+        {
+          identifier: 'choice question',
+          question: 'Are all my choices strings?',
+          choice: [
+            'choice1',
+            'choice2',
+            'choice3',
+          ],
+          default: 'choice1',
+        },
+        {
+          identifier: 'choice_question_no_default',
+          question: 'Are all my choices strings without a default?',
+          choice: [
+            'choice1',
+            'choice2',
+            'choice3',
+          ],
+        }
+      ],
     }
   end
 
@@ -251,6 +271,22 @@ RSpec.describe Metalware::Validation::Configure do
                                     default: 'I am not valid',
                                   }])
       expect_configure_error(h, /question type/)
+    end
+  end
+
+  context 'with invalid choice options' do
+    it 'the default is not in the choice list' do
+      h = correct_hash.deep_merge(self: [{
+                                    identifier: 'choice_question_no_bad_default',
+                                    question: 'Is my default valid?',
+                                    choice: [
+                                      'choice1',
+                                      'choice2',
+                                      'choice3',
+                                    ],
+                                    default: 'not in list',
+                                  }])
+      expect_configure_error(h, /choice list/)
     end
   end
 end

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Metalware::Validation::Configure do
             'choice2',
             'choice3',
           ],
-        }
+        },
       ],
     }
   end
@@ -138,9 +138,9 @@ RSpec.describe Metalware::Validation::Configure do
   end
 
   def expect_configure_error(my_hash, msg_regex)
-    expect{
+    expect do
       run_configure_validation(my_hash)
-    }.to raise_error(Metalware::ValidationFailure, msg_regex)
+    end.to raise_error(Metalware::ValidationFailure, msg_regex)
   end
 
   context 'with a valid input' do
@@ -170,21 +170,20 @@ RSpec.describe Metalware::Validation::Configure do
     it 'fails if the question is missing or empty identifier' do
       h = correct_hash.deep_merge(self: [{ question: 'I have no identifier' }])
       expect_configure_error(h, /is missing/)
-      h = correct_hash.deep_merge(self: [{ 
-        question: 'I have no identifier',
-        identifier: '',
-      }])
+      h = correct_hash.deep_merge(self: [{
+                                    question: 'I have no identifier',
+                                    identifier: '',
+                                  }])
       expect_configure_error(h, /must be filled/)
     end
-
 
     it 'fails if question is missing or empty' do
       h = correct_hash.deep_merge(self: [{ identifier: 'missing_question' }])
       expect_configure_error(h, /is missing/)
-      h = correct_hash.deep_merge(self: [{ 
-        question: '',
-        identifier: 'no_question',
-      }])
+      h = correct_hash.deep_merge(self: [{
+                                    question: '',
+                                    identifier: 'no_question',
+                                  }])
       expect_configure_error(h, /must be filled/)
     end
 
@@ -194,7 +193,7 @@ RSpec.describe Metalware::Validation::Configure do
                                     question: 'Do I have an unsupported type?',
                                     type: 'Unsupported',
                                   }])
-    expect_configure_error(h, /Is an unsupported question type/)
+      expect_configure_error(h, /Is an unsupported question type/)
     end
 
     it 'fails if the optional input is not true or false' do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -21,66 +21,89 @@
 # For more information on the Alces Metalware, please visit:
 # https://github.com/alces-software/metalware
 #==============================================================================
+
+require 'config'
 require 'validation/configure'
+require 'file_path'
 require 'data'
+require 'filesystem'
 
 RSpec.describe Metalware::Validation::Configure do
-  # let :correct_hash do
-  #   {
-  #     questions: {
-  #       questions: 'Are not part of the specification of a correct file.',
-  #       note: 'However they are very commonly associated with configure files',
-  #       note2: 'All other top level keys apart from questions, domain, group' \
-  #              'and node will cause an error.',
-  #     },
+  let :config { Metalware::Config.new }
+  let :file_path { Metalware::FilePath.new(config) }
 
-  #     domain: {
-  #       string_question: {
-  #         question: 'Am I a string question without a default and type?',
-  #       },
-  #       integer_question: {
-  #         question: 'Am I an integer question with a default?',
-  #         type: 'integer',
-  #         default: 10,
-  #       },
-  #       boolean_true: {
-  #         question: 'Can I have a boolean true (/yes) default?',
-  #         type: 'boolean',
-  #         default: 'yes',
-  #       },
-  #     },
+  let :correct_hash do
+    {
+      questions: {
+        questions: 'Are not part of the specification of a correct file.',
+        note: 'However they are very commonly associated with configure files',
+        note2: 'All other top level keys apart from questions, domain, group' \
+               'and node will cause an error.',
+      },
 
-  #     group: {
-  #       string_question: {
-  #         question: 'Am I a string question without a type but with a default?',
-  #         default: 'yes I am a string',
-  #       },
-  #       integer_question: {
-  #         question: 'Am I a integer question without a default?',
-  #         type: 'integer',
-  #       },
-  #       boolean_false: {
-  #         question: 'Can I have a boolean false (/no) default?',
-  #         type: 'boolean',
-  #         default: 'no',
-  #       },
-  #     },
+      domain: {
+        string_question: {
+          question: 'Am I a string question without a default and type?',
+        },
+        integer_question: {
+          question: 'Am I an integer question with a default?',
+          type: 'integer',
+          default: 10,
+        },
+        boolean_true: {
+          question: 'Can I have a boolean true (/yes) default?',
+          type: 'boolean',
+          default: 'yes',
+        },
+      },
 
-  #     node: {
-  #       string_question: {
-  #         question: 'Am I a string question with a type and default?',
-  #         type: 'string',
-  #         default: 'yes I am a string',
-  #       },
-  #       string_empty_default: {
-  #         question: 'My default is a empty string?',
-  #         default: '',
-  #       },
-  #     },
+      group: {
+        string_question: {
+          question: 'Am I a string question without a type but with a default?',
+          default: 'yes I am a string',
+        },
+        integer_question: {
+          question: 'Am I a integer question without a default?',
+          type: 'integer',
+        },
+        boolean_false: {
+          question: 'Can I have a boolean false (/no) default?',
+          type: 'boolean',
+          default: 'no',
+        },
+      },
 
-  #     self: {},
-  #   }
-  # end
+      node: {
+        string_question: {
+          question: 'Am I a string question with a type and default?',
+          type: 'string',
+          default: 'yes I am a string',
+        },
+        string_empty_default: {
+          question: 'My default is a empty string?',
+          default: '',
+        },
+      },
+
+      self: {},
+    }
+  end
+
+  context 'without a hash input' do
+    it 'loads configure file from the repo' do
+      data = { data: 'I am the configure data' }
+      Metalware::Data.dump(file_path.configure_file, data)
+      v = Metalware::Validation::Configure.new(config)
+      expect(v.send(:raw_data)).to eq(data)
+    end
+  end
+
+  context 'with a hash input' do
+    it 'uses the has as the data input' do
+      v = Metalware::Validation::Configure.new(config, correct_hash)
+      expect(v.send(:raw_data)).to eq(correct_hash)
+    end
+  end
 
   # def build_validator(my_hash = {})
   #   allow(Metalware::Data).to receive(:load).and_return(my_hash)

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -230,29 +230,27 @@ RSpec.describe Metalware::Validation::Configure do
     end
   end
 
-  # context 'with invalid integer questions' do
-  #   it 'fails with non-integer default' do
-  #     h = correct_hash.deep_merge(node: {
-  #                                   bad_integer_question: {
-  #                                     question: 'Do I fail because my default is a string?',
-  #                                     type: 'integer',
-  #                                     default: '10',
-  #                                   },
-  #                                 })
-  #     expect(run_configure_validation(h).keys).to eq([:default_integer_type])
-  #   end
-  # end
+  context 'with invalid integer questions' do
+    it 'fails with non-integer default' do
+      h = correct_hash.deep_merge(node: [{
+                                    identifier: 'bad_integer_question',
+                                    question: 'Do I fail because my default is a string?',
+                                    type: 'integer',
+                                    default: '10',
+                                  }])
+      expect_configure_error(h, /question type/)
+    end
+  end
 
-  # context 'with invalid boolean questions' do
-  #   it 'fails with non-boolean default' do
-  #     h = correct_hash.deep_merge(node: {
-  #                                   bad_integer_question: {
-  #                                     question: 'Do I fail because my default is a string?',
-  #                                     type: 'boolean',
-  #                                     default: 'I am not valid',
-  #                                   },
-  #                                 })
-  #     expect(run_configure_validation(h).keys).to eq([:default_boolean_type])
-  #   end
-  # end
+  context 'with invalid boolean questions' do
+    it 'fails with non-boolean default' do
+      h = correct_hash.deep_merge(node: [{
+                                    identifier: 'bad_integer_question',
+                                    question: 'Do I fail because my default is a string?',
+                                    type: 'boolean',
+                                    default: 'I am not valid',
+                                  }])
+      expect_configure_error(h, /question type/)
+    end
+  end
 end

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -189,22 +189,27 @@ RSpec.describe Metalware::Validation::Configure do
     end
   end
 
-  # context 'with missing question blocks' do
-  #   it 'fails when domain is missing' do
-  #     correct_hash.delete(:domain)
-  #     expect(run_configure_validation(correct_hash)).not_to be_empty
-  #   end
+  context 'with missing question blocks' do
+    it 'fails when domain is missing' do
+      correct_hash.delete(:domain)
+      expect_configure_error(correct_hash, /is missing/)
+    end
 
-  #   it 'fails when group is missing' do
-  #     correct_hash.delete(:group)
-  #     expect(run_configure_validation(correct_hash)).not_to be_empty
-  #   end
+    it 'fails when group is missing' do
+      correct_hash.delete(:group)
+      expect_configure_error(correct_hash, /is missing/)
+    end
 
-  #   it 'fails when node is missing' do
-  #     correct_hash.delete(:node)
-  #     expect(run_configure_validation(correct_hash)).not_to be_empty
-  #   end
-  # end
+    it 'fails when node is missing' do
+      correct_hash.delete(:node)
+      expect_configure_error(correct_hash, /is missing/)
+    end
+
+    it 'fails when self is missing' do
+      correct_hash.delete(:self)
+      expect_configure_error(correct_hash, /is missing/)
+    end
+  end
 
   # context 'with invalid string questions' do
   #   it 'fails with a non-string default with no type specified' do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -27,6 +27,7 @@ require 'validation/configure'
 require 'file_path'
 require 'data'
 require 'filesystem'
+require 'constants'
 
 RSpec.describe Metalware::Validation::Configure do
   let :config { Metalware::Config.new }
@@ -211,24 +212,11 @@ RSpec.describe Metalware::Validation::Configure do
   end
 
   context 'with missing question blocks' do
-    it 'fails when domain is missing' do
-      correct_hash.delete(:domain)
-      expect_validation_failure(correct_hash, /is missing/)
-    end
-
-    it 'fails when group is missing' do
-      correct_hash.delete(:group)
-      expect_validation_failure(correct_hash, /is missing/)
-    end
-
-    it 'fails when node is missing' do
-      correct_hash.delete(:node)
-      expect_validation_failure(correct_hash, /is missing/)
-    end
-
-    it 'fails when self is missing' do
-      correct_hash.delete(:self)
-      expect_validation_failure(correct_hash, /is missing/)
+    Metalware::Constants::CONFIGURE_SECTIONS.each do |section|
+      it "fails when #{section} is missing" do
+        correct_hash.delete(section)
+        expect_validation_failure(correct_hash, /is missing/)
+      end
     end
   end
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -41,51 +41,59 @@ RSpec.describe Metalware::Validation::Configure do
                'and node will cause an error.',
       },
 
-      domain: {
-        string_question: {
+      domain: [
+        {
+          identifier: 'string_question',
           question: 'Am I a string question without a default and type?',
         },
-        integer_question: {
+        {
+          identifier: 'integer_question',
           question: 'Am I an integer question with a default?',
           type: 'integer',
           default: 10,
         },
-        boolean_true: {
+        {
+          identifier: 'boolean_true',
           question: 'Can I have a boolean true (/yes) default?',
           type: 'boolean',
           default: 'yes',
         },
-      },
+      ],
 
-      group: {
-        string_question: {
+      group: [
+        {
+          identifier: 'string_question',
           question: 'Am I a string question without a type but with a default?',
           default: 'yes I am a string',
         },
-        integer_question: {
+        {
+          identifier: 'integer_question',
           question: 'Am I a integer question without a default?',
           type: 'integer',
         },
-        boolean_false: {
+        {
+          identifier: 'boolean_false',
           question: 'Can I have a boolean false (/no) default?',
           type: 'boolean',
           default: 'no',
         },
-      },
+      ],
 
-      node: {
-        string_question: {
+      node: [
+        {
+          identifier: 'string_question',
           question: 'Am I a string question with a type and default?',
           type: 'string',
           default: 'yes I am a string',
         },
-        string_empty_default: {
+        {
+          identifier: 'string_empty_default',
           question: 'My default is a empty string?',
           default: '',
         },
-      },
+      ],
 
-      self: {},
+      self: [],
     }
   end
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -113,36 +113,20 @@ RSpec.describe Metalware::Validation::Configure do
     end
   end
 
-  # def build_validator(my_hash = {})
-  #   allow(Metalware::Data).to receive(:load).and_return(my_hash)
-  #   Metalware::Validation::Configure.new('path/has/been/mocked')
-  # end
+  def run_configure_validation(my_hash = {})
+    Metalware::Validation::Configure.new(config, my_hash).data
+  end
 
-  # def run_configure_validation(my_hash = {})
-  #   validator = build_validator(my_hash)
-  #   validator.validate.messages
-  # end
+  context 'with a valid input' do
+    it 'passes with questions key' do
+      expect(run_configure_validation(correct_hash)).to eq(correct_hash)
+    end
 
-  # context 'with a valid input' do
-  #   it 'passes with questions key' do
-  #     expect(run_configure_validation(correct_hash)).to be_empty
-  #   end
-
-  #   it 'passes without questions key' do
-  #     correct_hash.delete(:questions)
-  #     expect(run_configure_validation(correct_hash)).to be_empty
-  #   end
-
-  #   it 'checks that deep merged hashes pass (tests the testing)' do
-  #     h = correct_hash.deep_merge(domain: {
-  #                                   check_string_question: {
-  #                                     question: 'Am I deep merged into the domain?',
-  #                                     default: 'I sure hope so',
-  #                                   },
-  #                                 })
-  #     expect(run_configure_validation(h)).to be_empty
-  #   end
-  # end
+    it 'passes without questions key' do
+      correct_hash.delete(:questions)
+      expect(run_configure_validation(correct_hash)).to eq(correct_hash)
+    end
+  end
 
   # context 'with general invalid inputs' do
   #   it 'fails with invalid top level keys' do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -158,26 +158,15 @@ RSpec.describe Metalware::Validation::Configure do
     end
 
 
-    # it 'fails if question is missing a title' do
-    #   h = correct_hash.deep_merge(domain: {
-    #                                 missing_title_question: {
-    #                                   default: 'I am missing my question!',
-    #                                 },
-    #                               })
-    #   results = run_configure_validation(h)
-    #   expect(results[:parameters][:question][0]).to eq('is missing')
-    # end
-
-    # it 'fails if question if the title is empty' do
-    #   h = correct_hash.deep_merge(node: {
-    #                                 missing_title_question: {
-    #                                   question: '',
-    #                                   default: 'I am missing my question!',
-    #                                 },
-    #                               })
-    #   results = run_configure_validation(h)
-    #   expect(results[:parameters][:question][0]).to eq('must be filled')
-    # end
+    it 'fails if question is missing or empty' do
+      h = correct_hash.deep_merge(self: [{ identifier: 'missing_question' }])
+      expect_configure_error(h, /is missing/)
+      h = correct_hash.deep_merge(self: [{ 
+        question: '',
+        identifier: 'no_question',
+      }])
+      expect_configure_error(h, /must be filled/)
+    end
 
     # it "fails if type isn't supported" do
     #   h = correct_hash.deep_merge(group: {

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -179,16 +179,14 @@ RSpec.describe Metalware::Validation::Configure do
     #   expect(results[:parameters].keys).to eq([:type])
     # end
 
-    # it 'fails if the optional input is not true or false' do
-    #   h = correct_hash.deep_merge(group: {
-    #                                 invalid_optional_flag: {
-    #                                   question: 'Do I have a boolean optional input?',
-    #                                   optional: 'I should be true or false',
-    #                                 },
-    #                               })
-    #   results = run_configure_validation(h)
-    #   expect(results[:parameters].keys).to eq([:optional])
-    # end
+    it 'fails if the optional input is not true or false' do
+      h = correct_hash.deep_merge(group: [{
+                                    identifier: 'invalid_optional_flag',
+                                    question: 'Do I have a boolean optional input?',
+                                    optional: 'I should be true or false',
+                                  }])
+      expect_configure_error(h, /must be boolean/)
+    end
   end
 
   # context 'with missing question blocks' do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -147,6 +147,17 @@ RSpec.describe Metalware::Validation::Configure do
   end
 
   context 'with invalid question fields' do
+    it 'fails if the question is missing or empty identifier' do
+      h = correct_hash.deep_merge(self: [{ question: 'I have no identifier' }])
+      expect_configure_error(h, /is missing/)
+      h = correct_hash.deep_merge(self: [{ 
+        question: 'I have no identifier',
+        identifier: '',
+      }])
+      expect_configure_error(h, /must be filled/)
+    end
+
+
     # it 'fails if question is missing a title' do
     #   h = correct_hash.deep_merge(domain: {
     #                                 missing_title_question: {

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe Metalware::Validation::Configure do
     Metalware::Validation::Configure.new(config, my_hash).data
   end
 
+  def expect_configure_error(my_hash, msg_regex)
+    expect{
+      run_configure_validation(my_hash)
+    }.to raise_error(Metalware::ValidationFailure, msg_regex)
+  end
+
   context 'with a valid input' do
     it 'passes with questions key' do
       expect(run_configure_validation(correct_hash)).to eq(correct_hash)
@@ -128,23 +134,23 @@ RSpec.describe Metalware::Validation::Configure do
     end
   end
 
-  # context 'with general invalid inputs' do
-  #   it 'fails with invalid top level keys' do
-  #     h = correct_hash.deep_merge(invalid_key: true)
-  #     expect(run_configure_validation(h).keys).to eq([:valid_top_level_keys])
-  #   end
+  context 'with general invalid inputs' do
+    it 'fails with invalid top level keys' do
+      h = correct_hash.deep_merge(invalid_key: true)
+      expect_configure_error(h, /invalid top level key/)
+    end
 
-  #   it 'fails if question is not a hash' do
-  #     h = correct_hash.deep_merge(group: {
-  #                                   question: 'Am I missing my mid level question key?',
-  #                                   type: 'string',
-  #                                   default: 'Each field will now be interpreted as a separate question',
-  #                                 })
-  #     results = build_validator(h).validate.errors
-  #     expect(results.keys).to eq([:parameters])
-  #     expect(results[:parameters][0]).to eq('must be a hash')
-  #   end
-  # end
+    # it 'fails if question is not a hash' do
+    #   h = correct_hash.deep_merge(group: {
+    #                                 question: 'Am I missing my mid level question key?',
+    #                                 type: 'string',
+    #                                 default: 'Each field will now be interpreted as a separate question',
+    #                               })
+    #   results = build_validator(h).validate.errors
+    #   expect(results.keys).to eq([:parameters])
+    #   expect(results[:parameters][0]).to eq('must be a hash')
+    # end
+  end
 
   # context 'with invalid question fields' do
   #   it 'fails if unrecognized fields in a question' do

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -140,73 +140,56 @@ RSpec.describe Metalware::Validation::Configure do
       expect_configure_error(h, /invalid top level key/)
     end
 
-    # it 'fails if question is not a hash' do
-    #   h = correct_hash.deep_merge(group: {
-    #                                 question: 'Am I missing my mid level question key?',
-    #                                 type: 'string',
-    #                                 default: 'Each field will now be interpreted as a separate question',
-    #                               })
-    #   results = build_validator(h).validate.errors
-    #   expect(results.keys).to eq([:parameters])
-    #   expect(results[:parameters][0]).to eq('must be a hash')
-    # end
+    it 'fails if sections are not an array' do
+      h = correct_hash.deep_merge(group: { key: 'I am not an array' })
+      expect_configure_error(h, /must be an array/)
+    end
   end
 
-  # context 'with invalid question fields' do
-  #   it 'fails if unrecognized fields in a question' do
-  #     h = correct_hash.deep_merge(domain: {
-  #                                   invalid_field_question: {
-  #                                     question: 'Do I have have an unrecognized field?',
-  #                                     default: 'I do',
-  #                                     invalid_filed: true,
-  #                                   },
-  #                                 })
-  #     expect(run_configure_validation(h).keys).to eq([:valid_top_level_question_keys])
-  #   end
+  context 'with invalid question fields' do
+    # it 'fails if question is missing a title' do
+    #   h = correct_hash.deep_merge(domain: {
+    #                                 missing_title_question: {
+    #                                   default: 'I am missing my question!',
+    #                                 },
+    #                               })
+    #   results = run_configure_validation(h)
+    #   expect(results[:parameters][:question][0]).to eq('is missing')
+    # end
 
-  #   it 'fails if question is missing a title' do
-  #     h = correct_hash.deep_merge(domain: {
-  #                                   missing_title_question: {
-  #                                     default: 'I am missing my question!',
-  #                                   },
-  #                                 })
-  #     results = run_configure_validation(h)
-  #     expect(results[:parameters][:question][0]).to eq('is missing')
-  #   end
+    # it 'fails if question if the title is empty' do
+    #   h = correct_hash.deep_merge(node: {
+    #                                 missing_title_question: {
+    #                                   question: '',
+    #                                   default: 'I am missing my question!',
+    #                                 },
+    #                               })
+    #   results = run_configure_validation(h)
+    #   expect(results[:parameters][:question][0]).to eq('must be filled')
+    # end
 
-  #   it 'fails if question if the title is empty' do
-  #     h = correct_hash.deep_merge(node: {
-  #                                   missing_title_question: {
-  #                                     question: '',
-  #                                     default: 'I am missing my question!',
-  #                                   },
-  #                                 })
-  #     results = run_configure_validation(h)
-  #     expect(results[:parameters][:question][0]).to eq('must be filled')
-  #   end
+    # it "fails if type isn't supported" do
+    #   h = correct_hash.deep_merge(group: {
+    #                                 unsupported_type: {
+    #                                   question: 'Do I have an unsupported type?',
+    #                                   type: 'Unsupported',
+    #                                 },
+    #                               })
+    #   results = run_configure_validation(h)
+    #   expect(results[:parameters].keys).to eq([:type])
+    # end
 
-  #   it "fails if type isn't supported" do
-  #     h = correct_hash.deep_merge(group: {
-  #                                   unsupported_type: {
-  #                                     question: 'Do I have an unsupported type?',
-  #                                     type: 'Unsupported',
-  #                                   },
-  #                                 })
-  #     results = run_configure_validation(h)
-  #     expect(results[:parameters].keys).to eq([:type])
-  #   end
-
-  #   it 'fails if the optional input is not true or false' do
-  #     h = correct_hash.deep_merge(group: {
-  #                                   invalid_optional_flag: {
-  #                                     question: 'Do I have a boolean optional input?',
-  #                                     optional: 'I should be true or false',
-  #                                   },
-  #                                 })
-  #     results = run_configure_validation(h)
-  #     expect(results[:parameters].keys).to eq([:optional])
-  #   end
-  # end
+    # it 'fails if the optional input is not true or false' do
+    #   h = correct_hash.deep_merge(group: {
+    #                                 invalid_optional_flag: {
+    #                                   question: 'Do I have a boolean optional input?',
+    #                                   optional: 'I should be true or false',
+    #                                 },
+    #                               })
+    #   results = run_configure_validation(h)
+    #   expect(results[:parameters].keys).to eq([:optional])
+    # end
+  end
 
   # context 'with missing question blocks' do
   #   it 'fails when domain is missing' do

--- a/spec/validation/saver_spec.rb
+++ b/spec/validation/saver_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Metalware::Validation::Saver do
   let :saver do
     Metalware::Validation::Saver.new(config)
   end
-  let :stubbed_answer_load { OpenStruct.new({data: data}) }
+  let :stubbed_answer_load { OpenStruct.new(data: data) }
   let :data { { key: 'data' } }
 
   let :filesystem do

--- a/spec/validation/saver_spec.rb
+++ b/spec/validation/saver_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'validation/saver'
+require 'config'
+require 'filesystem'
+
+module SaverSpec
+  module TestingMethods
+    def input_test(*a)
+      a
+    end
+
+    def data_test(*_a)
+      data
+    end
+  end
+end
+Metalware::Validation::Saver::Methods.prepend(SaverSpec::TestingMethods)
+
+RSpec.describe Metalware::Validation::Saver do
+  let :config { Metalware::Config.new }
+
+  let :saver do
+    Metalware::Validation::Saver.new(config)
+  end
+
+  let :filesystem do
+    filesystem.setup(&:with_minimal_repo)
+  end
+
+  it 'errors if method is not defined' do
+    expect do
+      saver.not_found_methods('data')
+    end.to raise_error(NoMethodError)
+  end
+
+  it 'errors if data is not included' do
+    expect do
+      saver.domain_answers
+    end.to raise_error(Metalware::SaverNoData)
+  end
+
+  it 'passes an arguments and data to the save method' do
+    inputs = ['arg1', hash: 'value']
+    data = { key: 'data' }
+    expect(
+      saver.input_test(data, *inputs)
+    ).to eq(inputs)
+    expect(
+      saver.data_test(data, *inputs)
+    ).to eq(data)
+  end
+end

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -48,14 +48,7 @@ module Metalware
       end
 
       def answers
-        if options.answers
-          JSON.parse(options.answers)
-        else
-          # The `--answers` option has not been passed; the Configurator will
-          # ask the questions on the command line to get the answers to be
-          # saved.
-          nil
-        end
+        JSON.parse(options.answers) if options.answers
       end
 
       def handle_interrupt(_e)

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -32,8 +32,6 @@ module Metalware
     class ConfigureCommand < BaseCommand
       private
 
-      delegate :answers_file, to: :configurator
-
       GENDERS_INVALID_MESSAGE = <<-EOF.strip_heredoc
         You should be able to fix this error by re-running the `configure`
         command and correcting the invalid input, or by manually editing the
@@ -60,8 +58,12 @@ module Metalware
         # should be performed in this method in subclasses.
       end
 
+      def answer_file
+        raise NotImplementedError
+      end
+
       def relative_answer_file
-        answers_file.sub("#{config.answer_files_path}/", '')
+        answer_file.sub("#{config.answer_files_path}/", '')
       end
 
       def dependency_hash

--- a/src/commands/configure/domain.rb
+++ b/src/commands/configure/domain.rb
@@ -12,6 +12,10 @@ module Metalware
 
         def setup; end
 
+        def answer_file
+          file_path.domain_answers
+        end
+
         def configurator
           @configurator ||=
             Configurator.for_domain(config: config)

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -44,6 +44,10 @@ module Metalware
             Configurator.for_group(group_name, config: config)
         end
 
+        def answer_file
+          file_path.group_answers(group_name)
+        end
+
         def custom_configuration
           record_primary_group
         end

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -18,11 +18,7 @@ module Metalware
 
         def configurator
           @configurator ||=
-            Configurator.for_node(node, config: config)
-        end
-
-        def node
-          Metalware::Node.new(config, node_name)
+            Configurator.for_node(node_name, config: config)
         end
 
         def answer_file

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -25,6 +25,10 @@ module Metalware
           Metalware::Node.new(config, node_name)
         end
 
+        def answer_file
+          file_path.node_answers(node_name)
+        end
+
         def dependency_hash
           dependency_specifications.for_node_in_configured_group(node_name)
         end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -54,15 +54,15 @@ module Metalware
       # Note: This is slightly inconsistent with `for_group`, as that just
       # takes a group name and this takes a Node object (as we need to be able
       # to access the Node's primary group).
-      def for_node(node, config:)
+      def for_node(node_name, config:)
         file_path = FilePath.new(config)
         new(
           config: config,
           questions_section: :node,
-          name: node.name,
+          name: node_name,
           higher_level_answer_files: [
             file_path.domain_answers,
-            file_path.group_answers(node.primary_group),
+            file_path.group_answers(node_name.primary_group),
           ]
         )
       end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -69,14 +69,13 @@ module Metalware
     end
 
     def initialize(
-      highline: HighLine.new,
       config:,
       questions_section:,
       name: nil,
       higher_level_answer_files:,
       use_readline: true
     )
-      @highline = highline
+      @highline = HighLine.new
       @config = config
       @questions_section = questions_section
       @name = name

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -124,20 +124,7 @@ module Metalware
     end
 
     def old_answers
-      @old_answers ||= begin
-        case questions_section
-        when :domain
-          loader.domain_answers
-        when :group
-          raise 'Group name must be specified' if name.nil?
-          loader.group_answers(name)
-        when :node
-          raise 'Node name must be specified' if name.nil?
-          loader.node_answers(name)
-        else
-          raise InternalError, "Unrecognised question section: #{questions_section}"
-        end
-      end
+      @old_answers ||= loader.section_answers(questions_section, name)
     end
 
     def ask_questions
@@ -162,18 +149,7 @@ module Metalware
     end
 
     def save_answers(answers)
-      case questions_section
-      when :domain
-        saver.domain_answers(answers)
-      when :group
-        raise 'Group name must be specified' if name.nil?
-        saver.group_answers(answers, name)
-      when :node
-        raise 'Node name must be specified' if name.nil?
-        saver.node_answers(answers, name)
-      else
-        raise InternalError, "Unrecognised question section: #{questions_section}"
-      end
+      saver.section_answers(answers, questions_section, name)
     end
 
     def create_question(identifier, properties, index)

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -66,21 +66,24 @@ module Metalware
           ]
         )
       end
+
+      # Used by the tests to switch readline on and off
+      def use_readline
+        true
+      end
     end
 
     def initialize(
       config:,
       questions_section:,
       name: nil,
-      higher_level_answer_files:,
-      use_readline: true
+      higher_level_answer_files:
     )
       @highline = HighLine.new
       @config = config
       @questions_section = questions_section
       @name = name
       @higher_level_answer_files = higher_level_answer_files
-      @use_readline = use_readline
     end
 
     def configure(answers = nil)
@@ -102,8 +105,7 @@ module Metalware
                 :highline,
                 :questions_section,
                 :name,
-                :higher_level_answer_files,
-                :use_readline
+                :higher_level_answer_files
 
     def loader
       @loader ||= Validation::Loader.new(config)
@@ -190,7 +192,6 @@ module Metalware
         properties: properties,
         questions_section: questions_section,
         old_answer: old_answers[identifier],
-        use_readline: use_readline,
         progress_indicator: progress_indicator(index)
       )
     end
@@ -214,8 +215,7 @@ module Metalware
         :progress_indicator,
         :question,
         :required,
-        :type,
-        :use_readline
+        :type
 
       def initialize(
         config:,
@@ -224,8 +224,7 @@ module Metalware
         old_answer: nil,
         progress_indicator:,
         properties:,
-        questions_section:,
-        use_readline:
+        questions_section:
       )
         @choices = properties[:choices]
         @default = default
@@ -234,7 +233,6 @@ module Metalware
         @progress_indicator = progress_indicator
         @question = properties[:question]
         @required = !properties[:optional]
-        @use_readline = use_readline
 
         @type = type_for(
           properties[:type],
@@ -270,7 +268,7 @@ module Metalware
         # Dont't provide readline bindings for boolean questions, in this case
         # they cause an issue where the question is repeated twice if no/bad
         # input is entered, and they are not really necessary in this case.
-        use_readline && type != :boolean
+        Metalware::Configurator.use_readline && type != :boolean
       end
 
       def default_input

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -80,7 +80,7 @@ module Metalware
       @config = config
       @questions_section = questions_section
       @name = name,
-      @higher_level_answer_files = higher_level_answer_files
+              @higher_level_answer_files = higher_level_answer_files
       @use_readline = use_readline
     end
 

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -79,8 +79,8 @@ module Metalware
       @highline = highline
       @config = config
       @questions_section = questions_section
-      @name = name,
-              @higher_level_answer_files = higher_level_answer_files
+      @name = name
+      @higher_level_answer_files = higher_level_answer_files
       @use_readline = use_readline
     end
 

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -245,7 +245,7 @@ module Metalware
       end
 
       def ask(highline)
-        ask_method = "ask_#{type}_question"
+        ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'
         send(ask_method, highline) do |highline_question|
           highline_question.readline = true if use_readline?
 

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -180,6 +180,9 @@ module Metalware
       super(msg)
     end
   end
+
+  class InternalError < MetalwareError
+  end
 end
 
 # Alias for Exception to use to indicate we want to catch everything, and to

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -160,6 +160,13 @@ module Metalware
   class MissingExternalDNS < MetalwareError
   end
 
+  class SaverNoData < MetalwareError
+    def initialize(msg = 'No data provided to Validation::Saver'); end
+  end
+
+  class MissingExternalDNS < MetalwareError
+  end
+
   class SelfBuildMethodError < MetalwareError
     def initialize(build_method: nil, building_self_node: true)
       msg = if build_method

--- a/src/repo.rb
+++ b/src/repo.rb
@@ -1,5 +1,6 @@
 
 # frozen_string_literal: true
+require 'constants'
 
 require 'constants'
 

--- a/src/repo.rb
+++ b/src/repo.rb
@@ -2,8 +2,7 @@
 # frozen_string_literal: true
 
 require 'constants'
-
-require 'constants'
+require 'validation/loader'
 
 module Metalware
   class Repo
@@ -21,8 +20,12 @@ module Metalware
 
     private
 
+    def loader
+      @loader ||= Validation::Loader.new(config)
+    end
+
     def configure_data
-      @configure_data ||= Data.load(config.configure_file)
+      @configure_data ||= loader.configure_data
     end
 
     def configure_data_sections

--- a/src/repo.rb
+++ b/src/repo.rb
@@ -1,5 +1,6 @@
 
 # frozen_string_literal: true
+
 require 'constants'
 
 require 'constants'

--- a/src/validation/answer.rb
+++ b/src/validation/answer.rb
@@ -74,7 +74,7 @@ module Metalware
         @validation_result.success?
       end
 
-      def load
+      def data
         success? ? answers : (raise ValidationFailure, error_message)
       end
 

--- a/src/validation/answer.rb
+++ b/src/validation/answer.rb
@@ -30,9 +30,9 @@ module Metalware
     class Answer
       ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
-      def initialize(metalware_config, answer_file, answer_section: nil)
+      def initialize(metalware_config, answers, answer_section: nil)
         @config = metalware_config
-        @answer_file_path = answer_file
+        @answers = answers
         @section = answer_section
       end
 
@@ -56,7 +56,7 @@ module Metalware
       def error_message
         validate if @validation_result.nil?
         return '' if @validation_result.success?
-        msg_header = "Failed to validate answers: #{answer_file_path}\n"
+        msg_header = "Failed to validate answers:\n"
         case @last_ran_test
         when :MissingSchema
           "#{msg_header}" \
@@ -80,7 +80,7 @@ module Metalware
 
       private
 
-      attr_reader :config, :answer_file_path, :section
+      attr_reader :config, :section, :answers
 
       def loader
         @loader ||= Validation::Loader.new(config)
@@ -92,10 +92,6 @@ module Metalware
 
       def questions
         loader.configure_data
-      end
-
-      def answers
-        @answers ||= Data.load(answer_file_path)
       end
 
       def validation_hash

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -71,6 +71,7 @@ module Metalware
 
       QuestionSchema = Dry::Validation.Schema do
         required(:identifier) { filled? & str? }
+        required(:question) { filled? & str? }
       end
 
       ConfigureSchema = Dry::Validation.Schema do

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -72,6 +72,7 @@ module Metalware
       QuestionSchema = Dry::Validation.Schema do
         required(:identifier) { filled? & str? }
         required(:question) { filled? & str? }
+        optional(:optional) { bool? }
       end
 
       ConfigureSchema = Dry::Validation.Schema do

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -37,7 +37,7 @@ module Metalware
 
       # NOTE: Supported types in error.yaml message must be updated manually
 
-      # SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'choice'].freeze
+      SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'choice'].freeze
       # BOOLEAN_VALUE = ['yes', 'no'].freeze
       ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
@@ -70,9 +70,19 @@ module Metalware
       end
 
       QuestionSchema = Dry::Validation.Schema do
+        configure do
+          config.messages_file = ERROR_FILE
+          config.namespace = :configure
+
+          def supported_type?(value)
+            SUPPORTED_TYPES.include?(value)
+          end
+        end
+
         required(:identifier) { filled? & str? }
         required(:question) { filled? & str? }
         optional(:optional) { bool? }
+        optional(:type) { supported_type? }
       end
 
       ConfigureSchema = Dry::Validation.Schema do

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -71,10 +71,9 @@ module Metalware
         array_data = raw_data.dup
         hash_data = {}
         Constants::CONFIGURE_SECTIONS.each do |section|
-          hash_data[section] = array_data[section].inject({}) do |memo, question|
+          hash_data[section] = array_data[section].each_with_object({}) do |question, memo|
             identifier = question.delete(:identifier)
             memo[identifier.to_sym] = question
-            memo
           end
         end
         hash_data

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -116,7 +116,8 @@ module Metalware
           config.namespace = :configure
 
           def top_level_keys?(data)
-            (data.keys - Constants::CONFIGURE_SECTIONS.push(:questions)).empty?
+            section = Constants::CONFIGURE_SECTIONS.dup.push(:questions)
+            (data.keys - section).empty?
           end
         end
 

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -47,7 +47,7 @@ module Metalware
         when 'integer'
           value.is_a?(Integer)
         when 'boolean'
-          value == 'yes' || value == 'no'
+          [true, false].include?(value)
         else
           false
         end

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -37,7 +37,7 @@ module Metalware
 
       # NOTE: Supported types in error.yaml message must be updated manually
 
-      SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'choice'].freeze
+      SUPPORTED_TYPES = ['string', 'integer', 'boolean'].freeze
       ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
       def self.type_check(type, value)

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -38,7 +38,6 @@ module Metalware
       # NOTE: Supported types in error.yaml message must be updated manually
 
       SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'choice'].freeze
-      # BOOLEAN_VALUE = ['yes', 'no'].freeze
       ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
       def initialize(config, data_hash = nil)
@@ -47,7 +46,7 @@ module Metalware
       end
 
       def data
-        raise ValidationFailure, validate.errors unless validate.success?
+        raise ValidationFailure, validate.errors[:data] unless validate.success?
         raw_data.dup
       end
 
@@ -114,10 +113,12 @@ module Metalware
                 case type
                 when 'string', nil
                   default.is_a?(String)
+                when 'integer'
+                  default.is_a?(Integer)
+                when 'boolean'
+                  default == 'yes' || default == 'no'
                 else
-                  true
-                  # TODO: This needs to be uncommented to replace the true
-                  #raise NotImplementedError
+                  false
                 end
               end
             end

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -69,6 +69,10 @@ module Metalware
         end
       end
 
+      QuestionSchema = Dry::Validation.Schema do
+        required(:identifier) { filled? & str? }
+      end
+
       ConfigureSchema = Dry::Validation.Schema do
         configure do
           config.messages_file = ERROR_FILE
@@ -85,13 +89,12 @@ module Metalware
             ::Metalware::Constants::CONFIGURE_SECTIONS.each do |section|
               required(section) do
                 # Loops through each question
-                array?# & each { schema(QuestionSchema) }
+                array? & each { schema(QuestionSchema) }
               end
             end
           end
         end
       end
-
 
       # QuestionSchema = Dry::Validation.Schema do
       #   configure do

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -40,6 +40,19 @@ module Metalware
       SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'choice'].freeze
       ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
+      def self.type_check(type, value)
+        case type
+        when 'string', nil
+          value.is_a?(String)
+        when 'integer'
+          value.is_a?(Integer)
+        when 'boolean'
+          value == 'yes' || value == 'no'
+        else
+          false
+        end
+      end
+
       def initialize(config, data_hash = nil)
         @config = config
         @raw_data = (data_hash || load_configure_file).freeze
@@ -72,19 +85,6 @@ module Metalware
         msg_header = 'An error occurred validating the questions. ' \
                      "The following error(s) have been detected: \n"
         msg_header + validate.errors[:data].to_s
-      end
-
-      def self.type_check(type, value)
-        case type
-        when 'string', nil
-          value.is_a?(String)
-        when 'integer'
-          value.is_a?(Integer)
-        when 'boolean'
-          value == 'yes' || value == 'no'
-        else
-          false
-        end
       end
 
       QuestionSchema = Dry::Validation.Schema do
@@ -157,7 +157,7 @@ module Metalware
                 # Loops through each question
                 array? & each do
                   schema(QuestionSchema) & \
-                  default_type? & choice_with_default? & choice_type?
+                    default_type? & choice_with_default? & choice_type?
                 end
               end
             end

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -47,7 +47,7 @@ module Metalware
       end
 
       def data
-        raise ValidationFailure, validate.errors unless validate.success?
+        raise ValidationFailure, validate.errors[:data] unless validate.success?
         raw_data.dup
       end
 
@@ -79,8 +79,19 @@ module Metalware
           end
         end
 
-        required(:data).value(:top_level_keys?)
+        required(:data) do
+          top_level_keys? & schema do
+            # Loops through each section
+            ::Metalware::Constants::CONFIGURE_SECTIONS.each do |section|
+              required(section) do
+                # Loops through each question
+                array?# & each { schema(QuestionSchema) }
+              end
+            end
+          end
+        end
       end
+
 
       # QuestionSchema = Dry::Validation.Schema do
       #   configure do

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -46,7 +46,7 @@ module Metalware
       end
 
       def data
-        raise ValidationFailure, validate.errors[:data] unless validate.success?
+        raise ValidationFailure, error_msg unless validate.success?
         raw_data.dup
       end
 
@@ -66,6 +66,12 @@ module Metalware
         @validate ||= begin
           ConfigureSchema.call(data: raw_data)
         end
+      end
+
+      def error_msg
+        msg_header = 'An error occurred validating the questions. ' \
+                     "The following error(s) have been detected: \n"
+        msg_header + validate.errors[:data].to_s
       end
 
       QuestionSchema = Dry::Validation.Schema do
@@ -127,7 +133,9 @@ module Metalware
             ::Metalware::Constants::CONFIGURE_SECTIONS.each do |section|
               required(section) do
                 # Loops through each question
-                array? & each { schema(QuestionSchema) } & each { default_type? }
+                array? & \
+                each { schema(QuestionSchema) } & \
+                each { default_type? }
               end
             end
           end

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -47,6 +47,11 @@ module Metalware
         @raw_data = (data_hash || load_configure_file).freeze
       end
 
+      def data
+        validate
+        raw_data.dup
+      end
+
       private
 
       attr_reader :config, :raw_data
@@ -59,25 +64,8 @@ module Metalware
         Data.load(file_path.configure_file)
       end
 
-      # def validate
-      #   @validate ||= begin
-      #     configure_results = ConfigureSchema.call(yaml: @yaml)
-      #     if configure_results.success?
-      #       [:domain, :group, :node, :self].each do |section|
-      #         @yaml[section].each do |identifier, parameters|
-      #           payload = {
-      #             section: section,
-      #             identifier: identifier,
-      #             parameters: parameters,
-      #           }
-      #           question_results = QuestionSchema.call(payload)
-      #           return question_results unless question_results.success?
-      #         end
-      #       end
-      #     end
-      #     configure_results
-      #   end
-      # end
+      def validate
+      end
 
       # def success?
       #   validate.success?

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -94,6 +94,7 @@ module Metalware
         optional(:optional) { bool? }
         optional(:type) { supported_type? }
         optional(:default) { default? }
+        optional(:choice) { array? }
       end
 
       ConfigureSchema = Dry::Validation.Schema do
@@ -127,6 +128,15 @@ module Metalware
                   false
                 end
               end
+
+              def choice_with_default?(value)
+                return true if value[:choice].nil? || value[:default].nil?
+                return false unless value[:choice].is_a?(Array)
+                value[:choice].include?(value[:default])
+              end
+
+              def choice_type?(value)
+              end
             end
 
             # Loops through each section
@@ -135,7 +145,7 @@ module Metalware
                 # Loops through each question
                 array? & \
                 each { schema(QuestionSchema) } & \
-                each { default_type? }
+                each { default_type? & choice_with_default? }
               end
             end
           end

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -21,7 +21,9 @@
 # For more information on the Alces Metalware, please visit:
 # https://github.com/alces-software/metalware
 #==============================================================================
+
 require 'exceptions'
+require 'file_path'
 require 'data'
 require 'dry-validation'
 require 'active_support/core_ext/module/delegation'
@@ -40,9 +42,22 @@ module Metalware
       # BOOLEAN_VALUE = ['yes', 'no'].freeze
       # ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
-      # def initialize(file:, hash:)
-        
-      # end
+      def initialize(config, data_hash = nil)
+        @config = config
+        @raw_data = (data_hash || load_configure_file).freeze
+      end
+
+      private
+
+      attr_reader :config, :raw_data
+
+      def file_path
+        @file_path ||= FilePath.new(config)
+      end
+
+      def load_configure_file
+        Data.load(file_path.configure_file)
+      end
 
       # def validate
       #   @validate ||= begin

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -35,117 +35,111 @@ module Metalware
       # determined by whether they are supplied.
 
       # NOTE: Supported types in error.yaml message must be updated manually
-      SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'choice'].freeze
-      BOOLEAN_VALUE = ['yes', 'no'].freeze
-      ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
-      def initialize(file)
-        @yaml = Data.load(file)
-      end
+      # SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'choice'].freeze
+      # BOOLEAN_VALUE = ['yes', 'no'].freeze
+      # ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
-      def validate
-        @validate ||= begin
-          configure_results = ConfigureSchema.call(yaml: @yaml)
-          if configure_results.success?
-            Constants::CONFIGURE_SECTIONS.each do |section|
-              @yaml[section].each do |identifier, parameters|
-                payload = {
-                  section: section,
-                  identifier: identifier,
-                  parameters: parameters,
-                }
-                question_results = QuestionSchema.call(payload)
-                return question_results unless question_results.success?
-              end
-            end
-          end
-          configure_results
-        end
-      end
+      # def initialize(file:, hash:)
+        
+      # end
 
-      delegate :success?, to: :validate
+      # def validate
+      #   @validate ||= begin
+      #     configure_results = ConfigureSchema.call(yaml: @yaml)
+      #     if configure_results.success?
+      #       [:domain, :group, :node, :self].each do |section|
+      #         @yaml[section].each do |identifier, parameters|
+      #           payload = {
+      #             section: section,
+      #             identifier: identifier,
+      #             parameters: parameters,
+      #           }
+      #           question_results = QuestionSchema.call(payload)
+      #           return question_results unless question_results.success?
+      #         end
+      #       end
+      #     end
+      #     configure_results
+      #   end
+      # end
 
-      # TODO: make these error messages more descriptive
-      def load
-        raise ValidationFailure, validate.messages unless success?
-        @yaml
-      end
+      # def success?
+      #   validate.success?
+      # end
 
-      private
+      # # TODO: make these error messages more descriptive
+      # def load
+      #   raise ValidationFailure, validate.messages unless success?
+      #   @yaml
+      # end
 
-      QuestionSchema = Dry::Validation.Schema do
-        configure do
-          config.messages_file = ERROR_FILE
-          config.namespace = :configure_question
+      # private
 
-          def question_type?(value)
-            SUPPORTED_TYPES.include?(value)
-          end
+      # QuestionSchema = Dry::Validation.Schema do
+      #   configure do
+      #     config.messages_file = ERROR_FILE
+      #     config.namespace = :configure_question
 
-          def boolean?(value)
-            BOOLEAN_VALUE.include?(value)
-          end
+      #     def question_type?(value)
+      #       SUPPORTED_TYPES.include?(value)
+      #     end
 
-          def empty_string?(value)
-            value.is_a?(String) && value.empty?
-          end
-        end
+      #     def boolean?(value)
+      #       BOOLEAN_VALUE.include?(value)
+      #     end
+      #   end
 
-        validate(valid_top_level_question_keys: :parameters) do |q|
-          (q.keys - [:question, :type, :default, :choice, :optional]).empty?
-        end
+      #   validate(valid_top_level_question_keys: :parameters) do |q|
+      #     (q.keys - [:question, :type, :default, :choice, :optional]).empty?
+      #   end
 
-        required(:parameters).value(:hash?)
-        required(:parameters).schema do
-          required(:question).value(:str?, :filled?)
-          optional(:type).value(:question_type?)
-          optional(:default) { filled? | str? }
-          optional(:optional).value(:bool?)
+      #   required(:parameters).value(:hash?)
+      #   required(:parameters).schema do
+      #     required(:question).value(:str?, :filled?)
+      #     optional(:type).value(:question_type?)
+      #     optional(:default) { filled? | str? }
+      #     optional(:optional).value(:bool?)
 
-          # NOTE: The crazy logic on the LHS of the then ('>') is because
-          # the RHS determines the error message. Hence the RHS needs to be
-          # as simple as possible otherwise the error message will be crazy
-          rule(default_string_type: [:default, :type]) do |default, type|
-            (default.filled? & (type.none? | type.eql?('string'))) > default.str?
-          end
+      #     # NOTE: The crazy logic on the LHS of the then ('>') is because
+      #     # the RHS determines the error message. Hence the RHS needs to be
+      #     # as simple as possible otherwise the error message will be crazy
+      #     rule(default_string_type: [:default, :type]) do |default, type|
+      #       (default.filled? & (type.none? | type.eql?('string'))) > default.str?
+      #     end
 
-          # Enforces empty string defaults have a string type
-          rule(default_empty_string_type: [:default, :type]) do |default, type|
-            default.empty_string? > (type.none? | type.eql?('string'))
-          end
+      #     rule(default_integer_type: [:default, :type]) do |default, type|
+      #       (default.filled? & type.eql?('integer')) > default.int?
+      #     end
 
-          rule(default_integer_type: [:default, :type]) do |default, type|
-            (default.filled? & type.eql?('integer')) > default.int?
-          end
+      #     rule(default_boolean_type: [:default, :type]) do |default, type|
+      #       (default.filled? & type.eql?('boolean')) > default.boolean?
+      #     end
 
-          rule(default_boolean_type: [:default, :type]) do |default, type|
-            (default.filled? & type.eql?('boolean')) > default.boolean?
-          end
+      #     # Choice does not currently support default answers
+      #     rule(default_choice_type: [:default, :type]) do |default, type|
+      #       default.none? | type.excluded_from?(['choice'])
+      #     end
+      #   end
+      # end
 
-          # Choice does not currently support default answers
-          rule(default_choice_type: [:default, :type]) do |default, type|
-            default.none? | type.excluded_from?(['choice'])
-          end
-        end
-      end
+      # ConfigureSchema = Dry::Validation.Schema do
+      #   configure do
+      #     config.messages_file = ERROR_FILE
+      #     config.namespace = :configure
+      #   end
 
-      ConfigureSchema = Dry::Validation.Schema do
-        configure do
-          config.messages_file = ERROR_FILE
-          config.namespace = :configure
-        end
+      #   # White-lists the keys allowed in the configure.yaml file
+      #   validate(valid_top_level_keys: :yaml) do |yaml|
+      #     (yaml.keys - [:domain, :self, :group, :node, :questions]).empty?
+      #   end
 
-        # White-lists the keys allowed in the configure.yaml file
-        validate(valid_top_level_keys: :yaml) do |yaml|
-          (yaml.keys - [:domain, :self, :group, :node, :questions]).empty?
-        end
-
-        required(:yaml).schema do
-          required(:domain).value(:hash?)
-          required(:group).value(:hash?)
-          required(:node).value(:hash?)
-        end
-      end
+      #   required(:yaml).schema do
+      #     required(:domain).value(:hash?)
+      #     required(:group).value(:hash?)
+      #     required(:node).value(:hash?)
+      #   end
+      # end
     end
   end
 end

--- a/src/validation/errors.yaml
+++ b/src/validation/errors.yaml
@@ -7,6 +7,8 @@ en:
           , 'node', and 'self' are allowed
         supported_type?: >
           Is an unsupported question type
+        default?: >
+          Default's must be filled or a string
         default_type?: >
           The question type does not match the default
 

--- a/src/validation/errors.yaml
+++ b/src/validation/errors.yaml
@@ -11,6 +11,8 @@ en:
           Default's must be filled or a string
         default_type?: >
           The question type does not match the default
+        choice_with_default?: >
+          The default must appear in the choice list
 
       answer:
         missing_questions?: >

--- a/src/validation/errors.yaml
+++ b/src/validation/errors.yaml
@@ -13,6 +13,8 @@ en:
           The question type does not match the default
         choice_with_default?: >
           The default must appear in the choice list
+        choice_type?: >
+          All choices must match the question type
 
       answer:
         missing_questions?: >

--- a/src/validation/errors.yaml
+++ b/src/validation/errors.yaml
@@ -2,22 +2,9 @@ en:
   errors:
     rules:
       configure:
-        valid_top_level_keys: >
-          'configure.yaml' must only contain 'domain', 'group', 'node', and
-          'questions'
-
-      configure_question:
-        question_type?: >
-          Type must be: 'string', 'integer', or 'boolean'
-        valid_top_level_question_keys: >
-          Questions can only have the following fields: 'question', 'type',
-          'default' 'choice', 'optional'
-        default_type?: >
-          Type mismatch between question 'type' and 'default' value
-        boolean?: >
-          Boolean defaults must be 'yes' or 'no'
-        empty_string?:
-          Empty string defaults must have a string type
+        top_level_keys?: >
+          An invalid top level key has been detected. Only 'questions', 'domain'
+          , 'node', and 'self' are allowed
 
       answer:
         missing_questions?: >

--- a/src/validation/errors.yaml
+++ b/src/validation/errors.yaml
@@ -5,6 +5,10 @@ en:
         top_level_keys?: >
           An invalid top level key has been detected. Only 'questions', 'domain'
           , 'node', and 'self' are allowed
+        supported_type?: >
+          Is an unsupported question type
+        default_type?: >
+          The question type does not match the default
 
       answer:
         missing_questions?: >

--- a/src/validation/load_save_base.rb
+++ b/src/validation/load_save_base.rb
@@ -22,57 +22,36 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
-require 'exceptions'
 require 'file_path'
 require 'validation/answer'
+require 'validation/configure'
 require 'data'
 
 module Metalware
   module Validation
-    class Saver
-      def initialize(metalware_config)
-        @config = metalware_config
+    class LoadSaveBase
+      def initialize(*_a)
+        raise NotImplementedError
       end
 
-      def respond_to_missing?(s, *_a)
-        Methods.instance_methods.include?(s)
+      def domain_answers
+        answer(path.domain_answers, :domain)
       end
 
-      # Enforces the first argument to always be the data
-      def method_missing(s, *a, &b)
-        data = a[0]
-        if respond_to_missing?(s)
-          raise SaverNoData unless data
-          Methods.new(config, data).send(s, *a[1..-1], &b)
-        else
-          super
-        end
+      def group_answers(file)
+        answer(path.group_answers(file), :groups)
+      end
+
+      def node_answers(file)
+        answer(path.node_answers(file), :nodes)
       end
 
       private
 
-      attr_reader :config
+      attr_reader :path, :config
 
-      def method_builder(data)
-        Methods.new(config, data)
-      end
-
-      class Methods < LoadSaveBase
-        def initialize(config, data)
-          @config = config
-          @path = FilePath.new(config)
-          @data = data
-        end
-
-        private
-
-        attr_reader :path, :config, :data
-
-        def answer(save_path, section)
-          valid = Validation::Answer.new(config, data, answer_section: section)
-                                    .data
-          Data.dump(save_path, valid)
-        end
+      def answer(absolute_path, section)
+        raise NotImplementedError
       end
     end
   end

--- a/src/validation/load_save_base.rb
+++ b/src/validation/load_save_base.rb
@@ -50,7 +50,7 @@ module Metalware
 
       attr_reader :path, :config
 
-      def answer(absolute_path, section)
+      def answer(_absolute_path, _section)
         raise NotImplementedError
       end
     end

--- a/src/validation/load_save_base.rb
+++ b/src/validation/load_save_base.rb
@@ -46,6 +46,21 @@ module Metalware
         answer(path.node_answers(file), :nodes)
       end
 
+      def section_answers(section, name = nil)
+        case section
+        when :domain
+          domain_answers
+        when :group
+          raise InternalError, 'No group name given' if name.nil?
+          group_answers(name)
+        when :node
+          raise InternalError, 'No node name given' if name.nil?
+          node_answers(name)
+        else
+          raise InternalError, "Unrecognised question seciton: #{section}"
+        end
+      end
+
       private
 
       attr_reader :path, :config

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -36,7 +36,7 @@ module Metalware
       end
 
       def configure_data
-        Validation::Configure.new(path.configure_file).load
+        Validation::Configure.new(config).data
       end
 
       def group_cache

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -68,7 +68,7 @@ module Metalware
         validator = Validation::Answer.new(config,
                                            yaml,
                                            answer_section: section)
-        validator.load
+        validator.data
       end
     end
   end

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -64,8 +64,9 @@ module Metalware
       attr_reader :path, :config
 
       def answer(absolute_path, section)
+        yaml = Data.load(absolute_path)
         validator = Validation::Answer.new(config,
-                                           absolute_path,
+                                           yaml,
                                            answer_section: section)
         validator.load
       end

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -25,11 +25,12 @@
 require 'file_path'
 require 'validation/answer'
 require 'validation/configure'
+require 'validation/load_save_base'
 require 'data'
 
 module Metalware
   module Validation
-    class Loader
+    class Loader < LoadSaveBase
       def initialize(metalware_config)
         @config = metalware_config
         @path = FilePath.new(config)
@@ -41,22 +42,6 @@ module Metalware
 
       def group_cache
         Data.load(path.group_cache)
-      end
-
-      def self_answers
-        answer(path.self_answers, :self)
-      end
-
-      def domain_answers
-        answer(path.domain_answers, :domain)
-      end
-
-      def group_answers(file)
-        answer(path.group_answers(file), :groups)
-      end
-
-      def node_answers(file)
-        answer(path.node_answers(file), :nodes)
       end
 
       private

--- a/src/validation/saver.rb
+++ b/src/validation/saver.rb
@@ -64,11 +64,17 @@ module Metalware
           @data = data
         end
 
-        def domain_answers; end
+        def domain_answers
+          Data.dump(path.domain_answers, validate_answer(:domain))
+        end
 
         private
 
         attr_reader :path, :config, :data
+
+        def validate_answer(section)
+          Validation::Answer.new(config, data, answer_section: section).data
+        end
       end
     end
   end

--- a/src/validation/saver.rb
+++ b/src/validation/saver.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'exceptions'
+require 'file_path'
+require 'validation/answer'
+require 'data'
+
+module Metalware
+  module Validation
+    class Saver
+      def initialize(metalware_config)
+        @config = metalware_config
+      end
+
+      def respond_to_missing?(s, *_a)
+        Methods.instance_methods.include?(s)
+      end
+
+      # Enforces the first argument to always be the data
+      def method_missing(s, *a, &b)
+        data = a[0]
+        if respond_to_missing?(s)
+          raise SaverNoData unless data
+          Methods.new(config, data).send(s, *a[1..-1], &b)
+        else
+          super
+        end
+      end
+
+      private
+
+      attr_reader :config
+
+      def method_builder(data)
+        Methods.new(config, data)
+      end
+
+      class Methods
+        def initialize(config, data)
+          @config = config
+          @path = FilePath.new(config)
+          @data = data
+        end
+
+        def domain_answers; end
+
+        private
+
+        attr_reader :path, :config, :data
+      end
+    end
+  end
+end


### PR DESCRIPTION
The large number of commits in this PR is the culmination of work dealing with the `configure.yaml` questions and the `Configurator`.

The three broad sections of commits are:
- Change the `configure.yaml` data structure to be based on an array. This has simplified the validation significantly. Also the last stage of the `Validation` is to convert to the previous hash format so `Metalware` has not changed internally.
- Implement the file `Saver`. This allows answer files to be validated before they are saved.
- Refactor `Configurator` to reduce the number of inputs. It previously had inputs which where only used for testing purposes (e.g. `Highline`) which have been removed and the objects mocked instead. The `higher_level_answers` could also be determined internally to `Configurator` so it has also been removed as an input. 