### PR TITLE
Allow orphan nodes to be configured without a group

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -162,12 +162,6 @@ module AlcesUtils
       metal_config.cli[:strict] = bool
     end
 
-    # TODO: Remove this. It is only used as part of the testing
-    def alces_default_to_domain_scope_off
-      allow(metal_config).to \
-        receive(:alces_default_to_domain_scope).and_return(false)
-    end
-
     def with_blank_config_and_answer(namespace)
       allow(namespace).to receive(:config).and_return(OpenStruct.new)
       allow(namespace).to receive(:answer).and_return(OpenStruct.new)

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -71,17 +71,12 @@ RSpec.describe AlcesUtils do
     context 'with a mocked config' do
       AlcesUtils.mock self, :each do
         validation_off
-        alces_default_to_domain_scope_off
         mock_strict(false)
       end
 
       it 'turns the validation off' do
         config = Metalware::Config.new
         expect(config.validation).to be_a(FalseClass)
-      end
-
-      it 'does not default to domain scope' do
-        expect { alces.config }.to raise_error(NoMethodError)
       end
 
       it 'strict matches what is set' do

--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
 
     def configurator
       Metalware::Configurator.new(
-        config: config,
+        alces,
         questions_section: :domain
       )
     end

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Metalware::Commands::Configure::Domain do
   it 'creates correct configurator' do
     filesystem.test do
       expect(Metalware::Configurator).to receive(:new).with(
-        config: instance_of(Metalware::Config),
+        instance_of(Metalware::Namespaces::Alces),
         questions_section: :domain
       ).and_call_original
 

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
   it 'creates correct configurator' do
     filesystem.test do
       expect(Metalware::Configurator).to receive(:new).with(
-        config: instance_of(Metalware::Config),
+        instance_of(Metalware::Namespaces::Alces),
         questions_section: :group,
         name: 'testnodes'
       ).and_call_original

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe Metalware::Commands::Configure::Group do
   end
 
   let :config { Metalware::Config.new }
-  let :cache { Metalware::GroupCache.new(config, force_reload_file: true) }
+
+  def new_cache
+    Metalware::GroupCache.new(config)
+  end
 
   let :filesystem do
     FileSystem.setup(&:with_minimal_repo)
@@ -62,7 +65,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
         filesystem.test do
           run_configure_group 'testnodes'
 
-          expect(cache.primary_groups).to eq [
+          expect(new_cache.primary_groups).to eq [
             'testnodes',
             'local',
           ]
@@ -73,11 +76,11 @@ RSpec.describe Metalware::Commands::Configure::Group do
     context 'when `cache/groups.yaml` exists' do
       it 'inserts primary group if new' do
         filesystem.test do
-          cache.add('first_group')
+          new_cache.add('first_group')
 
           run_configure_group 'second_group'
 
-          expect(cache.primary_groups).to eq [
+          expect(new_cache.primary_groups).to eq [
             'first_group',
             'second_group',
             'local',
@@ -87,11 +90,11 @@ RSpec.describe Metalware::Commands::Configure::Group do
 
       it 'does nothing if primary group already presnt' do
         filesystem.test do
-          ['first_group', 'second_group'].each { |g| cache.add(g) }
+          ['first_group', 'second_group'].each { |g| new_cache.add(g) }
 
           run_configure_group 'second_group'
 
-          expect(cache.primary_groups).to eq [
+          expect(new_cache.primary_groups).to eq [
             'first_group',
             'second_group',
             'local',

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
 
           expect(new_cache.primary_groups).to eq [
             'testnodes',
-            'local',
+            'orphan',
           ]
         end
       end
@@ -83,7 +83,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
           expect(new_cache.primary_groups).to eq [
             'first_group',
             'second_group',
-            'local',
+            'orphan',
           ]
         end
       end
@@ -97,7 +97,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
           expect(new_cache.primary_groups).to eq [
             'first_group',
             'second_group',
-            'local',
+            'orphan',
           ]
         end
       end

--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Metalware::Commands::Configure::Node do
   it 'creates correct configurator' do
     filesystem.test do
       expect(Metalware::Configurator).to receive(:new).with(
-        config: instance_of(Metalware::Config),
+        instance_of(Metalware::Namespaces::Alces),
         questions_section: :node,
         name: 'testnode01'
       ).and_call_original

--- a/spec/commands/remove/group_spec.rb
+++ b/spec/commands/remove/group_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Metalware::Commands::Remove::Group do
   include AlcesUtils
 
   AlcesUtils.mock self, :each do
-    alces_default_to_domain_scope_off
     validation_off
   end
 

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Metalware::Configurator do
     # Spoofs HighLine to always return the testing version of highline
     allow(HighLine).to receive(:new).and_return(highline)
     Metalware::Configurator.new(
-      config: config,
+      alces,
       questions_section: :domain
     )
   end

--- a/spec/group_cache_spec.rb
+++ b/spec/group_cache_spec.rb
@@ -28,7 +28,11 @@ require 'filesystem'
 
 RSpec.describe Metalware::GroupCache do
   let :config { Metalware::Config.new }
-  let :cache { Metalware::GroupCache.new(config) }
+  let :cache { new_cache }
+
+  def new_cache
+    Metalware::GroupCache.new(config)
+  end
 
   let :filesystem do
     FileSystem.setup do |fs|
@@ -103,6 +107,29 @@ RSpec.describe Metalware::GroupCache do
         cache.add(group2)
         expect(cache.index(group2)).to eq 4
       end
+    end
+  end
+
+  describe '#orphans' do
+    it 'is a blank list by default' do
+      expect(cache.orphans).to eq([])
+    end
+  end
+
+  describe '#add_orphan' do
+    it 'adds the orphans' do
+      orphans = ['node1', 'node2', 'node3']
+      orphans.each do |orphan|
+        cache.push_orphan(orphan)
+      end
+      expect(new_cache.orphans).to eq(orphans)
+    end
+
+    it 'siliently refuses to double add orphans' do
+      orphan = 'node1'
+      new_cache.push_orphan(orphan)
+      new_cache.push_orphan(orphan)
+      expect(new_cache.orphans).to eq([orphan])
     end
   end
 end

--- a/spec/hash_mergers/metal_recursive_open_struct_spec.rb
+++ b/spec/hash_mergers/metal_recursive_open_struct_spec.rb
@@ -16,9 +16,7 @@ module Metalware
 end
 
 RSpec.describe Metalware::HashMergers::MetalRecursiveOpenStruct do
-  include AlcesUtils
-
-  AlcesUtils.mock self, :each { alces_default_to_domain_scope_off }
+  let :metal_config { Metalware::Config.cache(new_if_missing: true) }
 
   let :alces do
     namespace = Metalware::Namespaces::Alces.new(metal_config)

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -37,8 +37,6 @@ EMPTY_REPO_PATH = File.join(FIXTURES_PATH, 'configs/empty-repo.yaml')
 RSpec.describe Metalware::Templater do
   include AlcesUtils
 
-  AlcesUtils.mock self, :each { alces_default_to_domain_scope_off }
-
   let :filesystem do
     FileSystem.setup do |fs|
       fs.write template_path, template.strip_heredoc

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -85,8 +85,11 @@ module Metalware
       end
 
       def render_genders
+        # The genders file must be templated with a new namespace object as the
+        # answers may have changed since they where loaded
+        new_alces = Namespaces::Alces.new(config)
         Staging.template do |templater|
-          RenderMethods::Genders.render_to_staging(alces.domain, templater)
+          RenderMethods::Genders.render_to_staging(new_alces, templater)
         end
       end
     end

--- a/src/commands/configure/domain.rb
+++ b/src/commands/configure/domain.rb
@@ -17,8 +17,8 @@ module Metalware
         end
 
         def configurator
-          @configurator ||=
-            Configurator.for_domain(config: config)
+         @configurator ||=
+            Configurator.for_domain(alces)
         end
       end
     end

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -41,7 +41,7 @@ module Metalware
 
         def configurator
           @configurator ||=
-            Configurator.for_group(group_name, config: config)
+            Configurator.for_group(alces, group_name)
         end
 
         def answer_file

--- a/src/commands/configure/local.rb
+++ b/src/commands/configure/local.rb
@@ -14,7 +14,7 @@ module Metalware
 
         def configurator
           @configurator ||=
-            Configurator.for_local(config: config)
+            Configurator.for_local(alces)
         end
 
         def answer_file

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -18,7 +18,7 @@ module Metalware
 
         def configurator
           @configurator ||=
-            Configurator.for_node(node_name, config: config)
+            Configurator.for_node(alces, node_name)
         end
 
         def answer_file

--- a/src/commands/configure/node.rb
+++ b/src/commands/configure/node.rb
@@ -24,10 +24,6 @@ module Metalware
         def answer_file
           file_path.node_answers(node_name)
         end
-
-        def dependency_hash
-          dependency_specifications.for_node_in_configured_group(node_name)
-        end
       end
     end
   end

--- a/src/config.rb
+++ b/src/config.rb
@@ -74,7 +74,6 @@ module Metalware
     # XXX Maybe move all these paths into Constants and then reference them here
     KEYS_WITH_DEFAULTS = {
       validation: true,
-      alces_default_to_domain_scope: true,
       build_poll_sleep: 10,
       answer_files_path: '/var/lib/metalware/answers',
       built_nodes_storage_path: '/var/lib/metalware/cache/built-nodes',

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -36,16 +36,16 @@ HighLine::Menu.prepend Metalware::Patches::HighLine::Menu
 module Metalware
   class Configurator
     class << self
-      def for_domain(config:)
+      def for_domain(alces)
         new(
-          config: config,
+          alces,
           questions_section: :domain
         )
       end
 
-      def for_group(group_name, config:)
+      def for_group(alces, group_name)
         new(
-          config: config,
+          alces,
           questions_section: :group,
           name: group_name
         )
@@ -54,17 +54,17 @@ module Metalware
       # Note: This is slightly inconsistent with `for_group`, as that just
       # takes a group name and this takes a Node object (as we need to be able
       # to access the Node's primary group).
-      def for_node(node_name, config:)
+      def for_node(alces, node_name)
         new(
-          config: config,
+          alces,
           questions_section: :node,
           name: node_name
         )
       end
 
-      def for_local(config:)
+      def for_local(alces)
         new(
-          config: config,
+          alces,
           questions_section: :local
         )
       end
@@ -76,12 +76,13 @@ module Metalware
     end
 
     def initialize(
-      config:,
+      alces,
       questions_section:,
       name: nil
     )
+      @alces = alces
       @highline = HighLine.new
-      @config = config
+      @config = Config.cache
       @questions_section = questions_section
       @name = name
     end
@@ -101,7 +102,8 @@ module Metalware
 
     private
 
-    attr_reader :config,
+    attr_reader :alces,
+                :config,
                 :highline,
                 :questions_section,
                 :name

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -55,6 +55,7 @@ module Metalware
       # takes a group name and this takes a Node object (as we need to be able
       # to access the Node's primary group).
       def for_node(alces, node_name)
+        return for_local(alces) if node_name == 'local'
         new(
           alces,
           questions_section: :node,

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -132,10 +132,10 @@ module Metalware
         when :group, :local
           [loader.domain_answers]
         when :node
-          node = Node.new(config, name)
+          node = alces.nodes.find_by_name(name)
           [
             loader.domain_answers,
-            loader.group_answers(node.primary_group),
+            loader.group_answers(node.group),
           ]
         else
           raise InternalError, "Unrecognised question section: #{questions_section}"

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -71,6 +71,16 @@ module Metalware
       primary_groups_hash.keys.map(&:to_s)
     end
 
+    def orphans
+      data[:orphans]
+    end
+
+    def push_orphan(name)
+      return if orphans.include?(name)
+      orphans.push(name)
+      save
+    end
+
     private
 
     attr_reader :config, :force_reload
@@ -87,7 +97,8 @@ module Metalware
       loader.group_cache.tap do |d|
         if d.empty?
           d.merge!(next_index: 1,
-                   primary_groups: {})
+                   primary_groups: {},
+                   orphans: [])
         end
       end
     end
@@ -116,6 +127,7 @@ module Metalware
       payload = {
         next_index: next_available_index,
         primary_groups: groups_hash,
+        orphans: orphans,
       }
       Data.dump(file_path.group_cache, payload)
       @data = nil # Reloads the cached file

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -109,7 +109,7 @@ module Metalware
 
     def primary_groups_hash
       @primary_groups_hash ||= begin
-        data[:primary_groups][:local] = 0
+        data[:primary_groups][:orphan] = 0
         data[:primary_groups]
       end
     end
@@ -123,7 +123,7 @@ module Metalware
     end
 
     def save
-      groups_hash = primary_groups_hash.dup.tap { |x| x.delete(:local) }
+      groups_hash = primary_groups_hash.dup.tap { |x| x.delete(:orphan) }
       payload = {
         next_index: next_available_index,
         primary_groups: groups_hash,

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -68,7 +68,7 @@ module Metalware
       DOUBLE_SCOPE_ERROR = 'A node and group can not both be in scope'
 
       def scope
-        dynamic = current_dynamic_namespace
+        dynamic = current_dynamic_namespace || OpenStruct.new
         raise ScopeError, DOUBLE_SCOPE_ERROR if dynamic.group && dynamic.node
         if dynamic.node
           dynamic.node

--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -69,6 +69,10 @@ module Metalware
           @build_files_retriever ||= BuildFilesRetriever.new(metal_config)
         end
 
+        def orphan_list
+          @orphan_list ||= group_cache.orphans
+        end
+
         private
 
         def group_cache


### PR DESCRIPTION
Fixes #251 

Previously `metal configure node` would fail if a node does not belong to a group. This is because there is no mechanism to add single nodes to the genders file and thus metalware.

It is now possible to add single nodes to an orphan group. This is done when a node that does not exist is configured with `metal configure node`. It will automatically be added to the orphan group. A warning is issued however as there is no mechanism to remove it from the orphan group if it is later reconfigured.

The `local` group has been replaced by the `orphan` group. This means it has a group index of 0 and the `local` node will belong to it. The updated genders template (see link below) will automatically detect the local node as an orphan.
https://github.com/alces-software/metalware-default/pull/19/commits/227db0c8d92d4bf5b8cc06a90af8d3ea0b246f5b

The orphan nodes are saved in the group cache for ease of reference when reading the genders file. This means the nodes will not be lost on multiple re-renders of the file without syncing.

Otherwise the remaining commits where internal metalware changes. See commit message for details.