### PR TITLE
Remove and suppress the output during the tests

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -181,7 +181,7 @@ module AlcesUtils
 
     def mock_node(name, *genders)
       AlcesUtils.check_and_raise_fakefs_error
-      alces.nodes # Ensures the nodes list is initialized
+      raise_if_node_exists(name)
       add_node_to_genders_file(name, *genders)
       Metalware::Namespaces::Node.create(alces, name).tap do |node|
         with_blank_config_and_answer(node)
@@ -211,6 +211,12 @@ module AlcesUtils
     private
 
     attr_reader :alces, :metal_config, :test
+
+    def raise_if_node_exists(name)
+      return unless File.exist? Metalware::FilePath.genders
+      msg = "Node '#{name}' already exists"
+      raise Metalware::InternalError, msg if alces.nodes.find_by_name(name)
+    end
 
     def add_node_to_genders_file(name, *genders)
       genders = [AlcesUtils.default_group] if genders.empty?

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -181,13 +181,16 @@ module AlcesUtils
 
     def mock_node(name, *genders)
       AlcesUtils.check_and_raise_fakefs_error
-      genders = [AlcesUtils.default_group] if genders.empty?
-      genders_entry = "#{name} #{genders.join(',')}\n"
-      File.write(file_path.genders, genders_entry, mode: 'a')
-      alces.instance_variable_set(:@nodes, nil)
-      node = alces.nodes.find_by_name(name)
-      with_blank_config_and_answer(node)
-      allow(alces).to receive(:node).and_return(node)
+      alces.nodes # Ensures the nodes list is initialized
+      add_node_to_genders_file(name, *genders)
+      Metalware::Namespaces::Node.create(alces, name).tap do |node|
+        with_blank_config_and_answer(node)
+        hexadecimal_ip(node)
+        new_nodes = alces.nodes.reduce([node], &:push)
+        metal_nodes = Metalware::Namespaces::MetalArray.new(new_nodes)
+        allow(alces).to receive(:nodes).and_return(metal_nodes)
+        allow(alces).to receive(:node).and_return(node)
+      end
     end
 
     def mock_group(name)
@@ -208,6 +211,12 @@ module AlcesUtils
     private
 
     attr_reader :alces, :metal_config, :test
+
+    def add_node_to_genders_file(name, *genders)
+      genders = [AlcesUtils.default_group] if genders.empty?
+      genders_entry = "#{name} #{genders.join(',')}\n"
+      File.write(file_path.genders, genders_entry, mode: 'a')
+    end
 
     # Allows the RSpec methods to be accessed
     def respond_to_missing?(s, *_a)

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -172,6 +172,12 @@ RSpec.describe AlcesUtils do
         expect(alces.node.answer.to_h).to be_empty
       end
 
+      it 'errors if the node already exists' do
+        expect do
+          AlcesUtils.mock(self) { mock_node(name) }
+        end.to raise_error(Metalware::InternalError)
+      end
+
       context 'with a new node' do
         let :new_node { 'some_random_new_node4362346' }
         let :genders { ['_some_group_1', '_some_group_2'] }

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Metalware::Commands::Build do
     AlcesUtils.mock self, :each do
       test_group = 'some_random_test_group'
       mock_group(test_group)
-      ['node00', 'node01', 'node02', 'node03'].each do |node|
+      ['nodeA00', 'nodeA01', 'nodeA02', 'nodeA03'].each do |node|
         mock_node(node, test_group)
         hexadecimal_ip(alces.node)
       end

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -46,9 +46,11 @@ RSpec.describe Metalware::Commands::Build do
   def run_build(node_group, delay_report_built: nil, **options_hash)
     Timeout.timeout build_wait_time do
       th = Thread.new do
-        Metalware::Utils.run_command(
-          Metalware::Commands::Build, node_group.name, **options_hash
-        )
+        AlcesUtils.redirect_std(:stdout) do
+          Metalware::Utils.run_command(
+            Metalware::Commands::Build, node_group.name, **options_hash
+          )
+        end
       end
 
       # Allows the build to report finished after a set delay

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -77,7 +77,9 @@ RSpec.describe '`metal build`' do
       thr = Thread.new do
         begin
           Timeout.timeout 20 do
-            Metalware::Commands::Build.new([name], options)
+            AlcesUtils.redirect_std(:stdout) do
+              Metalware::Commands::Build.new([name], options)
+            end
           end
         rescue => e
           STDERR.puts e.inspect


### PR DESCRIPTION
The `build` tests use to print a huge amount of warnings during the tests. This is because the nodes with a mocked `hexadecimal` ip address where being deleted and recreated. This meant the rendering scripts where failing.

Instead the old node objects are now preserved. Also the `hexadecimal` ip address is now automatically mocked for all mocked nodes.

The stdout of the build tests are also suppressed as `rspec` will automatically answer the questions regardless of what is displayed.