### PR TITLE
Fixes #253, Run run_all_complete_hooks on build_event

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -99,6 +99,13 @@ module AlcesUtils
       $stderr = hash[:stderr] if hash[:stderr]
     end
 
+    def kill_other_threads
+      Thread.list
+            .reject { |t| t == Thread.current }
+            .tap { |t| t.each(&:kill) }
+            .tap { |t| t.each(&:join) }
+    end
+
     def mock(test, *a, &b)
       mock_block = lambda do |*_inputs|
         mock_alces = AlcesUtils::Mock.new(self)

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -21,12 +21,7 @@ RSpec.describe Metalware::BuildEvent do
   AlcesUtils.mock self, :each do
     nodes.each { |node| mock_node(node) }
     alces.nodes.each { |node| hexadecimal_ip(node) }
-    Thread.list.each do |t| 
-      unless t == Thread.current
-        t.kill
-        t.join
-      end
-    end
+    AlcesUtils.kill_other_threads
   end
 
   def wait_for_hooks_to_run(test_obj: build_event)

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -38,9 +38,7 @@ RSpec.describe Metalware::Commands::Build do
     # Shortens the wait times for the tests
     allow(metal_config).to receive(:build_poll_sleep).and_return(0.1)
     # Makes sure there aren't any other threads
-    Thread.list.each do |th|
-      th.kill unless th == Thread.main
-    end
+    AlcesUtils.kill_other_threads
   end
 
   let :build_wait_time { metal_config.build_poll_sleep * 5 }

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -150,7 +150,7 @@ module Metalware
           [yes/no]
         EOF
 
-        run_all_complete_hooks if agree(should_rerender)
+        build_event.run_all_complete_hooks if agree(should_rerender)
       end
     end
   end


### PR DESCRIPTION
Small bug fix. The `run_all_complete_hook` is now located in the `build_event`