### PR TITLE
Fix various interconnected bugs

### DIFF
--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -31,7 +31,12 @@ RSpec.describe Metalware::BuildEvent do
   end
 
   def build_node(node)
-    FileUtils.touch node.build_complete_path
+    touch_file node.build_complete_path
+  end
+
+  def touch_file(path)
+    FileUtils.mkdir_p File.dirname(path)
+    FileUtils.touch path
   end
 
   describe '#run_all_complete_hooks' do
@@ -118,7 +123,7 @@ RSpec.describe Metalware::BuildEvent do
       let :event_file { Metalware::FilePath.event(node, event) }
 
       context 'with basic features only (no hooks nor messages)' do
-        before :each { FileUtils.touch event_file }
+        before :each { touch_file event_file }
 
         it 'reports the event and node names to stdout' do
           expect(process[:stdout].read).to include(node.name, event)

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe Metalware::Commands::Build do
         else
           node_group.nodes
         end.each do |node|
-          FileUtils.touch node.build_complete_path
+          path = node.build_complete_path
+          FileUtils.mkdir_p File.dirname(path)
+          FileUtils.touch path
         end
       end
       th.join

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -113,7 +113,9 @@ RSpec.describe '`metal build`' do
   let :file_path { Metalware::FilePath.new(metal_config) }
 
   def touch_complete_file(name)
-    FileUtils.touch(file_path.build_complete(alces.nodes.find_by_name(name)))
+    path = file_path.build_complete(alces.nodes.find_by_name(name))
+    FileUtils.mkdir_p File.dirname(path)
+    FileUtils.touch(path)
   end
 
   context 'for single node' do

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Metalware::Namespaces::Alces do
           key: 'value',
           embedded_key: '<%= alces.testing.key %>',
           infinite_value1: '<%= alces.testing.infinite_value2 %>',
-          infinite_value2: '<%= alces.testing.infinite_value1 %>'
+          infinite_value2: '<%= alces.testing.infinite_value1 %>',
+          false_key: false
         ) do |template_string|
           alces.render_erb_template(template_string)
         end
@@ -43,6 +44,11 @@ RSpec.describe Metalware::Namespaces::Alces do
         output = render_template('<%= alces.testing.infinite_value1 %>')
         STDERR.puts "Template output: #{output}"
       end.to raise_error(Metalware::RecursiveConfigDepthExceededError)
+    end
+
+    it 'evalutes the false string as Falsey' do
+      template = '<%= alces.testing.false_key ? "true" : "false" %>'
+      expect(render_template(template)).to eq(false)
     end
   end
 

--- a/spec/templating/nil_detection_wrapper_spec.rb
+++ b/spec/templating/nil_detection_wrapper_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
       be_a(Binding)
   end
 
+  context 'with a falsey result' do
+    let :false_obj do
+      build_wrapper_object(OpenStruct.new(nil_key: nil, false_key: false))
+    end
+
+    def expect_falsey(value)
+      expect(value ? true : false).to be(false)
+    end
+
+    it 'preserves the falsey-ness of nil' do
+      expect_falsey(false_obj.nil_key)
+    end
+
+    it "preserves the falsey-ness of 'false'" do
+      expect_falsey(false_obj.false_key)
+    end
+  end
+
   context 'with a wrapped integer' do
     let :object { 100 }
     let :wrapped_object { build_wrapper_object(object) }

--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -22,6 +22,7 @@ module Metalware
 
     def run_all_complete_hooks
       nodes.each { |node| run_hook(node, 'complete') }
+      loop if hook_active?
     end
 
     def build_complete?

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -140,10 +140,9 @@ module Metalware
         @new_if_missing = false
       end
 
+      # Remove mkdir input
       def event(node_namespace, event = '', mkdir: true)
-        path = File.join(events_dir, node_namespace.name, event)
-        FileUtils.mkdir_p(event == '' ? path : File.dirname(path)) if mkdir
-        path
+        File.join(events_dir, node_namespace.name, event)
       end
 
       private

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -115,12 +115,16 @@ module Metalware
         if dynamic_stack.length > Constants::MAXIMUM_RECURSIVE_CONFIG_DEPTH
           raise RecursiveConfigDepthExceededError
         end
-        dynamic_namespace =
-          Constants::HASH_MERGER_DATA_STRUCTURE.new(namespace)
-        dynamic_stack.push(dynamic_namespace)
+        dynamic_stack.push(dynamic_hash(namespace))
         result = yield
         dynamic_stack.pop
         parse_result(result)
+      end
+
+      def dynamic_hash(namespace)
+        Constants::HASH_MERGER_DATA_STRUCTURE.new(namespace) do |template|
+          alces.render_erb_template(template)
+        end
       end
 
       def parse_result(result)


### PR DESCRIPTION
This PR contains a few bug fixes that where either detected or directly responsible for parsing error bug (fixes #264).

1. Initially it was suspected that the parser error was because the dynamic namespace didn't have a templating block to use. It was unrelated, however the fix is included as it is best practice for MetalROS to be initialised with a template_block. https://github.com/alces-software/metalware/commit/f827249616ebb7af649c3d1f71189438f300d9a9
1. The `FalseClass` being true was due to the `NilDetectionWrapper` always being `truthy`. The fix is to never wrap falsy values. `NilDetectionWrapper` has been updated to handle `nil` and `false` in a similar way (except `nil` issues a warning). https://github.com/alces-software/metalware/commit/be20cb494b2859324a0c7f17efea4031168e4896
1. Related to this, the `firstboot` doesn't always toggle correctly. This was initially due to the bug above, however there is also a race condition between the re-render of the pxelinux and metalware ending. Instead metalware will hang until the re-render is complete (or another interrupt is received). https://github.com/alces-software/metalware/commit/2dede6d0cbf3351cccf67b004c784dff5e3535ff
1. Finally the events dir isn't created by metalware as this creates file permissions issues. https://github.com/alces-software/metalware/commit/51ad78ee36a7401e65772436be4996c9dc5f8d50