### PR TITLE
KVM orchestration

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -115,3 +115,8 @@ Style/NumericPredicate:
 Naming/BinaryOperatorParameterName:
   Exclude:
     - 'src/node.rb'
+
+# Offense count: 1
+Style/OpMethod:
+  Exclude:
+    - 'src/node.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -115,8 +115,3 @@ Style/NumericPredicate:
 Naming/BinaryOperatorParameterName:
   Exclude:
     - 'src/node.rb'
-
-# Offense count: 1
-Style/OpMethod:
-  Exclude:
-    - 'src/node.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,9 @@ gem 'net-dhcp'
 gem 'network_interface', '~> 0.0.1'
 gem 'pcap', git: 'https://github.com/alces-software/ruby-pcap.git'
 gem 'recursive-open-struct'
+gem 'ruby-libvirt'
 gem 'rugged'
 gem 'terminal-table'
-gem 'ruby-libvirt'
 
 # Forked of a fork containing a logger fix. The main gem can be used
 # again once StructuredWarnings is removed

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'pcap', git: 'https://github.com/alces-software/ruby-pcap.git'
 gem 'recursive-open-struct'
 gem 'rugged'
 gem 'terminal-table'
+gem 'ruby-libvirt'
 
 # Forked of a fork containing a logger fix. The main gem can be used
 # again once StructuredWarnings is removed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-libvirt (0.7.0)
     ruby-prof (0.16.2)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
@@ -285,6 +286,7 @@ DEPENDENCIES
   recursive-open-struct
   rspec
   rubocop
+  ruby-libvirt
   ruby-prof
   rubytree!
   rugged

--- a/bin/install-ci-dependencies
+++ b/bin/install-ci-dependencies
@@ -16,3 +16,6 @@ sudo apt-get install libpcap-dev -y
 
 # Required for `nodeattr`.
 sudo apt-get install genders -y
+
+# Required for ruby-libvirt gem.
+sudo apt-get install libvirt-dev -y

--- a/bin/setup
+++ b/bin/setup
@@ -39,6 +39,9 @@ yum install libpcap libpcap-devel -y
 # Required for `nodeattr`.
 yum install genders -y
 
+# Required for ruby-libvirt gem.
+yum install libvirt-devel -y
+
 # Install Ruby and gems.
 rvm install ruby-2.4.1
 cd .. && cd -  # Let RVM automatically use correct Ruby for dir.

--- a/scripts/os/el6.sh
+++ b/scripts/os/el6.sh
@@ -36,7 +36,9 @@ install_base_prerequisites() {
 install_build_prerequisites() {
     # ruby: openssl readline zlib libffi
     # hunter: libpcap
+    # ruby-libvirt: libvirt-devel
     yum -e0 -y groupinstall "Development Tools" && \
         yum -e0 -y install openssl-devel readline-devel zlib-devel libffi-devel && \
-        yum -e0 -y install libpcap-devel
+        yum -e0 -y install libpcap-devel && \
+        yum -e0 -y install libvirt-devel
 }

--- a/scripts/os/el7.sh
+++ b/scripts/os/el7.sh
@@ -42,8 +42,10 @@ install_build_prerequisites() {
     # ruby: openssl readline zlib libffi
     # hunter: libpcap
     # rugged: cmake libcurl-devel libssh2-devel gmp-devel
+    # ruby-libvirt: libvirt-devel
     yum -e0 -y groupinstall "Development Tools" && \
         yum -e0 -y install openssl-devel readline-devel zlib-devel libffi-devel && \
         yum -e0 -y install libpcap-devel && \
-        yum -e0 -y install cmake libcurl-devel libssh2-devel gmp-devel
+        yum -e0 -y install cmake libcurl-devel libssh2-devel gmp-devel && \
+        yum -e0 -y install libvirt-devel
 }

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AlcesUtils do
   context 'with the AlceUtils.mock method' do
     before :each do
       AlcesUtils::Mock.new(self)
-                      .define_method_testing{} # Intentionally blank
+                      .define_method_testing {} # Intentionally blank
     end
 
     it 'only has the local node by default' do

--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
   class TestCommand < Metalware::CommandHelpers::ConfigureCommand
     private
 
-    def setup; end
-
     # Overridden to be three element array with third a valid `configure.yaml`
     # questions section; `BaseCommand` expects command classes to be namespaced
     # by two modules.

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -72,7 +72,7 @@ class FileSystem
   def self.root_setup
     FakeFS.without do
       yield FileSystem.root_file_system_config
-      FileSystem.test{} # Applies the changes
+      FileSystem.test {} # Applies the changes
     end
   end
 

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -75,6 +75,8 @@ subcommands:
     syntax: metal orchestrate destroy NODE_IDENTIFIER [options]
     summary: Destroys a new virtual machine
     action: Commands::Orchestrate::Destroy
+    options:
+      - *group_option
 
   remove_group: &remove_group
     syntax: metal remove group GROUP_NAME [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -66,14 +66,14 @@ subcommands:
 
   orchestrate_create: &orchestrate_create
     syntax: metal orchestrate create NODE_IDENTIFIER [options]
-    summary: Creates a new virtual machine
+    summary: Creates a new virtual machine or group of machines
     action: Commands::Orchestrate::Create
     options:
       - *group_option
 
   orchestrate_destroy: &orchestrate_destroy
     syntax: metal orchestrate destroy NODE_IDENTIFIER [options]
-    summary: Destroys a new virtual machine
+    summary: Destroys a single or group of virtual machines
     action: Commands::Orchestrate::Destroy
     options:
       - *group_option

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -68,6 +68,8 @@ subcommands:
     syntax: metal orchestrate create NODE_IDENTIFIER [options]
     summary: Creates a new virtual machine
     action: Commands::Orchestrate::Create
+    options:
+      - *group_option
 
   orchestrate_destroy: &orchestrate_destroy
     syntax: metal orchestrate destroy NODE_IDENTIFIER [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -64,6 +64,16 @@ subcommands:
       the system environment. This command is intended to only be ran once.
     action: Commands::Configure::Local
 
+  orchestrate_create: &orchestrate_create
+    syntax: metal orchestrate create NODE_IDENTIFIER [options]
+    summary: Creates a new virtual machine
+    action: Commands::Orchestrate::Create
+
+  orchestrate_destroy: &orchestrate_destroy
+    syntax: metal orchestrate destroy NODE_IDENTIFIER [options]
+    summary: Destroys a new virtual machine
+    action: Commands::Orchestrate::Destroy
+
   remove_group: &remove_group
     syntax: metal remove group GROUP_NAME [options]
     summary: Removes a previously configured group
@@ -281,6 +291,13 @@ commands:
         type: String
         description: >
           The IPMI tool command to run, for example `sel list`
+
+  orchestrate:
+    syntax: metal orchestrate [COMMAND] [options]
+    summary: Orchestrate virtual machines
+    subcommands:
+      create: *orchestrate_create
+      destroy: *orchestrate_destroy
 
   plugin:
     syntax: metal plugin [options]

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -16,7 +16,7 @@ module Metalware
       def nodes
         @nodes ||= begin
           nodes = if options.group
-                    alces.groups.find_by_name(node_identifier)&.nodes
+                    group&.nodes
                   else
                     alces.nodes.find_by_name(node_identifier)
                   end

--- a/src/command_helpers/orchestrate_command.rb
+++ b/src/command_helpers/orchestrate_command.rb
@@ -27,13 +27,13 @@ require 'command_helpers/node_identifier'
 require 'config'
 
 module Metalware
-  module Commands
-    class Orchestrate < CommandHelpers::BaseCommand
-      def setup; end
-
+  module CommandHelpers
+    class OrchestrateCommand < BaseCommand
       private
 
       prepend CommandHelpers::NodeIdentifier
+
+      def setup; end
 
       def node_info
         { libvirt_host: node.answer.libvirt_host }
@@ -52,12 +52,12 @@ module Metalware
       end
 
       def node_names
-        @node_names ||= nodes.map(&:mame)
+        @node_names ||= nodes.map(&:name)
       end
 
-      def render_template(node, type)
+      def render_template(node_name, type)
         path = "/var/lib/metalware/repo/libvirt/#{type}.xml"
-        node = alces.nodes.find_by_name(node)
+        node = alces.nodes.find_by_name(node_name)
         templater = node ? node : alces
         templater.render_erb_template(File.read(path))
       end

--- a/src/command_helpers/orchestrate_command.rb
+++ b/src/command_helpers/orchestrate_command.rb
@@ -54,13 +54,6 @@ module Metalware
       def node_names
         @node_names ||= nodes.map(&:name)
       end
-
-      def render_template(node_name, type)
-        path = "/var/lib/metalware/repo/libvirt/#{type}.xml"
-        node = alces.nodes.find_by_name(node_name)
-        templater = node ? node : alces
-        templater.render_erb_template(File.read(path))
-      end
     end
   end
 end

--- a/src/command_helpers/orchestrate_command.rb
+++ b/src/command_helpers/orchestrate_command.rb
@@ -33,8 +33,6 @@ module Metalware
 
       prepend CommandHelpers::NodeIdentifier
 
-      def setup; end
-
       def node_info
         { libvirt_host: node.answer.libvirt_host }
       end

--- a/src/commands/configure/domain.rb
+++ b/src/commands/configure/domain.rb
@@ -10,8 +10,6 @@ module Metalware
       class Domain < CommandHelpers::ConfigureCommand
         private
 
-        def setup; end
-
         def answer_file
           file_path.domain_answers
         end

--- a/src/commands/configure/local.rb
+++ b/src/commands/configure/local.rb
@@ -10,8 +10,6 @@ module Metalware
       class Local < CommandHelpers::ConfigureCommand
         private
 
-        def setup; end
-
         def configurator
           @configurator ||=
             Configurator.for_local(alces)

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -22,7 +22,6 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
-require 'pty'
 require 'commands/ipmi'
 
 module Metalware
@@ -32,7 +31,7 @@ module Metalware
 
       def run
         if vm?
-          libvirt = Metalware::Vm.new(libvirt_info[:host], node_names[0])
+          system("virsh console #{node.name}")
         elsif valid_connection?
           puts 'Establishing SOL connection, type &. to exit ..'
           system(command('activate'))

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -31,12 +31,17 @@ module Metalware
       private
 
       def run
-        puts "Attempting to connect to node #{node_names[0]}.."
-        if valid_connection?
-          puts 'Establishing SOL connection, type &. to exit..'
-          system(command('activate'))
+        if vm?
+          libvirt = Metalware::Vm.new(libvirt_info[:host], node.name)
+          libvirt.console
         else
-          puts 'Failed to connect..'
+          puts "Attempting to connect to node #{node_names[0]}.."
+          if valid_connection?
+            puts 'Establishing SOL connection, type &. to exit..'
+            system(command('activate'))
+          else
+            puts 'Failed to connect'
+          end
         end
       end
 

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -33,15 +33,11 @@ module Metalware
       def run
         if vm?
           libvirt = Metalware::Vm.new(libvirt_info[:host], node_names[0])
-          libvirt.console
+        elsif valid_connection?
+          puts 'Establishing SOL connection, type &. to exit ..'
+          system(command('activate'))
         else
-          puts "Attempting to connect to node #{node_names[0]}.."
-          if valid_connection?
-            puts 'Establishing SOL connection, type &. to exit..'
-            system(command('activate'))
-          else
-            puts 'Failed to connect'
-          end
+          raise MetalwareError, "Unable to connect to #{node_names[0]}"
         end
       end
 

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -32,7 +32,7 @@ module Metalware
 
       def run
         if vm?
-          libvirt = Metalware::Vm.new(libvirt_info[:host], node.name)
+          libvirt = Metalware::Vm.new(libvirt_info[:host], node_names[0])
           libvirt.console
         else
           puts "Attempting to connect to node #{node_names[0]}.."

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -35,8 +35,6 @@ module Metalware
 
       prepend CommandHelpers::NodeIdentifier
 
-      def setup; end
-
       def run
         if options.group
           node_names.each do

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -39,22 +39,20 @@ module Metalware
 
       def run
         if options.group
-          node_names.each do |node|
-            run_vm if vm?
-            run_baremetal unless vm?
+          node_names.each do
+            ipmi
           end
         else
-          run_vm if vm?
-          run_baremetal unless vm?
+          ipmi
         end
       end
 
-      def run_vm
-        libvirt_run(libvirt_info[:host], node)
-      end
-
-      def run_baremetal
-        puts "#{node}: #{SystemCommand.run(command(node))}"
+      def ipmi
+        if vm?
+          libvirt_run(libvirt_info[:host], node)
+        else
+          puts "#{node}: #{SystemCommand.run(command(node))}"
+        end
       end
 
       def libvirt_run(host, node)

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -46,12 +46,10 @@ module Metalware
               puts "#{node}: #{SystemCommand.run(command(node))}"
             end
           end
+        elsif vm?
+          libvirt_run(libvirt_info[:host], node.name)
         else
-          if vm?
-            libvirt_run(libvirt_info[:host], node.name)
-          else
-            puts "#{node.name}: #{SystemCommand.run(command(node.name))}"
-          end
+          puts "#{node.name}: #{SystemCommand.run(command(node.name))}"
         end
       end
 
@@ -91,7 +89,7 @@ module Metalware
         object = options.group ? group : node
         {
           host: object.answer.libvirt_host,
-          vm: object.answer.is_vm
+          vm: object.answer.is_vm,
         }
       end
 

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -26,6 +26,7 @@ require 'command_helpers/base_command'
 require 'command_helpers/node_identifier'
 require 'config'
 require 'system_command'
+require 'vm'
 
 module Metalware
   module Commands
@@ -39,11 +40,24 @@ module Metalware
       def run
         if options.group
           node_names.each do |node|
-            puts "#{node}: #{SystemCommand.run(command(node))}"
+            if vm?
+              libvirt_run(libvirt_info[:host], node)
+            else
+              puts "#{node}: #{SystemCommand.run(command(node))}"
+            end
           end
         else
-          SystemCommand.run(command(node.name))
+          if vm?
+            libvirt_run(libvirt_info[:host], node.name)
+          else
+            puts "#{node.name}: #{SystemCommand.run(command(node.name))}"
+          end
         end
+      end
+
+      def libvirt_run(host, node)
+        libvirt = Metalware::Vm.new(host, node)
+        libvirt.run(args[1])
       end
 
       def command(host)
@@ -71,6 +85,18 @@ module Metalware
 
       def node_names
         @node_names ||= nodes.map(&:name)
+      end
+
+      def libvirt_info
+        object = options.group ? group : node
+        {
+          host: object.answer.libvirt_host,
+          vm: object.answer.is_vm
+        }
+      end
+
+      def vm?
+        libvirt_info[:vm]
       end
     end
   end

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -40,17 +40,21 @@ module Metalware
       def run
         if options.group
           node_names.each do |node|
-            if vm?
-              libvirt_run(libvirt_info[:host], node)
-            else
-              puts "#{node}: #{SystemCommand.run(command(node))}"
-            end
+            run_vm if vm?
+            run_baremetal unless vm?
           end
-        elsif vm?
-          libvirt_run(libvirt_info[:host], node.name)
         else
-          puts "#{node.name}: #{SystemCommand.run(command(node.name))}"
+          run_vm if vm?
+          run_baremetal unless vm?
         end
+      end
+
+      def run_vm
+        libvirt_run(libvirt_info[:host], node)
+      end
+
+      def run_baremetal
+        puts "#{node}: #{SystemCommand.run(command(node))}"
       end
 
       def libvirt_run(host, node)

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -47,7 +47,7 @@ module Metalware
           MetalLog.info "Creating new node #{node.name}"
           libvirt.create(render_template(node.name, 'disk'), render_template(node.name, 'vm'))
           MetalLog.info "Updating MAC address for #{node.name}"
-          hunter_updater.add(node.name, node.answers.vm_mac_address_build)
+          hunter_updater.add(node.name, node.answer.vm_mac_address_build)
         end
 
         def hunter_updater

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -42,7 +42,7 @@ module Metalware
               create(node)
             end
           else
-            create(node)
+            create(node.name)
           end
         end
 
@@ -53,8 +53,8 @@ module Metalware
         end
 
         def create(node)
-          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node)
-          libvirt.create(render_template('disk'), render_template('vm'))
+          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node, node.answer.vm_disk_pool)
+          libvirt.create(render_template(node.name, 'disk'), render_template(node.name, 'vm'))
         end
 
         def object
@@ -73,9 +73,10 @@ module Metalware
           @node_names ||= nodes.map(&:name)
         end
 
-        def render_template(type)
+        def render_template(node, type)
           template_path = "/var/lib/metalware/repo/libvirt/#{type}.xml"
           template = File.read(template_path)
+          node = alces.nodes.find_by_name(node)
           templater = node ? node : alces
           templater.render_erb_template(template)
         end

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -22,23 +22,28 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
+require 'command_helpers/orchestrate_command'
+
 module Metalware
   module Commands
-    class Create < Orchestrate
-      private
-      def run
-        if options.group
-          nodes.each do |node|
-            create(node)
-          end
-        else
-          create(node.name)
-        end
-      end
+    module Orchestrate
+      class Create < CommandHelpers::OrchestrateCommand
+        private
 
-      def create(node)
-        libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
-        libvirt.create(render_template(node.name, 'disk'), render_template(node.name, 'vm'))
+        def run
+          if options.group
+            nodes.each do |node|
+              create(node)
+            end
+          else
+            create(node.name)
+          end
+        end
+
+        def create(node)
+          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
+          libvirt.create(render_template(node.name, 'disk'), render_template(node.name, 'vm'))
+        end
       end
     end
   end

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -23,12 +23,48 @@
 #==============================================================================
 
 require 'command_helpers/base_command'
+require 'command_helpers/node_identifier'
+require 'config'
+require 'vm'
 
 module Metalware
   module Commands
     module Orchestrate
       class Create < CommandHelpers::BaseCommand
         private
+
+        def setup; end
+
+        def run
+          if option.group
+            nodes.each do |node|
+              create_domain(node)
+            end
+          end
+        end
+
+        def node_info
+          {
+            libvirt_host: node.config.libvirt_host
+          }
+        end
+
+        def create_domain
+          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node)
+          libvirt.create_domain
+        end
+
+        def group
+          alces.groups.find_by_name(args[0])
+        end
+
+        def node
+          alces.nodes.find_by_name(node_names[0])
+        end
+
+        def nodes
+          @nodes ||= nodes.map(&:name)
+        end
       end
     end
   end

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -44,9 +44,7 @@ module Metalware
 
         def create(node)
           libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
-          MetalLog.info "Creating new node #{node.name}"
           libvirt.create(render_template(node.name, 'disk'), render_template(node.name, 'vm'))
-          MetalLog.info "Updating MAC address for #{node.name}"
           hunter_updater.add(node.name, node.answer.vm_mac_address_build)
         end
 

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -39,7 +39,7 @@ module Metalware
         def run
           if options.group
             nodes.each do |node|
-              create_domain(node)
+              create(node)
             end
           end
         end
@@ -50,9 +50,13 @@ module Metalware
           }
         end
 
-        def create_domain(node)
+        def create(node)
           libvirt = Metalware::Vm.new(node_info[:libvirt_host], node)
-          libvirt.create_domain(render_template)
+          libvirt.create(render_template)
+        end
+
+        def object
+          options.group ? group : node
         end
 
         def group

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -53,7 +53,7 @@ module Metalware
         end
 
         def create(node)
-          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node, node.answer.vm_disk_pool)
+          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
           libvirt.create(render_template(node.name, 'disk'), render_template(node.name, 'vm'))
         end
 

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -22,7 +22,9 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
+require 'constants'
 require 'command_helpers/orchestrate_command'
+require 'hunter_updater'
 
 module Metalware
   module Commands
@@ -42,7 +44,14 @@ module Metalware
 
         def create(node)
           libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
+          MetalLog.info "Creating new node #{node.name}"
           libvirt.create(render_template(node.name, 'disk'), render_template(node.name, 'vm'))
+          MetalLog.info "Updating MAC address for #{node.name}"
+          hunter_updater.add(node.name, node.answers.vm_mac_address_build)
+        end
+
+        def hunter_updater
+          @hunter_updater ||= HunterUpdater.new(Constants::HUNTER_PATH)
         end
       end
     end

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -41,18 +41,20 @@ module Metalware
             nodes.each do |node|
               create(node)
             end
+          else
+            create(node)
           end
         end
 
         def node_info
           {
-            libvirt_host: node.config.libvirt_host
+            libvirt_host: node.answer.libvirt_host
           }
         end
 
         def create(node)
           libvirt = Metalware::Vm.new(node_info[:libvirt_host], node)
-          libvirt.create(render_template)
+          libvirt.create(render_template('disk'), render_template('vm'))
         end
 
         def object
@@ -71,8 +73,8 @@ module Metalware
           @node_names ||= nodes.map(&:name)
         end
 
-        def render_template
-          template_path = '/var/lib/metalware/repo/libvirt/vm.xml'
+        def render_template(type)
+          template_path = "/var/lib/metalware/repo/libvirt/#{type}.xml"
           template = File.read(template_path)
           templater = node ? node : alces
           templater.render_erb_template(template)

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -36,7 +36,7 @@ module Metalware
               create(node)
             end
           else
-            create(node.name)
+            create(node)
           end
         end
 

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'command_helpers/base_command'
+
+module Metalware
+  module Commands
+    module Orchestrate
+      class Create < CommandHelpers::BaseCommand
+        private
+      end
+    end
+  end
+end

--- a/src/commands/orchestrate/create.rb
+++ b/src/commands/orchestrate/create.rb
@@ -53,6 +53,13 @@ module Metalware
         def hunter_updater
           @hunter_updater ||= HunterUpdater.new(Constants::HUNTER_PATH)
         end
+
+        def render_template(node_name, type)
+          path = "/var/lib/metalware/repo/libvirt/#{type}.xml"
+          node = alces.nodes.find_by_name(node_name)
+          templater = node ? node : alces
+          templater.render_erb_template(File.read(path))
+        end
       end
     end
   end

--- a/src/commands/orchestrate/destroy.rb
+++ b/src/commands/orchestrate/destroy.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'command_helpers/base_command'
+
+module Metalware
+  module Commands
+    module Orchestrate
+      class Destroy < CommandHelpers::BaseCommand
+        private
+      end
+    end
+  end
+end

--- a/src/commands/orchestrate/destroy.rb
+++ b/src/commands/orchestrate/destroy.rb
@@ -27,7 +27,7 @@ require 'command_helpers/orchestrate_command'
 module Metalware
   module Commands
     module Orchestrate
-      class Destroy < CommandHelpers::ConfigureCommand
+      class Destroy < CommandHelpers::OrchestrateCommand
         private
 
         def run
@@ -36,13 +36,13 @@ module Metalware
               destroy(node)
             end
           else
-            destroy(node.name)
+            destroy(node)
           end
         end
 
         def destroy(node)
           libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
-          libvirt.destroy(node.name, 'vm')
+          libvirt.destroy(node.name)
         end
       end
     end

--- a/src/commands/orchestrate/destroy.rb
+++ b/src/commands/orchestrate/destroy.rb
@@ -22,24 +22,28 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
+require 'command_helpers/orchestrate_command'
+
 module Metalware
   module Commands
-    class Destroy < Orchestrate
-      private
+    module Orchestrate
+      class Destroy < CommandHelpers::ConfigureCommand
+        private
 
-      def run
-        if options.group
-          nodes.each do |node|
-            destroy(node)
+        def run
+          if options.group
+            nodes.each do |node|
+              destroy(node)
+            end
+          else
+            destroy(node.name)
           end
-        else
-          destroy(node.name)
         end
-      end
 
-      def destroy(node)
-        libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
-        libvirt.destroy(node.name, 'vm')
+        def destroy(node)
+          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
+          libvirt.destroy(node.name, 'vm')
+        end
       end
     end
   end

--- a/src/commands/orchestrate/destroy.rb
+++ b/src/commands/orchestrate/destroy.rb
@@ -22,56 +22,24 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
-require 'command_helpers/base_command'
-require 'command_helpers/node_identifier'
-require 'config'
-
 module Metalware
   module Commands
-    module Orchestrate
-      class Destroy < CommandHelpers::BaseCommand
-        private
+    class Destroy < Orchestrate
+      private
 
-        prepend CommandHelpers::NodeIdentifier
-
-        def setup; end
-
-        def run
-          if options.group
-            nodes.each do |node|
-              destroy(node)
-            end
-          else
-            destroy(node.name)
+      def run
+        if options.group
+          nodes.each do |node|
+            destroy(node)
           end
+        else
+          destroy(node.name)
         end
+      end
 
-        def node_info
-          {
-            libvirt_host: node.answer.libvirt_host
-          }
-        end
-
-        def destroy(node)
-          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
-          libvirt.destroy(node.name, 'vm')
-        end
-
-        def object
-          options.group ? group : node
-        end
-
-        def group
-          alces.groups.find_by_name(args[0])
-        end
-
-        def node
-          alces.nodes.find_by_name(node_names[0])
-        end
-
-        def node_names
-          @node_names ||= nodes.map(&:name)
-        end
+      def destroy(node)
+        libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
+        libvirt.destroy(node.name, 'vm')
       end
     end
   end

--- a/src/commands/orchestrate/destroy.rb
+++ b/src/commands/orchestrate/destroy.rb
@@ -23,12 +23,55 @@
 #==============================================================================
 
 require 'command_helpers/base_command'
+require 'command_helpers/node_identifier'
+require 'config'
 
 module Metalware
   module Commands
     module Orchestrate
       class Destroy < CommandHelpers::BaseCommand
         private
+
+        prepend CommandHelpers::NodeIdentifier
+
+        def setup; end
+
+        def run
+          if options.group
+            nodes.each do |node|
+              destroy(node)
+            end
+          else
+            destroy(node.name)
+          end
+        end
+
+        def node_info
+          {
+            libvirt_host: node.answer.libvirt_host
+          }
+        end
+
+        def destroy(node)
+          libvirt = Metalware::Vm.new(node_info[:libvirt_host], node.name, 'vm')
+          libvirt.destroy(node.name, 'vm')
+        end
+
+        def object
+          options.group ? group : node
+        end
+
+        def group
+          alces.groups.find_by_name(args[0])
+        end
+
+        def node
+          alces.nodes.find_by_name(node_names[0])
+        end
+
+        def node_names
+          @node_names ||= nodes.map(&:name)
+        end
       end
     end
   end

--- a/src/commands/render.rb
+++ b/src/commands/render.rb
@@ -31,8 +31,6 @@ module Metalware
     class Render < CommandHelpers::BaseCommand
       private
 
-      def setup; end
-
       def run
         template_path, name = args
 

--- a/src/commands/sync.rb
+++ b/src/commands/sync.rb
@@ -32,8 +32,6 @@ module Metalware
 
       attr_reader :manifest
 
-      def setup; end
-
       def run
         Staging.update do |staging|
           sync_files(staging)

--- a/src/commands/view_answers/domain.rb
+++ b/src/commands/view_answers/domain.rb
@@ -9,8 +9,6 @@ module Metalware
       class Domain < CommandHelpers::BaseCommand
         private
 
-        def setup; end
-
         def run
           puts AnswersTableCreator.new(config, alces).domain_table
         end

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -48,10 +48,14 @@ module Metalware
     # - storage: Rendered Libvirt storage XML, used to create the root disk
     # - vm: Rendered Libvirt domain XML, used to create the domain
     def create(disk_tpl, domain_tpl)
-      puts "Provisioning new disk for #{@node}"
-      storage.create_volume_xml(disk_tpl)
-      puts "Provisioning new machine #{@node}"
-      @libvirt.define_domain_xml(domain_tpl)
+      unless volume_exists?
+        puts "Provisioning new storage volume for #{@node}"
+        storage.create_volume_xml(disk_tpl)
+      end
+      unless domain_exists?
+        puts "Provisioning new machine #{@node}"
+        @libvirt.define_domain_xml(domain_tpl)
+      end
     end
 
     # Destroys a VM and its associated disk
@@ -71,8 +75,12 @@ module Metalware
       @libvirt.lookup_domain_by_name(@node)
     end
 
-    def exists?
+    def domain_exists?
       @libvirt.lookup_domain_by_name(@node)
+    end
+
+    def volume_exists?
+      storage.lookup_volume_by_name(@node)
     end
 
     def running?

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -26,13 +26,13 @@ module Metalware
         stop
       when 'status'
         puts "#{@node}: Power state: #{info[:state]}"
-      else
-        raise 'Not possible'
+        else
+          raise 'Not possible'
       end
     end
 
     def console
-      puts "Attempting to connect to node #{node.name}"
+      puts "Attempting to connect to node #{@node}"
       domain.open_console if running?
     end
 
@@ -65,6 +65,10 @@ module Metalware
         when 1
           'on'
       end
+    end
+
+    def stream
+      @libvirt.stream
     end
   end
 end

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -9,6 +9,7 @@ module Metalware
 
     def initialize(libvirt_host, node)
       @libvirt ||= Libvirt.open("qemu://#{libvirt_host}/system")
+      @storage ||= @libvirt.lookup_storage_pool_by_name(node.vm_storage_pool)
       @node = node
     end
 
@@ -58,8 +59,9 @@ module Metalware
       domain.shutdown if running?
     end
 
-    def create(template)
-      @libvirt.define_domain_xml(template)
+    def create(storage, vm)
+      @storage.create_volume_xml(storage)
+      @libvirt.define_domain_xml(vm)
     end
 
     private

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -6,8 +6,6 @@ require 'metal_log'
 
 module Metalware
   class Vm
-    attr_accessor :node
-
     def initialize(libvirt_host, node, *args)
       @libvirt ||= Libvirt.open("qemu://#{libvirt_host}/system")
       @node = node

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -31,6 +31,11 @@ module Metalware
       end
     end
 
+    def console
+      puts "Attempting to connect to node #{node.name}"
+      domain.open_console if running?
+    end
+
     def start
       domain.create unless running?
     end

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -10,7 +10,6 @@ module Metalware
 
     def initialize(libvirt_host, node, *args)
       @libvirt ||= Libvirt.open("qemu://#{libvirt_host}/system")
-      @storage ||= @libvirt.lookup_storage_pool_by_name(args[0]) if args[0]
       @node = node
     end
 
@@ -76,6 +75,10 @@ module Metalware
 
     def stream
       @libvirt.stream
+    end
+
+    def storage
+      @storage ||= @libvirt.lookup_storage_pool_by_name(args[0])
     end
   end
 end

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -18,6 +18,9 @@ module Metalware
 
     def run(cmd)
       case cmd
+      when 'kill'
+        puts "Killing node #{@node}.."
+        kill
       when 'on'
         puts "Powering up node #{@node}.."
         start
@@ -37,6 +40,10 @@ module Metalware
     def console
       puts "Attempting to connect to node #{@node}"
       domain.open_console if running?
+    end
+
+    def kill
+      domain.destroy if running?
     end
 
     def reboot

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -10,7 +10,7 @@ module Metalware
 
     def initialize(libvirt_host, node, *args)
       @libvirt ||= Libvirt.open("qemu://#{libvirt_host}/system")
-      @storage ||= @libvirt.lookup_storage_pool_by_name(args[0])
+      @storage ||= @libvirt.lookup_storage_pool_by_name(args[0]) if args[0]
       @node = node
     end
 
@@ -45,10 +45,10 @@ module Metalware
     end
 
     def create(storage, vm)
-      puts "Provisioning new disk for #{@name}" unless disk_exists?
+      puts "Provisioning new disk for #{@node}"
       @storage.create_volume_xml(storage)
-      puts "Provisioning new machine #{@name}" unless exists?
-      #@libvirt.define_domain_xml(vm)
+      puts "Provisioning new machine #{@node}"
+      @libvirt.define_domain_xml(vm)
     end
 
     private
@@ -59,10 +59,6 @@ module Metalware
 
     def exists?
       @libvirt.lookup_domain_by_name(@node)
-    end
-
-    def disk_exists?
-      @storage.lookup_volume_by_name(@node)
     end
 
     def running?

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -48,14 +48,10 @@ module Metalware
     # - storage: Rendered Libvirt storage XML, used to create the root disk
     # - vm: Rendered Libvirt domain XML, used to create the domain
     def create(disk_tpl, domain_tpl)
-      unless volume_exists?
-        puts "Provisioning new storage volume for #{@node}"
-        storage.create_volume_xml(disk_tpl)
-      end
-      unless domain_exists?
-        puts "Provisioning new machine #{@node}"
-        @libvirt.define_domain_xml(domain_tpl)
-      end
+      puts "Provisioning new storage volume for #{@node}"
+      storage.create_volume_xml(disk_tpl)
+      puts "Provisioning new machine #{@node}"
+      @libvirt.define_domain_xml(domain_tpl)
     end
 
     # Destroys a VM and its associated disk
@@ -73,14 +69,6 @@ module Metalware
 
     def domain
       @libvirt.lookup_domain_by_name(@node)
-    end
-
-    def domain_exists?
-      @libvirt.lookup_domain_by_name(@node)
-    end
-
-    def volume_exists?
-      storage.lookup_volume_by_name(@node)
     end
 
     def running?

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -43,11 +43,23 @@ module Metalware
       domain.open_console if running?
     end
 
+    # Creates a new VM
+    # - storage: Rendered Libvirt storage XML, used to create the root disk
+    # - vm: Rendered Libvirt domain XML, used to create the domain
     def create(storage, vm)
       puts "Provisioning new disk for #{@node}"
       @storage.create_volume_xml(storage)
       puts "Provisioning new machine #{@node}"
       @libvirt.define_domain_xml(vm)
+    end
+
+    # Destroys a VM and its associated disk
+    # - domain: Domain name
+    def destroy(domain)
+      domain.destroy
+      domain.undefine
+      vol = storage.lookup_volume_by_name(domain)
+      vol.delete
     end
 
     private

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -20,20 +20,20 @@ module Metalware
       case cmd
       when 'kill'
         puts "Killing node #{@node}.."
-        domain.destroy if running?
+        domain.destroy
       when 'on'
         puts "Powering up node #{@node}.."
-        domain.create unless running?
+        domain.create
       when 'off'
         puts "Powering down node #{@node}.."
-        domain.shutdown if running?
+        domain.shutdown
       when 'reboot'
         puts "Rebooting node #{@node}.."
-        domain.reboot if running?
+        domain.reboot
       when 'status'
         puts "#{@node}: Power state: #{info[:state]}"
       else
-        raise 'Not possible'
+        raise MetalwareError, "Invalid command: #{cmd}"
       end
     end
 

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -58,6 +58,10 @@ module Metalware
       domain.shutdown if running?
     end
 
+    def create(template)
+      @libvirt.define_domain_xml(template)
+    end
+
     private
 
     def domain

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -26,8 +26,8 @@ module Metalware
         stop
       when 'status'
         puts "#{@node}: Power state: #{info[:state]}"
-        else
-          raise 'Not possible'
+      else
+        raise 'Not possible'
       end
     end
 
@@ -47,7 +47,7 @@ module Metalware
     private
 
     def domain
-     @libvirt.lookup_domain_by_name(@node)
+      @libvirt.lookup_domain_by_name(@node)
     end
 
     def exists?
@@ -60,10 +60,10 @@ module Metalware
 
     def state
       case domain.info.state
-        when 5
-          'off'
-        when 1
-          'on'
+      when 5
+        'off'
+      when 1
+        'on'
       end
     end
 

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -24,6 +24,9 @@ module Metalware
       when 'off'
         puts "Powering down node #{@node}.."
         stop
+      when 'reboot'
+        puts "Rebooting node #{@node}.."
+        reboot
       when 'status'
         puts "#{@node}: Power state: #{info[:state]}"
       else
@@ -34,6 +37,10 @@ module Metalware
     def console
       puts "Attempting to connect to node #{@node}"
       domain.open_console if running?
+    end
+
+    def reboot
+      domain.reboot if running?
     end
 
     def start

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'config'
+require 'libvirt'
+
+module Metalware
+  class Vm
+    attr_accessor :node
+
+    def initialize(libvirt_host, node)
+      @libvirt ||= Libvirt.open("qemu://#{libvirt_host}/system")
+      @node = node
+    end
+
+    def info
+      { state: state }
+    end
+
+    def run(cmd)
+      case cmd
+      when 'on'
+        puts "Powering up node #{@node}.."
+        start
+      when 'off'
+        puts "Powering down node #{@node}.."
+        stop
+      when 'status'
+        puts "#{@node}: Power state: #{info[:state]}"
+      else
+        raise 'Not possible'
+      end
+    end
+
+    def start
+      domain.create unless running?
+    end
+
+    def stop
+      domain.shutdown if running?
+    end
+
+    private
+
+    def domain
+     @libvirt.lookup_domain_by_name(@node)
+    end
+
+    def exists?
+      @libvirt.lookup_domain_by_name(@node)
+    end
+
+    def running?
+      domain.active?
+    end
+
+    def state
+      case domain.info.state
+        when 5
+          'off'
+        when 1
+          'on'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This addresses #242 

- Added `ruby-libvirt` gem and required setup tasks
- Added `orchestrate create` and `orchestrate destroy` commands
- Modified `power` command to detect whether a node is a virtual machine or not, and act accordingly
- Added new `Vm` class, acting as a wrapper around the Ruby Libvirt library

Still to-do, some pending discussion:

- [x] Add certificate generation process to Metalware installer
- [ ] Warn when unable to connect to specified Libvirt host, hinting certificates may need to be installed
- [ ] Fix `console` to correctly open a console on a domain using the Ruby Libvirt library
- [x] Fix Code Climate warnings