### PR TITLE
Speed up the build files retrieval process

### DIFF
--- a/spec/build_files_retriever_spec.rb
+++ b/spec/build_files_retriever_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe Metalware::BuildFilesRetriever do
 
   let :config { Metalware::Config.new }
 
+  let :node_name { 'testnode01' }
+
   subject do
-    Metalware::BuildFilesRetriever.new('testnode01', config)
+    Metalware::BuildFilesRetriever.new(config)
   end
 
   before do
@@ -70,7 +72,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
         FileUtils.mkdir_p File.dirname(url_path)
         FileUtils.touch(url_path)
 
-        retrieved_files = subject.retrieve(TEST_FILES_HASH)
+        retrieved_files = subject.retrieve(node_name, TEST_FILES_HASH)
 
         expect(retrieved_files[:namespace01][0]).to eq(raw: 'some/file_in_repo',
                                                        name: 'file_in_repo',
@@ -94,7 +96,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
           '/var/lib/metalware/cache/templates/url'
         )
 
-        subject.retrieve(TEST_FILES_HASH)
+        subject.retrieve(node_name, TEST_FILES_HASH)
       end
     end
 
@@ -105,7 +107,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
 
       describe 'for repo file identifier' do
         it 'adds error to file entry' do
-          retrieved_files = subject.retrieve(TEST_FILES_HASH)
+          retrieved_files = subject.retrieve(node_name, TEST_FILES_HASH)
 
           repo_file_entry = retrieved_files[:namespace01][0]
           template_path = "#{config.repo_path}/files/some/file_in_repo"
@@ -119,7 +121,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
 
       describe 'for absolute path file identifier' do
         it 'adds error to file entry' do
-          retrieved_files = subject.retrieve(TEST_FILES_HASH)
+          retrieved_files = subject.retrieve(node_name, TEST_FILES_HASH)
 
           absolute_file_entry = retrieved_files[:namespace01][1]
           template_path = '/some/other/path'
@@ -138,7 +140,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
       end
 
       it 'adds error to file entry' do
-        retrieved_files = subject.retrieve(TEST_FILES_HASH)
+        retrieved_files = subject.retrieve(node_name, TEST_FILES_HASH)
 
         url_file_entry = retrieved_files[:namespace01][2]
         url = 'http://example.com/url'

--- a/spec/build_files_retriever_spec.rb
+++ b/spec/build_files_retriever_spec.rb
@@ -28,6 +28,8 @@ require 'spec_utils'
 require 'config'
 
 RSpec.describe Metalware::BuildFilesRetriever do
+  include AlcesUtils
+
   TEST_FILES_HASH = {
     namespace01: [
       'some/file_in_repo',
@@ -39,12 +41,13 @@ RSpec.describe Metalware::BuildFilesRetriever do
     ],
   }.freeze
 
-  let :config { Metalware::Config.new }
-
-  let :node_name { 'testnode01' }
+  AlcesUtils.mock self, :each do
+    mock_node('testnode01')
+    config(alces.node, files: TEST_FILES_HASH)
+  end
 
   subject do
-    Metalware::BuildFilesRetriever.new(config)
+    Metalware::BuildFilesRetriever.new(metal_config)
   end
 
   before do
@@ -62,7 +65,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
 
     context 'when everything works' do
       it 'returns the correct files object' do
-        some_path = File.join(config.repo_path, 'files/some/file_in_repo')
+        some_path = File.join(metal_config.repo_path, 'files/some/file_in_repo')
         FileUtils.mkdir_p File.dirname(some_path)
         FileUtils.touch(some_path)
         other_path = '/some/other/path'
@@ -72,7 +75,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
         FileUtils.mkdir_p File.dirname(url_path)
         FileUtils.touch(url_path)
 
-        retrieved_files = subject.retrieve(node_name, TEST_FILES_HASH)
+        retrieved_files = subject.retrieve(alces.node)
 
         expect(retrieved_files[:namespace01][0]).to eq(raw: 'some/file_in_repo',
                                                        name: 'file_in_repo',
@@ -96,7 +99,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
           '/var/lib/metalware/cache/templates/url'
         )
 
-        subject.retrieve(node_name, TEST_FILES_HASH)
+        subject.retrieve(alces.node)
       end
     end
 
@@ -107,10 +110,10 @@ RSpec.describe Metalware::BuildFilesRetriever do
 
       describe 'for repo file identifier' do
         it 'adds error to file entry' do
-          retrieved_files = subject.retrieve(node_name, TEST_FILES_HASH)
+          retrieved_files = subject.retrieve(alces.node)
 
           repo_file_entry = retrieved_files[:namespace01][0]
-          template_path = "#{config.repo_path}/files/some/file_in_repo"
+          template_path = "#{metal_config.repo_path}/files/some/file_in_repo"
           expect(repo_file_entry[:error]).to match(/#{template_path}.*does not exist/)
 
           # Does not make sense to have these keys if file does not exist.
@@ -121,7 +124,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
 
       describe 'for absolute path file identifier' do
         it 'adds error to file entry' do
-          retrieved_files = subject.retrieve(node_name, TEST_FILES_HASH)
+          retrieved_files = subject.retrieve(alces.node)
 
           absolute_file_entry = retrieved_files[:namespace01][1]
           template_path = '/some/other/path'
@@ -140,7 +143,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
       end
 
       it 'adds error to file entry' do
-        retrieved_files = subject.retrieve(node_name, TEST_FILES_HASH)
+        retrieved_files = subject.retrieve(alces.node)
 
         url_file_entry = retrieved_files[:namespace01][2]
         url = 'http://example.com/url'

--- a/src/build_files_retriever.rb
+++ b/src/build_files_retriever.rb
@@ -37,17 +37,19 @@ module Metalware
     end
 
     def retrieve(node)
-      node.config.files&.map do |namespace, identifiers|
-        [
-          namespace,
-          identifiers.map do |identifier|
-            file_hash_for(node.name, namespace, identifier)
-          end
-        ]
+      node.config.files&.to_h&.keys&.map do |namespace|
+        retrieve_for_namespace(node, namespace)
       end.to_h
     end
 
     private
+
+    def retrieve_for_namespace(node, namespace)
+      file_hashes = node.config.files[namespace].map do |file|
+        file_hash_for(node.name, namespace, file)
+      end
+      [namespace, file_hashes]
+    end
 
     def file_hash_for(node_name, namespace, identifier)
       name = File.basename(identifier)

--- a/src/build_files_retriever.rb
+++ b/src/build_files_retriever.rb
@@ -36,12 +36,12 @@ module Metalware
       @config = config
     end
 
-    def retrieve(node_name, file_namespaces)
-      file_namespaces&.map do |namespace, identifiers|
+    def retrieve(node)
+      node.config.files&.map do |namespace, identifiers|
         [
           namespace,
           identifiers.map do |identifier|
-            file_hash_for(node_name, namespace, identifier)
+            file_hash_for(node.name, namespace, identifier)
           end
         ]
       end.to_h

--- a/src/build_files_retriever.rb
+++ b/src/build_files_retriever.rb
@@ -30,27 +30,26 @@ require 'input'
 
 module Metalware
   class BuildFilesRetriever
-    attr_reader :node_name, :config
+    attr_reader :config
 
-    def initialize(node_name, config)
-      @node_name = node_name
+    def initialize(config)
       @config = config
     end
 
-    def retrieve(file_namespaces)
+    def retrieve(node_name, file_namespaces)
       file_namespaces&.map do |namespace, identifiers|
         [
           namespace,
           identifiers.map do |identifier|
-            file_hash_for(namespace, identifier)
-          end,
+            file_hash_for(node_name, namespace, identifier)
+          end
         ]
       end.to_h
     end
 
     private
 
-    def file_hash_for(namespace, identifier)
+    def file_hash_for(node_name, namespace, identifier)
       name = File.basename(identifier)
       template = template_path(identifier)
 

--- a/src/build_files_retriever.rb
+++ b/src/build_files_retriever.rb
@@ -102,7 +102,7 @@ module Metalware
         # Download the template to the Metalware cache; will render it from
         # there.
         cache_template_path(name).tap do |template|
-          Input.download(identifier, template)
+          input.download(identifier, template)
         end
       elsif absolute_path?(identifier)
         # Path is an absolute path on the deployment server.
@@ -111,6 +111,10 @@ module Metalware
         # Path is within the repo `files` directory.
         repo_template_path(identifier)
       end
+    end
+
+    def input
+      @input ||= Input::Cache.new
     end
 
     def url?(identifier)

--- a/src/data.rb
+++ b/src/data.rb
@@ -33,7 +33,7 @@ module Metalware
 
       def load(data_file, skip_log: false)
         log.info "load: #{data_file}" unless skip_log
-        data = raw_load(data_file)
+        data = raw_load(data_file, skip_log: skip_log)
         process_loaded_data(data, source: data_file)
       rescue => e
         log.error("Fail: #{e.inspect}") unless skip_log
@@ -53,11 +53,11 @@ module Metalware
 
       private
 
-      def raw_load(data_file)
+      def raw_load(data_file, skip_log:)
         if File.file? data_file
           YAML.load_file(data_file) || {}
         else
-          log.info 'file not found'
+          log.info 'file not found' unless skip_log
           {}
         end
       end

--- a/src/input.rb
+++ b/src/input.rb
@@ -42,5 +42,29 @@ module Metalware
         @log ||= MetalLog.new('download')
       end
     end
+
+    class Cache
+      def initialize
+        @cache = {}
+      end
+
+      def download(*args)
+        key = args.join(' - ')
+        save_to_cache(key, args: args)
+        result = cache[key]
+        result.is_a?(Exception) ? raise(result) : result
+      end
+
+      private
+
+      attr_reader :cache
+
+      def save_to_cache(key, args:)
+        return if cache[key]
+        cache[key] = Input.download(*args)
+      rescue => e
+        cache[key] = e
+      end
+    end
   end
 end

--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -65,6 +65,10 @@ module Metalware
           end
         end
 
+        def build_files_retriever
+          @build_files_retriever ||= BuildFilesRetriever.new(metal_config)
+        end
+
         private
 
         def group_cache

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -77,16 +77,10 @@ module Metalware
         end
       end
 
-      #
-      # The BuildFilesRetriever may be moved to the Alces namespace, for:
-      # 1. The raw files can be cached so they don't need new request for
-      #    each node
-      #
       def files
         @files ||= begin
-          retriever = alces.build_files_retriever
-          Constants::HASH_MERGER_DATA_STRUCTURE
-            .new(retriever.retrieve(name, config.files), &template_block)
+          data = alces.build_files_retriever.retrieve(self)
+          Constants::HASH_MERGER_DATA_STRUCTURE.new(data, &template_block)
         end
       end
 

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -84,9 +84,9 @@ module Metalware
       #
       def files
         @files ||= begin
-          retriever = BuildFilesRetriever.new(name, metal_config)
+          retriever = alces.build_files_retriever
           Constants::HASH_MERGER_DATA_STRUCTURE
-            .new(retriever.retrieve(config.files), &template_block)
+            .new(retriever.retrieve(name, config.files), &template_block)
         end
       end
 


### PR DESCRIPTION
Previous the build files would be retrieved for every node. This was causing the same network request to be made multiple times. Instead, the network request will be cached so it is only made once. To facilitate this, all the nodes now share a `BuildFilesRetriever` object of `alces`.

Also fixed a bug where the logging in `DeploymentServer` was breaking the cli. This is because `DeploymentServer` sometimes tries to load a file (through ` Data`) before logging is set up.