### PR TITLE
Follow up fix for local answers

### DIFF
--- a/src/build_methods/local.rb
+++ b/src/build_methods/local.rb
@@ -14,10 +14,10 @@ module Metalware
       end
 
       def start_build
-        rendered_self_template =
+        rendered_local_template =
           file_path.template_save_path(:local, node: node)
-        FileUtils.chmod 'u+x', rendered_self_template
-        puts SystemCommand.run(rendered_self_template)
+        FileUtils.chmod 'u+x', rendered_local_template
+        puts SystemCommand.run(rendered_local_template)
       end
     end
   end

--- a/src/hash_mergers/answer.rb
+++ b/src/hash_mergers/answer.rb
@@ -15,7 +15,11 @@ module Metalware
       def default_array(groups:, node:)
         [default_hash(:domain)].tap do |x|
           x.push(default_hash(:group)) if groups
-          x.push(default_hash(:node)) if node
+          if node == 'local'
+            x.push(default_hash(:local))
+          elsif node
+            x.push(default_hash(:node))
+          end
         end
       end
 


### PR DESCRIPTION
The bug where the local node answer still exists for the defaults. This commit makes sure the local answers defaults (contained within `configure.yaml`) are used for the local node.

Fixes #233 