### PR TITLE
Support build events sending messages

### DIFF
--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -109,11 +109,10 @@ RSpec.describe Metalware::BuildEvent do
 
     context 'with an event trigger' do
       let :node { alces.nodes[3] }
+      let :event { '__trigger_without_a_build_method_hook__' }
+      let :event_file { Metalware::FilePath.event(node, event) }
 
       context 'with basic features only (no hooks nor messages)' do
-        let :event { '__trigger_without_a_build_method_hook__' }
-        let :event_file { Metalware::FilePath.event(node, event) }
-
         before :each { FileUtils.touch event_file }
 
         it 'reports the event and node names to stdout' do
@@ -123,6 +122,21 @@ RSpec.describe Metalware::BuildEvent do
         it 'deletes the file' do
           process
           expect(File.exist? event_file).to eq(false)
+        end
+      end
+
+      context 'with a message' do
+        let :message_arr do
+          ['I am a little message', 'With multiple lines', 'potato']
+        end
+
+        before :each do
+          FileUtils.mkdir_p File.dirname(event_file)
+          File.write(event_file, message_arr.join("\n"))
+        end
+
+        it 'displays the message' do
+          expect(process[:stdout].read).to include(*message_arr)
         end
       end
     end

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'build_event'
+require 'alces_utils'
+
+RSpec.describe Metalware::BuildEvent do
+  include AlcesUtils
+
+  let :nodes { ['node01', 'node02', 'node03', 'nodes4'] }
+  let :built_node { nodes[2] }
+  let :build_event { Metalware::BuildEvent.new(alces.nodes) }
+  let :empty_build_event { Metalware::BuildEvent.new([]) }
+
+  AlcesUtils.mock self, :each do
+    nodes.each { |node| mock_node(node) }
+    Thread.list.each { |t| t.kill unless t == Thread.current }
+  end
+
+  def wait_for_hooks_to_run(test_obj: build_event)
+    Timeout.timeout 3 do
+      sleep 0.1 while test_obj.hook_active?
+    end
+  end
+
+  describe '#run_start_hooks' do
+    it 'runs the start_hook for each node' do
+      alces.nodes.each do |node|
+        expect(node.build_method).to receive(:start_hook)
+      end
+      build_event.run_start_hooks
+      wait_for_hooks_to_run
+    end
+  end
+
+  describe '#build_complete?' do
+    it 'returns true if initialized with no nodes' do
+      expect(empty_build_event.build_complete?).to eq(true)
+    end
+
+    it 'returns false if a hook is still active' do
+      empty_build_event.send(:run_hook) { sleep 0 }
+      expect(empty_build_event.build_complete?).to eq(false)
+    end
+
+    it 'returns false if the nodes have not finished building' do
+      expect(build_event.build_complete?).to eq(false)
+    end
+  end
+
+  describe '#hook_active?' do
+    it 'returns false if no hooks are running' do
+      expect(build_event.hook_active?).to eq(false)
+    end
+
+    it 'returns true if there is a running thread' do
+      build_event.send(:run_hook) { sleep 0 }
+      expect(build_event.hook_active?).to eq(true)
+    end
+
+    it 'returns false once the thread has finished' do
+      build_event.send(:run_hook) { sleep 0.1 }
+      expect(build_event.hook_active?).to eq(true)
+      wait_for_hooks_to_run
+      expect(build_event.hook_active?).to eq(false)
+    end
+  end
+
+  describe '#kill_threads' do
+    it 'kills all the threads' do
+      build_event.send(:run_hook) { sleep 0 }
+      build_event.send(:run_hook) { sleep 0 }
+      build_event.kill_threads
+      wait_for_hooks_to_run
+      expect(build_event.hook_active?).to eq(false)
+    end
+  end
+end

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe Metalware::BuildEvent do
         process
         expect(File.exist?(built_node.build_complete_path)).to eq(false)
       end
+
+      it 'only builds the node once' do
+        expect(built_node.build_method).to receive(:complete_hook).once
+        process
+        build_node(built_node)
+        process
+      end
+
+      it 'does not finish the build' do
+        process
+        expect(build_event.build_complete?).to eq(false)
+      end
     end
 
     context 'with all the nodes built' do
@@ -87,6 +99,11 @@ RSpec.describe Metalware::BuildEvent do
         alces.nodes.each do |node|
           expect(File.exist?(node.build_complete_path)).to eq(false)
         end
+      end
+
+      it 'finishes the build' do
+        process
+        expect(build_event.build_complete?).to eq(true)
       end
     end
   end

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Metalware::BuildEvent do
 
   AlcesUtils.mock self, :each do
     nodes.each { |node| mock_node(node) }
+    alces.nodes.each { |node| hexadecimal_ip(node) }
     Thread.list.each { |t| t.kill unless t == Thread.current }
   end
 
@@ -45,8 +46,10 @@ RSpec.describe Metalware::BuildEvent do
 
   describe '#process' do
     def process(test_obj: build_event)
-      test_obj.process
-      wait_for_hooks_to_run(test_obj: test_obj)
+      AlcesUtils.redirect_std(:stderr) do
+        test_obj.process
+        wait_for_hooks_to_run(test_obj: test_obj)
+      end
     end
 
     context 'with a single node built' do

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Metalware::BuildEvent do
   include AlcesUtils
 
   let :nodes { ['node01', 'node02', 'node03', 'nodes4'] }
-  let :built_node { nodes[2] }
   let :build_event { Metalware::BuildEvent.new(alces.nodes) }
   let :empty_build_event { Metalware::BuildEvent.new([]) }
 
@@ -22,6 +21,10 @@ RSpec.describe Metalware::BuildEvent do
     end
   end
 
+  def build_node(node)
+    FileUtils.touch node.build_complete_path
+  end
+
   describe '#run_start_hooks' do
     it 'runs the start_hook for each node' do
       alces.nodes.each do |node|
@@ -29,6 +32,19 @@ RSpec.describe Metalware::BuildEvent do
       end
       build_event.run_start_hooks
       wait_for_hooks_to_run
+    end
+  end
+
+  describe '#process' do
+    context 'with a single node built' do
+      let :built_node { alces.nodes[2] }
+
+      it 'runs the complete_hook for the node' do
+        expect(built_node.build_method).to receive(:complete_hook)
+        build_node(built_node)
+        build_event.process
+        wait_for_hooks_to_run
+      end
     end
   end
 

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Metalware::BuildEvent do
     FileUtils.touch node.build_complete_path
   end
 
+  describe '#run_all_complete_hooks' do
+    it 'runs the complete hook for each node' do
+      alces.nodes.each do |node|
+        expect(node.build_method).to receive(:complete_hook).once
+      end
+      build_event.run_all_complete_hooks
+      wait_for_hooks_to_run
+    end
+  end
+
   describe '#run_start_hooks' do
     it 'runs the start_hook for each node' do
       alces.nodes.each do |node|

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -25,15 +25,18 @@
 require 'spec_utils'
 require 'filesystem'
 require 'group_cache'
+require 'alces_utils'
 
 RSpec.describe Metalware::Commands::Configure::Group do
+  include AlcesUtils
+
   def run_configure_group(group)
     Metalware::Utils.run_command(
       Metalware::Commands::Configure::Group, group
     )
   end
 
-  let :config { Metalware::Config.new }
+  let :config { Metalware::Config.cache }
 
   def new_cache
     Metalware::GroupCache.new(config)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe Metalware::Config do
       fs.with_metal_config_fixture('configs/empty.yaml')
     end
     config = Metalware::Config.new
-    expect(config.built_nodes_storage_path).to eq('/var/lib/metalware/cache/built-nodes')
     expect(config.rendered_files_path).to eq('/var/lib/metalware/rendered')
     expect(config.build_poll_sleep).to eq(10)
   end
@@ -55,7 +54,6 @@ RSpec.describe Metalware::Config do
       fs.with_metal_config_fixture('configs/non-empty.yaml')
     end
     config = Metalware::Config.new
-    expect(config.built_nodes_storage_path).to eq('/built/nodes')
     expect(config.rendered_files_path).to eq('/rendered/files')
     expect(config.build_poll_sleep).to eq(5)
   end

--- a/spec/group_cache_spec.rb
+++ b/spec/group_cache_spec.rb
@@ -25,9 +25,12 @@
 require 'config'
 require 'group_cache'
 require 'filesystem'
+require 'alces_utils'
 
 RSpec.describe Metalware::GroupCache do
-  let :config { Metalware::Config.new }
+  include AlcesUtils
+
+  let :config { metal_config }
   let :cache { new_cache }
 
   def new_cache

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe '`metal build`' do
   TEST_CONFIG = Metalware::Config.new
   TEST_KICKSTART_DIR = File.join(TEST_CONFIG.rendered_files_path, 'kickstart')
   TEST_PXELINUX_DIR = TEST_CONFIG.pxelinux_cfg_path
-  TEST_BUILT_NODES_DIR = TEST_CONFIG.built_nodes_storage_path
 
   PXELINUX_TEMPLATE = '/var/lib/metalware/repo/pxelinux/default'
 
@@ -67,7 +66,8 @@ RSpec.describe '`metal build`' do
   end
 
   def expect_clears_up_built_node_marker_files
-    files = Dir.glob(File.join(TEST_BUILT_NODES_DIR, '**/*'))
+    files = Dir.glob(File.join(Metalware::FilePath.events_dir, '**/*'))
+               .reject { |file| File.directory?(file) }
     expect(files.empty?).to be true
   end
 
@@ -94,7 +94,6 @@ RSpec.describe '`metal build`' do
     FileUtils.remove(TEST_DIR, force: true)
     FileUtils.mkdir_p(TEST_KICKSTART_DIR)
     FileUtils.mkdir_p(TEST_PXELINUX_DIR)
-    FileUtils.mkdir_p(TEST_BUILT_NODES_DIR)
   end
 
   AlcesUtils.mock self, :each do
@@ -111,8 +110,8 @@ RSpec.describe '`metal build`' do
 
   let :file_path { Metalware::FilePath.new(metal_config) }
 
-  def touch_complete_file(node)
-    FileUtils.touch(file_path.build_complete(node))
+  def touch_complete_file(name)
+    FileUtils.touch(file_path.build_complete(alces.nodes.find_by_name(name)))
   end
 
   context 'for single node' do

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -20,6 +20,10 @@ module Metalware
       nodes_complete
     end
 
+    def run_all_complete_hooks
+      nodes.each { |node| run_hook(node, 'complete') }
+    end
+
     def build_complete?
       return false if hook_active?
       nodes.empty?

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -10,6 +10,14 @@ module Metalware
       nodes.each { |node| run_hook { node.build_method.start_hook } }
     end
 
+    # TODO: Atm only the complete_hook is supported. Eventually this needs to
+    # be expanded to other hooks
+    def process
+      nodes.each do |node|
+        node_complete(node)
+      end
+    end
+
     def build_complete?
       return false if hook_active?
       nodes.empty?
@@ -30,6 +38,13 @@ module Metalware
 
     def build_threads
       @build_threads ||= []
+    end
+
+    def node_complete(node)
+      return unless File.exist?(node.build_complete_path)
+      run_hook do
+        node.build_method.complete_hook
+      end
     end
 
     def run_hook

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -43,6 +43,7 @@ module Metalware
     def node_complete(node)
       return unless File.exist?(node.build_complete_path)
       run_hook(node, 'complete')
+      FileUtils.rm node.build_complete_path
     end
 
     def run_hook(node, hook_name)

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -13,9 +13,7 @@ module Metalware
     # TODO: Atm only the complete_hook is supported. Eventually this needs to
     # be expanded to other hooks
     def process
-      nodes.each do |node|
-        node_complete(node)
-      end
+      nodes_complete
     end
 
     def build_complete?
@@ -42,10 +40,13 @@ module Metalware
       @build_threads ||= []
     end
 
-    def node_complete(node)
-      return unless File.exist?(node.build_complete_path)
-      run_hook(node, 'complete')
-      FileUtils.rm node.build_complete_path
+    def nodes_complete
+      nodes.delete_if do |node|
+        next unless File.exist?(node.build_complete_path)
+        run_hook(node, 'complete')
+        FileUtils.rm node.build_complete_path
+        true
+      end
     end
 
     def run_hook(node, hook_name)

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -31,6 +31,7 @@ module Metalware
 
     def kill_threads
       build_threads.each(&:kill)
+      sleep 0.001 while hook_active?
     end
 
     private

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Metalware
+  class BuildEvent
+    def initialize(nodes)
+      @nodes = nodes.dup
+    end
+
+    def run_start_hooks
+      nodes.each { |node| run_hook { node.build_method.start_hook } }
+    end
+
+    def build_complete?
+      return false if hook_active?
+      nodes.empty?
+    end
+
+    def hook_active?
+      build_threads.delete_if { |th| !th.alive? }
+      !build_threads.empty?
+    end
+
+    def kill_threads
+      build_threads.each(&:kill)
+    end
+
+    private
+
+    attr_reader :nodes
+
+    def build_threads
+      @build_threads ||= []
+    end
+
+    def run_hook
+      build_threads.push(Thread.new do
+        begin
+          yield
+        rescue
+          $stderr.puts $ERROR_INFO.message
+          $stderr.puts $ERROR_INFO.backtrace
+        end
+      end)
+    end
+  end
+end

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -10,6 +10,9 @@ module Metalware
       nodes.each { |node| run_hook(node, 'start') }
     end
 
+    # TODO: split process into to parts:
+    # process_events: - all hooks BUT complete
+    # complete_nodes: Check for completed nodes
     def process
       nodes.each do |node|
         event_files(node).each { |f| process_event_file(f) }
@@ -69,6 +72,7 @@ module Metalware
       end
     end
 
+    # TODO: Use the Output class to connect to the GUI
     def process_event_file(file)
       path_arr = file.split(File::SEPARATOR)
       event = path_arr[-1]

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -10,8 +10,6 @@ module Metalware
       nodes.each { |node| run_hook(node, 'start') }
     end
 
-    # TODO: Atm only the complete_hook is supported. Eventually this needs to
-    # be expanded to other hooks
     def process
       nodes.each do |node|
         event_files(node).each { |f| process_event_file(f) }
@@ -76,6 +74,9 @@ module Metalware
       event = path_arr[-1]
       node_str = path_arr[-2]
       puts "#{node_str}: #{event}"
+      content = File.read(file).chomp
+      puts content unless content.empty?
+      puts
       FileUtils.rm file
     end
   end

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -25,6 +25,7 @@ module Metalware
 
     def hook_active?
       build_threads.delete_if { |th| !th.alive? }
+                   .each(&:join)
       !build_threads.empty?
     end
 
@@ -50,9 +51,9 @@ module Metalware
       build_threads.push(Thread.new do
         begin
           node.build_method.send("#{hook_name}_hook")
-        rescue
-          $stderr.puts $ERROR_INFO.message
-          $stderr.puts $ERROR_INFO.backtrace
+        rescue => e
+          $stderr.puts e.message
+          $stderr.puts e.backtrace
         end
       end)
     end

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -7,7 +7,7 @@ module Metalware
     end
 
     def run_start_hooks
-      nodes.each { |node| run_hook { node.build_method.start_hook } }
+      nodes.each { |node| run_hook(node, 'start') }
     end
 
     # TODO: Atm only the complete_hook is supported. Eventually this needs to
@@ -42,15 +42,13 @@ module Metalware
 
     def node_complete(node)
       return unless File.exist?(node.build_complete_path)
-      run_hook do
-        node.build_method.complete_hook
-      end
+      run_hook(node, 'complete')
     end
 
-    def run_hook
+    def run_hook(node, hook_name)
       build_threads.push(Thread.new do
         begin
-          yield
+          node.build_method.send("#{hook_name}_hook")
         rescue
           $stderr.puts $ERROR_INFO.message
           $stderr.puts $ERROR_INFO.backtrace

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -179,7 +179,7 @@ module Metalware
 
       def handle_interrupt(_e)
         Output.info 'Exiting...'
-        ask_if_should_rerender
+        ask_if_should_run_build_complete
         teardown
       rescue Interrupt
         Output.info 'Re-rendering templates anyway...'
@@ -194,9 +194,9 @@ module Metalware
 
       delegate :agree, to: :high_line
 
-      def ask_if_should_rerender
+      def ask_if_should_run_build_complete
         should_rerender = <<-EOF.strip_heredoc
-          Re-render appropriate templates for nodes as if build succeeded?
+          Run the complete_hook for nodes as if build succeeded?
           [yes/no]
         EOF
 

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -79,9 +79,7 @@ module Metalware
 
       def start_build
         nodes.each do |node|
-          run_in_build_thread do
-            node.build_method.start_hook
-          end
+          run_in_build_thread { node.build_method.start_hook }
         end
       end
 
@@ -204,11 +202,6 @@ module Metalware
 
         run_all_complete_hooks if agree(should_rerender)
       end
-
-      EDIT_START_MSG = <<-EOF.strip_heredoc
-        The build templates have been rendered and ready to be edited with `metal edit`
-        Continue the build process with the `--edit-continue` flag
-      EOF
     end
   end
 end

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -133,7 +133,7 @@ module Metalware
       end
 
       def built?(node)
-        File.file?(file_path.build_complete(node.name))
+        File.file?(file_path.build_complete(node))
       end
 
       def record_gui_build_complete
@@ -172,9 +172,9 @@ module Metalware
       end
 
       def clear_up_built_node_marker_files
-        glob = File.join(config.built_nodes_storage_path, '*')
-        files = Dir.glob(glob)
-        FileUtils.rm_rf(files)
+        nodes.each do |node|
+          FileUtils.rm_rf(node.build_complete_path)
+        end
       end
 
       def handle_interrupt(_e)

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -49,10 +49,6 @@ module Metalware
         end
 
         def custom_configuration
-          record_primary_group
-        end
-
-        def record_primary_group
           cache.add(group_name)
         end
       end

--- a/src/config.rb
+++ b/src/config.rb
@@ -76,7 +76,6 @@ module Metalware
       validation: true,
       build_poll_sleep: 10,
       answer_files_path: '/var/lib/metalware/answers',
-      built_nodes_storage_path: '/var/lib/metalware/cache/built-nodes',
       rendered_files_path: '/var/lib/metalware/rendered',
       pxelinux_cfg_path: '/var/lib/tftpboot/pxelinux.cfg',
       repo_path: '/var/lib/metalware/repo',

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -135,10 +135,7 @@ module Metalware
         when :domain
           alces.domain
         when :group
-          alces.groups.find_by_name(name) || begin
-            idx = GroupCache.new.next_available_index
-            Namespaces::Group.new(alces, name, index: idx)
-          end
+          alces.groups.find_by_name(name) || create_new_group
         when :node, :local
           alces.nodes.find_by_name(name) || create_orphan_node
         else
@@ -158,6 +155,11 @@ module Metalware
         A node can be removed from the orphan group by editing:
       EOF
       msg + "\n" + FilePath.group_cache
+    end
+
+    def create_new_group
+      idx = GroupCache.new.next_available_index
+      Namespaces::Group.new(alces, name, index: idx)
     end
 
     def create_orphan_node

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -135,7 +135,10 @@ module Metalware
         when :domain
           alces.domain
         when :group
-          alces.groups.find_by_name(name)
+          alces.groups.find_by_name(name) || begin
+            idx = GroupCache.new.next_available_index
+            Namespaces::Group.new(alces, name, index: idx)
+          end
         when :node, :local
           alces.nodes.find_by_name(name) || create_orphan_node
         else
@@ -160,7 +163,7 @@ module Metalware
     def create_orphan_node
       MetalLog.warn orphan_warning unless questions_section == :local
       group_cache.push_orphan(name)
-      alces.groups.orphan
+      Namespaces::Node.create(alces, name)
     end
 
     def old_answers

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -40,6 +40,8 @@ module Metalware
     STAGING_DIR_PATH = File.join(METALWARE_DATA_PATH, 'staging')
     STAGING_MANIFEST_PATH = File.join(CACHE_PATH, 'staging-manifest.yaml')
 
+    EVENTS_DIR_PATH = File.join(METALWARE_DATA_PATH, 'events')
+
     DHCPD_HOSTS_PATH = '/etc/dhcp/dhcpd.hosts'
 
     # XXX Following needs to actually be created somewhere.

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -104,8 +104,8 @@ module Metalware
         File.join(var_named, zone)
       end
 
-      def build_complete(name)
-        File.join(config.built_nodes_storage_path, "metalwarebooter.#{name}")
+      def build_complete(node_namespace)
+        event(node_namespace, 'complete')
       end
 
       def rendered_build_file_path(node_name, namespace, file_name)
@@ -138,6 +138,12 @@ module Metalware
         instance_exec(&block)
       ensure
         @new_if_missing = false
+      end
+
+      def event(node_namespace, event = '', mkdir: true)
+        path = File.join(events_dir, node_namespace.name, event)
+        FileUtils.mkdir_p(event == '' ? path : File.dirname(path)) if mkdir
+        path
       end
 
       private

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -30,9 +30,10 @@ module Metalware
   class GroupCache
     include Enumerable
 
-    def initialize(metalware_config, force_reload_file: false)
+    # TODO: Remove the input
+    def initialize(_remove_this_input = nil, force_reload_file: false)
       @force_reload = force_reload_file
-      @config = metalware_config
+      @config = Config.cache
     end
 
     def group?(group)
@@ -69,6 +70,10 @@ module Metalware
 
     def primary_groups
       primary_groups_hash.keys.map(&:to_s)
+    end
+
+    def next_available_index
+      data[:next_index]
     end
 
     def orphans
@@ -112,10 +117,6 @@ module Metalware
         data[:primary_groups][:orphan] = 0
         data[:primary_groups]
       end
-    end
-
-    def next_available_index
-      data[:next_index]
     end
 
     def bump_next_index

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -94,6 +94,12 @@ module Metalware
 
       def hash_merger_input
         { groups: genders, node: name }
+      rescue NodeNotInGendersError
+        # The answer hash needs to be accessable by the Configurator
+        # Nodes in a group work fine as they appear in the genders file
+        # BUT local and orphan nodes DO NOT appear in the genders file and
+        # cause the above error
+        return { groups: ['orphan'], node: name }
       end
 
       def additional_dynamic_namespace

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -43,8 +43,7 @@ module Metalware
       end
 
       def build_complete_path
-        @build_complete_path ||= FilePath.new(metal_config)
-                                         .build_complete(name)
+        @build_complete_path ||= FilePath.build_complete(self)
       end
 
       def build_complete_url

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -69,6 +69,10 @@ module Metalware
         end
       end
 
+      def event_dir
+        FilePath.event self
+      end
+
       private
 
       def white_list_for_hasher


### PR DESCRIPTION
Fixes #207 

Metalware will now respond to events written to `/v/l/m/events/<node>/<event>` during the build process. Metalware will display the name and content of any file written to a directory of a building node. The build complete file has also been moved to this directory. A file called `complete` will tell metalware that the node has finished building.

To facilitate the change a new `BuildEvent` class has been created. It handles running all of the build hooks in separate threads and detecting if the build has finished. This has allowed for the simplification of the build process.

 Also fixed a bug concerning the orphan nodes. See the following commit for full details:
https://github.com/alces-software/metalware/commit/13bdf86b5d4f85014344f8544b6d386dd309612b