### PR TITLE
Fixing various bugs for v2017.1.0 release

### DIFF
--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Metalware::Commands::Configure::Node do
       expect(Metalware::Configurator).to receive(:new).with(
         config: instance_of(Metalware::Config),
         questions_section: :node,
-        name:'testnode01'
+        name: 'testnode01'
       ).and_call_original
 
       run_configure_node 'testnode01'

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -31,6 +31,7 @@ require 'config'
 require 'constants'
 require 'filesystem'
 require 'validation/loader'
+require 'validation/answer'
 
 RSpec.describe Metalware::Node do
   def node(name)
@@ -231,6 +232,9 @@ RSpec.describe Metalware::Node do
     before :each do
       allow(loader).to receive(:configure_data).and_return(configure_data)
       allow(Metalware::Validation::Loader).to receive(:new).and_return(loader)
+      # Turns off answer file validation as they do not match the configure.yaml
+      allow_any_instance_of(Metalware::Validation::Answer).to \
+        receive(:success?).and_return(true)
     end
 
     it 'performs a deep merge of defaults and answer files' do

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -28,6 +28,7 @@ require 'templater'
 require 'spec_utils'
 require 'node'
 require 'filesystem'
+require 'validation/answer'
 
 TEST_HUNTER_PATH = File.join(FIXTURES_PATH, 'cache/hunter.yaml')
 EMPTY_REPO_PATH = File.join(FIXTURES_PATH, 'configs/empty-repo.yaml')
@@ -406,6 +407,9 @@ RSpec.describe Metalware::Templater do
     # below?
     describe 'answers' do
       before :each do
+        # Turns off answer validation as the configure.yaml has not been created
+        allow_any_instance_of(Metalware::Validation::Answer).to \
+          receive(:success?).and_return(true)
         filesystem.dump '/var/lib/metalware/answers/nodes/testnode01.yaml',
                         some_question: 'some_answer'
       end

--- a/spec/templating/group_namespace_spec.rb
+++ b/spec/templating/group_namespace_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe Metalware::Templating::GroupNamespace do
 
   describe '#answers' do
     it 'returns the group answers merged into the domain answers' do
+      # Turns off answer file validation as they do not match the configure.yaml
+      allow_any_instance_of(Metalware::Validation::Answer).to \
+        receive(:success?).and_return(true)
+
       filesystem.test do
         expect(subject.answers.to_h).to eq(domain_value: 'domain_value',
                                            overriding_domain_value: 'testnodes_value',

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -39,7 +39,7 @@ module Metalware
 
     def run
       program :name, 'metal'
-      program :version, '2.0.0'
+      program :version, '2017.1.0'
       program :description, 'Alces tools for the management and configuration of bare metal machines'
 
       CliHelper::Parser.new(self).parse_commands

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -47,6 +47,10 @@ module Metalware
 
       def answers
         JSON.parse(options.answers) if options.answers
+      rescue => e
+        err = AnswerJSONSyntax.new('An error occurred passing the --answer JSON')
+        err.set_backtrace(e.backtrace)
+        raise err
       end
 
       def handle_interrupt(_e)

--- a/src/commands/configure/self.rb
+++ b/src/commands/configure/self.rb
@@ -22,7 +22,11 @@ module Metalware
 
         def configurator
           @configurator ||=
-            Configurator.for_node(self_node, config: config)
+            Configurator.for_self(config: config)
+        end
+
+        def answer_file
+          file_path.self_answers
         end
       end
     end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -61,6 +61,13 @@ module Metalware
         )
       end
 
+      def for_self(config:)
+        new(
+          config: config,
+          questions_section: :self
+        )
+      end
+
       # Used by the tests to switch readline on and off
       def use_readline
         true
@@ -119,7 +126,7 @@ module Metalware
         case questions_section
         when :domain
           []
-        when :group
+        when :group, :self
           [loader.domain_answers]
         when :node
           node = Node.new(config, name)

--- a/src/dns/named.rb
+++ b/src/dns/named.rb
@@ -75,13 +75,7 @@ module Metalware
 
       def restart_named
         MetalLog.info 'Restarting named'
-        loop_system_command('systemctl restart named')
-      end
-
-      def loop_system_command(cmds)
-        cmds.each do |cmd|
-          SystemCommand.run(cmd)
-        end
+        SystemCommand.run('systemctl restart named')
       end
 
       def each_network

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -183,6 +183,9 @@ module Metalware
 
   class InternalError < MetalwareError
   end
+
+  class AnswerJSONSyntax < MetalwareError
+  end
 end
 
 # Alias for Exception to use to indicate we want to catch everything, and to

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -50,7 +50,7 @@ module Metalware
     end
 
     def self_answers
-      File.join(answer_files, 'nodes/self.yaml')
+      File.join(answer_files, 'self.yaml')
     end
 
     def repo

--- a/src/templating/configuration.rb
+++ b/src/templating/configuration.rb
@@ -77,7 +77,7 @@ module Metalware
       def combine_answers
         config_answers = configs.map do |config_name|
           section = answer_section(config_name)
-          args = if section == :group || section == :node
+          args = if [:node, :group].include? section
                    [config_name]
                  else
                    []
@@ -87,7 +87,7 @@ module Metalware
         answer_hashes = [default_answers] + config_answers
         combine_hashes(answer_hashes)
       end
-      
+
       def answer_section(config_name)
         # XXX Using only the config name to determine the answers directory
         # will potentially lead to answers not being picked up if a group has

--- a/src/templating/missing_parameter_wrapper.rb
+++ b/src/templating/missing_parameter_wrapper.rb
@@ -25,34 +25,11 @@ module Metalware
         @wrapped_obj
       end
 
-      def [](a)
-        # ERB expects to be able to index in to the binding passed; this should
-        # function the same as a method call.
-        send(a)
-      end
-
       def wrapper_binding
         binding
       end
 
-      def updated_callstack(method, *args, &block)
-        str = method.to_s
-        str << "(#{args.join(',')})" unless args.empty?
-        str << '{ ... }' if block
-        @callstack + [str]
-      end
-
-      def callstack_string(callstack)
-        callstack.join('.')
-      end
-
       def method_missing(method, *args, &block)
-        if method.is_a?(Integer)
-          args.unshift(method)
-          method = :[]
-        elsif method == :send && args[0].is_a?(Integer)
-          args.unshift(:[])
-        end
         new_callstack = updated_callstack(method, *args, &block)
         value = @wrapped_obj.send(method, *args, &block)
         if value.nil? && !@missing_tags.include?(method)
@@ -70,6 +47,19 @@ module Metalware
         else
           MissingParameterWrapper.new(value, callstack: new_callstack)
         end
+      end
+
+      private
+
+      def updated_callstack(method, *args, &block)
+        str = method.to_s
+        str << "(#{args.join(',')})" unless args.empty?
+        str << '{ ... }' if block
+        @callstack + [str]
+      end
+
+      def callstack_string(callstack)
+        callstack.join('.')
       end
     end
   end

--- a/src/validation/answer.rb
+++ b/src/validation/answer.rb
@@ -101,7 +101,7 @@ module Metalware
             missing_questions: [],
           }
           answers.each_with_object(payload) do |(question, answer), pay|
-            if questions_in_section.key?(question)
+            if questions_in_section&.key?(question)
               pay[:answers].push(
                 {
                   question: question,

--- a/src/validation/load_save_base.rb
+++ b/src/validation/load_save_base.rb
@@ -46,10 +46,16 @@ module Metalware
         answer(path.node_answers(file), :nodes)
       end
 
+      def self_answers
+        answer(path.self_answers, :self)
+      end
+
       def section_answers(section, name = nil)
         case section
         when :domain
           domain_answers
+        when :self
+          self_answers
         when :group
           raise InternalError, 'No group name given' if name.nil?
           group_answers(name)

--- a/src/validation/load_save_base.rb
+++ b/src/validation/load_save_base.rb
@@ -63,7 +63,7 @@ module Metalware
           raise InternalError, 'No node name given' if name.nil?
           node_answers(name)
         else
-          raise InternalError, "Unrecognised question seciton: #{section}"
+          raise InternalError, "Unrecognised question section: #{section}"
         end
       end
 


### PR DESCRIPTION
This PR will contain commits for various bugs that need ironing out for the `2017.1.0` release of metalware. Please refer to commit messages for greater detail of each bug fix.

The first bug is `configure self` doesn't use the `self` question. This is fixed in https://github.com/alces-software/metalware/pull/198/commits/c577efe138f58989301df4f9732c6525d0f9c8a9 and fixes #193 

https://github.com/alces-software/metalware/pull/198/commits/adafe584ed037322f2513030985c45fe9757e3a0 fixes the array indexing issue by removing the legacy code used for indexing as it is no longer required. Fixes the issue raised #192 (however additional issues may persist). 

The additional bug in named was due to metalware trying to loop through multiple bash commands when their is only 1 command. Fixes #197, https://github.com/alces-software/metalware/pull/198/commits/e7ff2c7b42dc56ba68dfe9a05f3177ee7d9c1ed2

https://github.com/alces-software/metalware/pull/198/commits/38c8370906275584fded0ae0de3a45f86bc40bff improves the error message when invalid JSON is used with `--answers`, fixes #194 

The `build self` command was failing as `Configuration` was building it's own answer paths. It has now been switched over to using the `loader` https://github.com/alces-software/metalware/pull/198/commits/933e8a8c15bfd5615469eb1facb34e6aa1ed0811. This fixes #200