### PR TITLE
Don't attempt to copy `templates` dir that no longer exists. Fixes #267

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -91,7 +91,7 @@ chmod a+rw /var/lib/metalware/events
 ln -s /etc/hosts /var/lib/metalware/rendered/system/
 
 mkdir -p "${target}"
-cp -R "${source}/"{Gemfile,Gemfile.lock,bin,etc,libexec,src,templates} "${target}"
+cp -R "${source}/"{Gemfile,Gemfile.lock,bin,etc,libexec,src} "${target}"
 cp ${source}/etc/logrotate.d/* /etc/logrotate.d/
 say_done $?
 


### PR DESCRIPTION
I've seen this error far too many times lately, here is a quick fix