### PR TITLE
Fixes the `configure group` and choices bugs

### DIFF
--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -30,7 +30,8 @@ require 'validation/saver'
 require 'file_path'
 require 'node'
 
-HighLine::Question.prepend Metalware::Patches::HighLine::Questions
+HighLine::Question.prepend Metalware::Patches::HighLine::Question
+HighLine::Menu.prepend Metalware::Patches::HighLine::Menu
 
 module Metalware
   class Configurator

--- a/src/patches/highline.rb
+++ b/src/patches/highline.rb
@@ -24,21 +24,32 @@
 module Metalware
   module Patches
     module HighLine
-      module Questions
+      module Question
         def sanitize_default_erb_tags
-          @sanitized_default ||= @default.gsub('<%', '<%%')
+          @sanitized_default ||= @default&.gsub('<%', '<%%')
         end
 
         def append_default
-          if @question =~ /([\t ]+)\Z/
-            @question << "|#{sanitize_default_erb_tags}|#{Regexp.last_match(1)}"
-          elsif @question == ''
-            @question << "|#{sanitize_default_erb_tags}|  "
-          elsif @question[-1, 1] == "\n"
-            @question[-2, 0] = "  |#{sanitize_default_erb_tags}|"
+          append_default_helper(@question, sanitize_default_erb_tags)
+        end
+
+        def append_default_helper(question_str, default_str)
+          return question_str if default_str.nil?
+          if question_str =~ /([\t ]+)\Z/
+            question_str << "|#{default_str}|#{Regexp.last_match(1)}"
+          elsif question_str == ''
+            question_str << "|#{default_str}|  "
+          elsif question_str[-1, 1] == "\n"
+            question_str[-2, 0] = "  |#{default_str}|"
           else
-            @question << "  |#{sanitize_default_erb_tags}|"
+            question_str << "  |#{default_str}|"
           end
+        end
+      end
+
+      module Menu
+        def prompt
+          append_default_helper(@prompt.dup, sanitize_default_erb_tags)
         end
       end
     end

--- a/src/validation/load_save_base.rb
+++ b/src/validation/load_save_base.rb
@@ -39,11 +39,11 @@ module Metalware
       end
 
       def group_answers(file)
-        answer(path.group_answers(file), :groups)
+        answer(path.group_answers(file), :group)
       end
 
       def node_answers(file)
-        answer(path.node_answers(file), :nodes)
+        answer(path.node_answers(file), :node)
       end
 
       def self_answers


### PR DESCRIPTION
The first bug fix is when `configure group` failed to validate any answers. This was because it was looking for the `groups` questions instead of the `group`.

The second commit displays the default for choice questions. fixes #199 