### PR TITLE
Plugin commands

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -112,6 +112,6 @@ Style/NumericPredicate:
     - 'src/commands/repo/update.rb'
 
 # Offense count: 1
-Style/OpMethod:
+Naming/BinaryOperatorParameterName:
   Exclude:
     - 'src/node.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ source 'https://rubygems.org'
 # https://github.com/fakefs/fakefs#fakefs-----typeerror-superclass-mismatch-for-class-file.
 require 'pp'
 
+gem 'colorize'
 gem 'commander', git: 'https://github.com/alces-software/commander'
 gem 'dry-validation'
 gem 'hashie'
@@ -18,7 +19,6 @@ gem 'pcap', git: 'https://github.com/alces-software/ruby-pcap.git'
 gem 'recursive-open-struct'
 gem 'rugged'
 gem 'terminal-table'
-gem 'colorize'
 
 # Forked of a fork containing a logger fix. The main gem can be used
 # again once StructuredWarnings is removed

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'pcap', git: 'https://github.com/alces-software/ruby-pcap.git'
 gem 'recursive-open-struct'
 gem 'rugged'
 gem 'terminal-table'
+gem 'colorize'
 
 # Forked of a fork containing a logger fix. The main gem can be used
 # again once StructuredWarnings is removed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     builder (3.2.3)
     byebug (9.1.0)
     coderay (1.1.2)
+    colorize (0.8.1)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
@@ -265,6 +266,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap (~> 4.0.0.beta)
   byebug
+  colorize
   commander!
   concurrent-ruby
   dry-validation

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Metalware::Commands::Configure::Domain do
     )
   end
 
-  let :config { Metalware::Config.new }
-
   let :filesystem do
     FileSystem.setup(&:with_minimal_repo)
   end

--- a/spec/commands/plugin/disable_spec.rb
+++ b/spec/commands/plugin/disable_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'filesystem'
+require 'alces_utils'
+
+RSpec.describe Metalware::Commands::Plugin::Disable do
+  include AlcesUtils
+
+  def run_plugin_disable(plugin_name)
+    Metalware::Utils.run_command(
+      Metalware::Commands::Plugin::Disable, plugin_name
+    )
+  end
+
+  let :filesystem do
+    FileSystem.setup do |fs|
+      fs.with_minimal_repo
+      fs.mkdir_p example_plugin_dir
+    end
+  end
+
+  let :example_plugin_dir { File.join file_path.plugins_dir, example_plugin_name }
+  let :example_plugin_name { 'example' }
+
+  def example_plugin
+    Metalware::Plugins.find do |plugin|
+      plugin.name == example_plugin_name
+    end
+  end
+
+  it 'switches the plugin to be disabled' do
+    filesystem.test do
+      example_plugin.enable!
+
+      run_plugin_disable(example_plugin_name)
+
+      expect(example_plugin).not_to be_enabled
+    end
+  end
+
+  it 'gives error if plugin does not exist' do
+    filesystem.test do
+      unknown_plugin_name = 'unknown_plugin'
+
+      expect do
+        AlcesUtils.redirect_std(:stderr) do
+          run_plugin_disable(unknown_plugin_name)
+        end
+      end.to raise_error Metalware::MetalwareError,
+        "Unknown plugin: #{unknown_plugin_name}"
+    end
+  end
+end

--- a/spec/commands/plugin/enable_spec.rb
+++ b/spec/commands/plugin/enable_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Metalware::Commands::Plugin::Enable do
 
       run_plugin_enable(example_plugin_name)
 
-      matching_enabled_plugins = Metalware::Plugins.enabled_plugin_names.select do |name|
-        name == example_plugin_name
+      matching_enabled_plugins = Metalware::Plugins.select do |plugin|
+        plugin.name == example_plugin_name && plugin.enabled?
       end
       expect(matching_enabled_plugins.length).to eq 1
     end

--- a/spec/commands/plugin/enable_spec.rb
+++ b/spec/commands/plugin/enable_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'filesystem'
+require 'alces_utils'
+
+RSpec.describe Metalware::Commands::Plugin::Enable do
+  include AlcesUtils
+
+  def run_plugin_enable(plugin_name)
+    Metalware::Utils.run_command(
+      Metalware::Commands::Plugin::Enable, plugin_name
+    )
+  end
+
+  let :filesystem do
+    FileSystem.setup do |fs|
+      fs.with_minimal_repo
+      fs.mkdir_p example_plugin_dir
+    end
+  end
+
+  let :example_plugin_dir { File.join file_path.plugins_dir, example_plugin_name }
+  let :example_plugin_name { 'example' }
+
+  def example_plugin
+    Metalware::Plugins.find do |plugin|
+      plugin.name == example_plugin_name
+    end
+  end
+
+  it 'switches the plugin to be enabled' do
+    filesystem.test do
+      expect(example_plugin).not_to be_enabled
+
+      run_plugin_enable(example_plugin_name)
+
+      expect(example_plugin).to be_enabled
+    end
+  end
+
+  it 'does not duplicate enabled plugin if already enabled' do
+    filesystem.test do
+      example_plugin.enable!
+
+      run_plugin_enable(example_plugin_name)
+
+      matching_enabled_plugins = Metalware::Plugins.enabled_plugin_names.select do |name|
+        name == example_plugin_name
+      end
+      expect(matching_enabled_plugins.length).to eq 1
+    end
+  end
+
+  it 'gives error if plugin does not exist' do
+    filesystem.test do
+      unknown_plugin_name = 'unknown_plugin'
+
+      expect do
+        AlcesUtils.redirect_std(:stderr) do
+          run_plugin_enable(unknown_plugin_name)
+        end
+      end.to raise_error Metalware::MetalwareError,
+        "Unknown plugin: #{unknown_plugin_name}"
+    end
+  end
+end

--- a/spec/commands/plugin/list_spec.rb
+++ b/spec/commands/plugin/list_spec.rb
@@ -53,7 +53,22 @@ RSpec.describe Metalware::Commands::Plugin::List do
         run_plugin_list
       end[:stdout].read
 
-      expect(stdout).to eq "example01\nexample02\n"
+      expect(stdout).to match(/example01.*\nexample02.*\n/)
+    end
+  end
+
+  it 'specifies whether each plugin is enabled in output' do
+    filesystem.test do |fs|
+      # XXX Replace this with `plugin enable` once implemented?
+      fs.dump Metalware::Constants::PLUGINS_CACHE_PATH, {enabled: ['example01']}
+
+      stdout = AlcesUtils.redirect_std(:stdout) do
+        run_plugin_list
+      end[:stdout].read
+
+      enabled = '[ENABLED]'.green
+      disabled = '[DISABLED]'.red
+      expect(stdout).to eq "example01 #{enabled}\nexample02 #{disabled}\n"
     end
   end
 end

--- a/spec/commands/plugin/list_spec.rb
+++ b/spec/commands/plugin/list_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Metalware::Commands::Plugin::List do
   it 'specifies whether each plugin is enabled in output' do
     filesystem.test do |fs|
       # XXX Replace this with `plugin enable` once implemented?
-      fs.dump Metalware::Constants::PLUGINS_CACHE_PATH, {enabled: ['example01']}
+      Metalware::Plugins.enable!('example01')
 
       stdout = AlcesUtils.redirect_std(:stdout) do
         run_plugin_list

--- a/spec/commands/plugin/list_spec.rb
+++ b/spec/commands/plugin/list_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'filesystem'
+require 'alces_utils'
+
+RSpec.describe Metalware::Commands::Plugin::List do
+  include AlcesUtils
+
+  def run_plugin_list
+    Metalware::Utils.run_command(
+      Metalware::Commands::Plugin::List
+    )
+  end
+
+  let :filesystem do
+    FileSystem.setup do |fs|
+      fs.with_minimal_repo
+      fs.mkdir_p example_plugin_dir_1
+      fs.mkdir_p example_plugin_dir_2
+      fs.touch junk_other_plugins_dir_file
+    end
+  end
+
+  let :example_plugin_dir_1 { File.join file_path.plugins_dir, 'example01' }
+  let :example_plugin_dir_2 { File.join file_path.plugins_dir, 'example02' }
+  let :junk_other_plugins_dir_file { File.join file_path.plugins_dir, 'junk' }
+
+  it 'outputs line for each plugin subdirectory' do
+    filesystem.test do
+      stdout = AlcesUtils.redirect_std(:stdout) do
+        run_plugin_list
+      end[:stdout].read
+
+      expect(stdout).to eq "example01\nexample02\n"
+    end
+  end
+end

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -38,7 +38,7 @@ class FileSystem
   # called on a `FileSystemConfigurator` instance and will then be correctly
   # invoked when `FileSystem.test` is run with that instance. If these were run
   # directly outside of a `test` block then the real file system would be used.
-  delegate :mkdir_p, to: FileUtils
+  delegate :mkdir_p, :touch, to: FileUtils
   delegate :write, to: File
   delegate :dump, to: Metalware::Data
 

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -27,6 +27,7 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 require 'rubygems'
 require 'bundler/setup'
 require 'commander'
+require 'colorize'
 
 require 'commander_extensions'
 require 'cli_helper/parser'

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -103,6 +103,14 @@ subcommands:
         description: >
           Force update even if local changes have been made to the repo
 
+  plugin_list: &plugin_list
+    syntax: metal plugin list [options]
+    summary: List available and enabled plugins
+    description: >
+      List all available Metalware plugins, along with which of these are
+      currently enabled.
+    action: Commands::Plugin::List
+
   view-answers_domain: &view-answers_domain
     syntax: metal view-answers domain [options]
     summary: View configured answers for the overall domain
@@ -263,6 +271,12 @@ commands:
         type: String
         description: >
           The IPMI tool command to run, for example `sel list`
+
+  plugin:
+    syntax: metal plugin [options]
+    summary: View and manage enabled plugins
+    subcommands:
+      list: *plugin_list
 
   power:
     syntax: metal power NODE_IDENTIFIER [COMMAND] [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -111,6 +111,11 @@ subcommands:
       currently enabled.
     action: Commands::Plugin::List
 
+  plugin_enable: &plugin_enable
+    syntax: metal plugin enable PLUGIN_NAME [options]
+    summary: Enable given plugin for domain
+    action: Commands::Plugin::Enable
+
   view-answers_domain: &view-answers_domain
     syntax: metal view-answers domain [options]
     summary: View configured answers for the overall domain
@@ -277,6 +282,7 @@ commands:
     summary: View and manage enabled plugins
     subcommands:
       list: *plugin_list
+      enable: *plugin_enable
 
   power:
     syntax: metal power NODE_IDENTIFIER [COMMAND] [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -116,6 +116,11 @@ subcommands:
     summary: Enable given plugin for domain
     action: Commands::Plugin::Enable
 
+  plugin_disable: &plugin_disable
+    syntax: metal plugin disable PLUGIN_NAME [options]
+    summary: Disable given plugin for domain
+    action: Commands::Plugin::Disable
+
   view-answers_domain: &view-answers_domain
     syntax: metal view-answers domain [options]
     summary: View configured answers for the overall domain
@@ -283,6 +288,7 @@ commands:
     subcommands:
       list: *plugin_list
       enable: *plugin_enable
+      disable: *plugin_disable
 
   power:
     syntax: metal power NODE_IDENTIFIER [COMMAND] [options]

--- a/src/command_helpers/base_command.rb
+++ b/src/command_helpers/base_command.rb
@@ -112,9 +112,9 @@ module Metalware
         MetalLog.info "metal #{ARGV.join(' ')}"
       end
 
-      def setup
-        raise NotImplementedError
-      end
+      # Setup can optionally be used to perform command-specific setup early on
+      # in command execution.
+      def setup; end
 
       def run
         raise NotImplementedError

--- a/src/commands/plugin/disable.rb
+++ b/src/commands/plugin/disable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'command_helpers/base_command'
+require 'plugins'
+
+module Metalware
+  module Commands
+    module Plugin
+      class Disable < CommandHelpers::BaseCommand
+        private
+
+        def run
+          Plugins.disable!(plugin_name)
+        end
+
+        def plugin_name
+          args.first
+        end
+      end
+    end
+  end
+end

--- a/src/commands/plugin/enable.rb
+++ b/src/commands/plugin/enable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'command_helpers/base_command'
+require 'plugins'
+
+module Metalware
+  module Commands
+    module Plugin
+      class Enable < CommandHelpers::BaseCommand
+        private
+
+        def run
+          Plugins.enable!(plugin_name)
+        end
+
+        def plugin_name
+          args.first
+        end
+      end
+    end
+  end
+end

--- a/src/commands/plugin/list.rb
+++ b/src/commands/plugin/list.rb
@@ -31,11 +31,14 @@ module Metalware
         private
 
         def run
-          puts plugin_names.join("\n")
-        end
+          output = plugin_directories.map do |dir|
+            name = dir.basename.to_s
+            enabled = enabled_plugins.include?(name)
+            enabled_string = enabled ? '[ENABLED]'.green : '[DISABLED]'.red
+            "#{name} #{enabled_string}"
+          end.join("\n")
 
-        def plugin_names
-          plugin_directories.map(&:basename)
+          puts output
         end
 
         def plugin_directories
@@ -44,6 +47,14 @@ module Metalware
 
         def plugins_dir
           Pathname.new(file_path.plugins_dir)
+        end
+
+        def enabled_plugins
+          plugins_cache[:enabled] || []
+        end
+
+        def plugins_cache
+          Data.load(Constants::PLUGINS_CACHE_PATH)
         end
       end
     end

--- a/src/commands/plugin/list.rb
+++ b/src/commands/plugin/list.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'command_helpers/base_command'
+
+module Metalware
+  module Commands
+    module Plugin
+      class List < CommandHelpers::BaseCommand
+        private
+
+        def run
+          puts plugin_names.join("\n")
+        end
+
+        def plugin_names
+          plugin_directories.map(&:basename)
+        end
+
+        def plugin_directories
+          plugins_dir.children.select(&:directory?)
+        end
+
+        def plugins_dir
+          Pathname.new(file_path.plugins_dir)
+        end
+      end
+    end
+  end
+end

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -39,6 +39,7 @@ module Metalware
     INVALID_RENDERED_GENDERS_PATH = File.join(CACHE_PATH, 'invalid.genders')
     STAGING_DIR_PATH = File.join(METALWARE_DATA_PATH, 'staging')
     STAGING_MANIFEST_PATH = File.join(CACHE_PATH, 'staging-manifest.yaml')
+    PLUGINS_CACHE_PATH = File.join(CACHE_PATH, 'plugins.yaml')
 
     EVENTS_DIR_PATH = File.join(METALWARE_DATA_PATH, 'events')
 

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -77,6 +77,10 @@ module Metalware
         config.repo_path
       end
 
+      def plugins_dir
+        File.join(repo, 'plugins')
+      end
+
       def repo_relative_path_to(path)
         repo_path = Pathname.new(repo)
         Pathname.new(path).relative_path_from(repo_path).to_s

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -38,7 +38,25 @@ module Metalware
         cache[:enabled] || []
       end
 
+      def enable!(plugin_name)
+        raise MetalwareError,
+          "Unknown plugin: #{plugin_name}" unless exists?(plugin_name)
+        return if enabled_plugin_names.include?(plugin_name)
+
+        new_enabled_plugins = enabled_plugin_names + [plugin_name]
+        new_cache = cache.merge(enabled: new_enabled_plugins)
+        Data.dump(Constants::PLUGINS_CACHE_PATH, new_cache)
+      end
+
       private
+
+      def exists?(plugin_name)
+        all_plugin_names.include?(plugin_name)
+      end
+
+      def all_plugin_names
+        self.map(&:name)
+      end
 
       def plugin_directories
         plugins_dir.children.select(&:directory?)
@@ -69,6 +87,10 @@ module Metalware
       else
         '[DISABLED]'.red
       end
+    end
+
+    def enable!
+      Plugins.enable!(name)
     end
   end
 end

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -27,10 +27,10 @@ module Metalware
     class << self
       include Enumerable
 
-      def each(&block)
+      def each
         plugin_directories.each do |dir|
           plugin = Plugin.new(dir)
-          block.call(plugin)
+          yield(plugin)
         end
       end
 
@@ -58,8 +58,10 @@ module Metalware
       private
 
       def validate_plugin_exists!(plugin_name)
-        raise MetalwareError,
-          "Unknown plugin: #{plugin_name}" unless exists?(plugin_name)
+        unless exists?(plugin_name)
+          raise MetalwareError,
+                "Unknown plugin: #{plugin_name}"
+        end
       end
 
       def update_enabled_plugins!(new_enabled_plugins)
@@ -72,7 +74,7 @@ module Metalware
       end
 
       def all_plugin_names
-        self.map(&:name)
+        map(&:name)
       end
 
       def plugin_directories

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -34,8 +34,8 @@ module Metalware
         end
       end
 
-      def enabled_plugin_names
-        cache[:enabled] || []
+      def enabled?(plugin_name)
+        enabled_plugin_names.include?(plugin_name)
       end
 
       def enable!(plugin_name)
@@ -73,6 +73,10 @@ module Metalware
         all_plugin_names.include?(plugin_name)
       end
 
+      def enabled_plugin_names
+        cache[:enabled] || []
+      end
+
       def all_plugin_names
         map(&:name)
       end
@@ -97,7 +101,7 @@ module Metalware
     end
 
     def enabled?
-      Plugins.enabled_plugin_names.include?(name)
+      Plugins.enabled?(name)
     end
 
     def enabled_identifier

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -39,16 +39,33 @@ module Metalware
       end
 
       def enable!(plugin_name)
-        raise MetalwareError,
-          "Unknown plugin: #{plugin_name}" unless exists?(plugin_name)
+        validate_plugin_exists!(plugin_name)
         return if enabled_plugin_names.include?(plugin_name)
 
         new_enabled_plugins = enabled_plugin_names + [plugin_name]
-        new_cache = cache.merge(enabled: new_enabled_plugins)
-        Data.dump(Constants::PLUGINS_CACHE_PATH, new_cache)
+        update_enabled_plugins!(new_enabled_plugins)
+      end
+
+      def disable!(plugin_name)
+        validate_plugin_exists!(plugin_name)
+
+        new_enabled_plugins = enabled_plugin_names.reject do |name|
+          name == plugin_name
+        end
+        update_enabled_plugins!(new_enabled_plugins)
       end
 
       private
+
+      def validate_plugin_exists!(plugin_name)
+        raise MetalwareError,
+          "Unknown plugin: #{plugin_name}" unless exists?(plugin_name)
+      end
+
+      def update_enabled_plugins!(new_enabled_plugins)
+        new_cache = cache.merge(enabled: new_enabled_plugins)
+        Data.dump(Constants::PLUGINS_CACHE_PATH, new_cache)
+      end
 
       def exists?(plugin_name)
         all_plugin_names.include?(plugin_name)


### PR DESCRIPTION
This PR adds the `plugin` command with subcommands to `list`, `enable`, and `disable` plugins. Plugins are (for now at least) considered to be any directories within `/var/lib/metalware/repo/plugins`. Currently these commands are fairly unnecessary since no files within any plugins are being used in any way; this will be added in a future PR.

I'm just going to merge this straight through since it's relatively straightforward, but feel free to add comments if you have any.