### PR TITLE
Improve scoping for the Alces namespace and bug fixes

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -29,9 +29,6 @@ module AlcesUtils
           test_alces = Metalware::Namespaces::Alces.new(metal_config)
           allow(Metalware::Namespaces::Alces).to \
             receive(:new).and_return(test_alces)
-          # Allows the node method to be mocked
-          test_alces.define_singleton_method(:node) { method_missing(:node) }
-          test_alces.define_singleton_method(:group) { method_missing(:group) }
           test_alces
         end
 

--- a/spec/file_path_spec.rb
+++ b/spec/file_path_spec.rb
@@ -26,7 +26,7 @@ require 'config'
 require 'constants'
 require 'file_path'
 
-RSpec.describe Metalware::Network do
+RSpec.describe Metalware::FilePath do
   let :config { Metalware::Config.new }
 
   describe 'dynamic constant paths' do

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -114,13 +114,27 @@ RSpec.describe Metalware::Namespaces::Alces do
 
   describe '#scope' do
     let :scope_template { '<%= alces.scope.class %>' }
+    let :node_double { double(Metalware::Namespaces::Node) }
+    let :group_double { double(Metalware::Namespaces::Group) }
 
     def render_scope_template(**dynamic)
       alces.render_erb_template(scope_template, **dynamic)
     end
 
+    # TODO: Remove this redirect, it will be replaced by the scope eventually
+    before :each do
+      allow(Metalware::Config.cache).to \
+        receive(:alces_default_to_domain_scope).and_return(false)
+    end
+
     it 'defaults to the Domain namespace' do
       expect(render_scope_template.constantize).to eq(alces.domain.class)
+    end
+
+    it 'errors if a group and node are both in scope' do
+      expect {
+        render_scope_template(node: node_double, group: group_double)
+      }.to raise_error(Metalware::InternalError)
     end
   end
 end

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Metalware::Namespaces::Alces do
   shared_examples '#node errors' do
     describe '#node' do
       it 'errors' do
-        expect { render_node_template }.to raise_error(Metalware::ScopeError)
+        expect { alces.node }.to raise_error(Metalware::ScopeError)
       end
     end
   end
@@ -213,7 +213,7 @@ RSpec.describe Metalware::Namespaces::Alces do
   shared_examples '#group errors' do
     describe '#group' do
       it 'errors' do
-        expect { render_group_template }.to raise_error(Metalware::ScopeError)
+        expect { alces.group }.to raise_error(Metalware::ScopeError)
       end
     end
   end
@@ -230,7 +230,7 @@ RSpec.describe Metalware::Namespaces::Alces do
 
     describe '#node' do
       it 'returns a Node' do
-        expect(render_node_template).to eq(Metalware::Namespaces::Node.to_s)
+        expect(alces.node.class).to eq(Metalware::Namespaces::Node.to_s)
       end
     end
   end
@@ -241,7 +241,7 @@ RSpec.describe Metalware::Namespaces::Alces do
 
     describe '#group' do
       it 'returns a Group' do
-        expect(render_group_template).to eq(Metalware::Namespaces::Group.to_s)
+        expect(alces.group.class).to eq(Metalware::Namespaces::Group.to_s)
       end
     end
   end

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -152,7 +152,11 @@ RSpec.describe Metalware::Namespaces::Alces do
     let :test_h { double(test: scope_str) }
 
     let :scope do
-      double(scope_class, class: scope_str, config: test_h, answer: test_h)
+      d = double(scope_class, class: scope_str, config: test_h, answer: test_h)
+      d.define_singleton_method(:is_a?) do |input|
+        input == scope_class
+      end
+      d
     end
 
     before :each do
@@ -237,7 +241,7 @@ RSpec.describe Metalware::Namespaces::Alces do
 
     describe '#group' do
       it 'returns a Group' do
-        expect(render_node_template).to eq(Metalware::Namespaces::Group.to_s)
+        expect(render_group_template).to eq(Metalware::Namespaces::Group.to_s)
       end
     end
   end

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -114,11 +114,13 @@ RSpec.describe Metalware::Namespaces::Alces do
 
   describe '#scope' do
     let :scope_template { '<%= alces.scope.class %>' }
-    let :node_double { double(Metalware::Namespaces::Node) }
-    let :group_double { double(Metalware::Namespaces::Group) }
+    let :node_class { Metalware::Namespaces::Node }
+    let :group_class { Metalware::Namespaces::Group }
+    let :node_double { double(node_class, class: node_class) }
+    let :group_double { double(group_class, class: group_class) }
 
     def render_scope_template(**dynamic)
-      alces.render_erb_template(scope_template, **dynamic)
+      alces.render_erb_template(scope_template, **dynamic).constantize
     end
 
     # TODO: Remove this redirect, it will be replaced by the scope eventually
@@ -128,13 +130,21 @@ RSpec.describe Metalware::Namespaces::Alces do
     end
 
     it 'defaults to the Domain namespace' do
-      expect(render_scope_template.constantize).to eq(alces.domain.class)
+      expect(render_scope_template).to eq(alces.domain.class)
     end
 
     it 'errors if a group and node are both in scope' do
       expect {
         render_scope_template(node: node_double, group: group_double)
       }.to raise_error(Metalware::InternalError)
+    end
+
+    it 'can set a node as the scope' do
+      expect(render_scope_template(node: node_double)).to eq(node_class)
+    end
+
+    it 'can set a group as the scope' do
+      expect(render_scope_template(group: group_double)).to eq(group_class)
     end
   end
 end

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -111,4 +111,16 @@ RSpec.describe Metalware::Namespaces::Alces do
       receive(:warn).once.with(/.*domain.config.nil\Z/)
     render_template('<%= domain.config.nil %>')
   end
+
+  describe '#scope' do
+    let :scope_template { '<%= alces.scope.class %>' }
+
+    def render_scope_template(**dynamic)
+      alces.render_erb_template(scope_template, **dynamic)
+    end
+
+    it 'defaults to the Domain namespace' do
+      expect(render_scope_template.constantize).to eq(alces.domain.class)
+    end
+  end
 end

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -128,12 +128,6 @@ RSpec.describe Metalware::Namespaces::Alces do
       alces.render_erb_template(scope_template, **dynamic).constantize
     end
 
-    # TODO: Remove this redirect, it will be replaced by the scope eventually
-    before :each do
-      allow(Metalware::Config.cache).to \
-        receive(:alces_default_to_domain_scope).and_return(false)
-    end
-
     it 'defaults to the Domain namespace' do
       expect(render_scope_template).to eq(alces.domain.class)
     end
@@ -154,8 +148,11 @@ RSpec.describe Metalware::Namespaces::Alces do
   end
 
   shared_examples 'scope method tests' do |scope_class|
+    let :scope_str { scope_class.to_s }
+    let :test_hash { double(test: scope_str) }
+
     let :scope do
-      double(scope_class, config: 'config', answer: 'answer')
+      double(scope_class, config: test_hash, answer: test_hash)
     end
 
     before :each do
@@ -179,6 +176,22 @@ RSpec.describe Metalware::Namespaces::Alces do
         expect(render_template('<%= alces.local.class %>')).to eq(local_class)
       end
     end
+
+    describe '#config' do
+      it 'uses the scope to obtain the config' do
+        expect(render_template('<%= alces.config.test %>')).to eq(scope_str)
+      end
+    end
+
+    describe '#answer' do
+      it 'uses the scope to obtain the config' do
+        expect(render_template('<%= alces.answer.test %>')).to eq(scope_str)
+      end
+    end
+  end
+
+  context 'with a Domain scope' do
+    include_examples 'scope method tests', Metalware::Namespaces::Domain
   end
 
   context 'with a Node in scope' do

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Metalware::Namespaces::Node do
 
         def local_node_uses_local_build?(config_build_method)
           mock_build_method(config_build_method, local)
-          expect(local.build_method).to eq(local_build)
+          expect(local.build_method).to be_a(local_build)
         end
 
         it 'returns the local build method if not specified' do

--- a/src/deployment_server.rb
+++ b/src/deployment_server.rb
@@ -22,6 +22,8 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
+require 'network'
+
 module Metalware
   module DeploymentServer
     class << self
@@ -56,7 +58,7 @@ module Metalware
         # rendering the server config itself (the template shouldn't normally
         # depend on values dependent on the `build_interface`, but if it's
         # unspecified the `alces` namespace will fail to be created).
-        server_config[:build_interface] || Network.interfaces.first
+        server_config[:build_interface] || Metalware::Network.interfaces.first
       end
 
       private

--- a/src/exceptions.rb
+++ b/src/exceptions.rb
@@ -145,9 +145,6 @@ module Metalware
     end
   end
 
-  class DomainTemplatesInternalError < MetalwareError
-  end
-
   class EditModeError < MetalwareError
   end
 
@@ -171,6 +168,9 @@ module Metalware
   end
 
   class AnswerJSONSyntax < MetalwareError
+  end
+
+  class ScopeError < MetalwareError
   end
 end
 

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -49,10 +49,15 @@ module Metalware
       # TODO: Remove this method, use Config.cache instead
       attr_reader :metal_config
 
+      SCOPE_ERROR = 'A node and group can not both be in scope'
+
       def scope
         dynamic = current_dynamic_namespace
-        if dynamic.group && dynamic.node
-          raise InternalError, 'A node and group can not both be in scope'
+        raise InternalError, SCOPE_ERROR if dynamic.group && dynamic.node
+        if dynamic.node
+          node
+        elsif dynamic.group
+          group
         else
           alces.domain
         end

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -51,17 +51,31 @@ module Metalware
 
       delegate :config, :answer, to: :scope
 
+      NODE_ERROR = 'Error, a Node is not in scope'
+
+      def node
+        raise ScopeError, NODE_ERROR unless scope.is_a? Namespaces::Node
+        scope
+      end
+
+      GROUP_ERROR = 'Error, a Group is not in scope'
+
+      def group
+        raise ScopeError, GROUP_ERROR unless scope.is_a? Namespaces::Group
+        scope
+      end
+
       DOUBLE_SCOPE_ERROR = 'A node and group can not both be in scope'
 
       def scope
         dynamic = current_dynamic_namespace
         raise ScopeError, DOUBLE_SCOPE_ERROR if dynamic.group && dynamic.node
         if dynamic.node
-          node
+          dynamic.node
         elsif dynamic.group
-          group
+          dynamic.group
         else
-          alces.domain
+          domain
         end
       end
 

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -51,6 +51,8 @@ module Metalware
 
       SCOPE_ERROR = 'A node and group can not both be in scope'
 
+      delegate :config, :answer, to: :scope
+
       def scope
         dynamic = current_dynamic_namespace
         raise InternalError, SCOPE_ERROR if dynamic.group && dynamic.node
@@ -64,15 +66,9 @@ module Metalware
       end
 
       def render_erb_template(template_string, dynamic_namespace = {})
-        # Renders against a domain scope by default
-        redirect_off = !metal_config.alces_default_to_domain_scope
-        if dynamic_namespace.key?(:config) || redirect_off
-          run_with_dynamic(dynamic_namespace) do
-            Templating::Renderer
-              .replace_erb_with_binding(template_string, wrapped_binding)
-          end
-        else
-          domain.render_erb_template(template_string, dynamic_namespace)
+        run_with_dynamic(dynamic_namespace) do
+          Templating::Renderer
+            .replace_erb_with_binding(template_string, wrapped_binding)
         end
       end
 

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -50,7 +50,12 @@ module Metalware
       attr_reader :metal_config
 
       def scope
-        alces.domain
+        dynamic = current_dynamic_namespace
+        if dynamic.group && dynamic.node
+          raise InternalError, 'A node and group can not both be in scope'
+        else
+          alces.domain
+        end
       end
 
       def render_erb_template(template_string, dynamic_namespace = {})

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -46,7 +46,12 @@ module Metalware
         @dynamic_stack = []
       end
 
+      # TODO: Remove this method, use Config.cache instead
       attr_reader :metal_config
+
+      def scope
+        alces.domain
+      end
 
       def render_erb_template(template_string, dynamic_namespace = {})
         # Renders against a domain scope by default

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -49,13 +49,13 @@ module Metalware
       # TODO: Remove this method, use Config.cache instead
       attr_reader :metal_config
 
-      SCOPE_ERROR = 'A node and group can not both be in scope'
-
       delegate :config, :answer, to: :scope
+
+      DOUBLE_SCOPE_ERROR = 'A node and group can not both be in scope'
 
       def scope
         dynamic = current_dynamic_namespace
-        raise InternalError, SCOPE_ERROR if dynamic.group && dynamic.node
+        raise ScopeError, DOUBLE_SCOPE_ERROR if dynamic.group && dynamic.node
         if dynamic.node
           node
         elsif dynamic.group

--- a/src/namespaces/hash_merger_namespace.rb
+++ b/src/namespaces/hash_merger_namespace.rb
@@ -53,8 +53,6 @@ module Metalware
         lambda do |template|
           alces.render_erb_template(
             template,
-            config: config,
-            answer: answer,
             **additional_dynamic_namespace,
             **user_dynamic_namespace
           )

--- a/src/namespaces/local.rb
+++ b/src/namespaces/local.rb
@@ -17,12 +17,18 @@ module Metalware
         end
       end
 
-      def build_method
-        BuildMethods::Local
-      end
-
       def build_interface
         @build_interface ||= DeploymentServer.build_interface
+      end
+
+      private
+
+      def white_list_for_hasher
+        super.push(:build_interface)
+      end
+
+      def build_method_class
+        BuildMethods::Local
       end
     end
   end

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -79,6 +79,7 @@ module Metalware
                        :index,
                        :kickstart_url,
                        :build_complete_url,
+                       :build_complete_path,
                        :hexadecimal_ip,
                        :build_method,
                      ])


### PR DESCRIPTION
Previously the `config` and `answer` was dumped into the `dynamic_namespace` along with the `node` or `group` that is in scope. However this causes a few issues because it means the `config` may not match what is in scope. Also it meant a weird domain redirect was required if the scope was not specified.

Instead a `scope` method has been defined. It can be:
1. The domain by default
1. A group namespace if a `group:` key appears in the dynamic namespace
1. A node namespace if a `node:` key appears in the dynamic namespace
1. Errors if both `group:` and `node:` are in the dynamic namespace

This means the `config` and `answer` can be delegated to the scope to ensure they are always correct.
It also means that `node` and `group` do not need to go through `method_missing`. Instead they are defined methods that do a type check on the `scope`. If then scope is incorrect, the a `ScopeError` is raised.

Also fixed a few bugs, see https://github.com/alces-software/metalware/commit/ae5329976f7a1c997b1a4de4acdceb3b7a333cc2 and https://github.com/alces-software/metalware/commit/9d3b0f6d56f67288594fe43234289d6ef4c0f308 for more details.