### PR TITLE
Always default build interface to valid interface

### DIFF
--- a/src/deployment_server.rb
+++ b/src/deployment_server.rb
@@ -50,13 +50,13 @@ module Metalware
       end
 
       def build_interface
-        # Default to 'eth0' if `build_interface` is not set yet. In practise
-        # this _should_ only occur prior to first render of server config, but
-        # this is needed so a valid interface is used when rendering the server
-        # config itself (the template shouldn't normally depend on values
-        # dependent on the `build_interface`, but if it's unspecified the
-        # `alces` namespace will fail to be created).
-        server_config[:build_interface] || 'eth0'
+        # Default to first network interface if `build_interface` is not set
+        # yet. In practise this _should_ only occur prior to first render of
+        # server config, but this is needed so a valid interface is used when
+        # rendering the server config itself (the template shouldn't normally
+        # depend on values dependent on the `build_interface`, but if it's
+        # unspecified the `alces` namespace will fail to be created).
+        server_config[:build_interface] || Network.interfaces.first
       end
 
       private


### PR DESCRIPTION
Rather than defaulting to `eth0`, which may not exist depending on the host setup, default to the first network interface, which should always exist. This should work better as a more robust default build interface.

Afaics this appears to work fine, @ColonelPanicks you may want to test and merge with your real usage.