### PR TITLE
Preserve the dynamic-stack when multi-threaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.  This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2017.2.1]
+- Fix the infinite recursion bug when rendering the pxelinux file for
+  multiple nodes in the build command.
+
 ## [2017.2.0]
 - Added `metal template` command which renders the templates and build files
   for a node or group. All files are rendered to the staging directory and not

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe Metalware::Namespaces::Alces do
       template = '<%= alces.testing.false_key ? "true" : "false" %>'
       expect(render_template(template)).to eq(false)
     end
+
+    it 'preserve the scope when threaded' do
+      template = '<% sleep 0.2 %><%= key %>'
+      long_sleep = '<% sleep 0.3 %>'
+      t = Thread.new do
+        rendered = alces.render_erb_template(template, key: 'correct')
+        expect(rendered).to eq('correct')
+      end
+      sleep 0.1
+      alces.render_erb_template(long_sleep, key: 'incorrect scope')
+      t.join
+    end
   end
 
   describe '#local' do

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -39,7 +39,7 @@ module Metalware
 
     def run
       program :name, 'metal'
-      program :version, '2017.2.0'
+      program :version, '2017.2.1'
       program :description, 'Alces tools for the management and configuration of bare metal machines'
 
       CliHelper::Parser.new(self).parse_commands

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -43,7 +43,7 @@ module Metalware
 
       def initialize(metal_config)
         @metal_config = metal_config
-        @dynamic_stack = []
+        @stacks_hash = {}
       end
 
       # TODO: Remove this method, use Config.cache instead
@@ -109,7 +109,7 @@ module Metalware
 
       private
 
-      attr_reader :dynamic_stack
+      attr_reader :stacks_hash
 
       def run_with_dynamic(namespace)
         if dynamic_stack.length > Constants::MAXIMUM_RECURSIVE_CONFIG_DEPTH
@@ -144,6 +144,13 @@ module Metalware
 
       def current_dynamic_namespace
         dynamic_stack.last
+      end
+
+      attr_reader :stacks_hash
+
+      def dynamic_stack
+        stacks_hash[Thread.current] = [] unless stacks_hash[Thread.current]
+        stacks_hash[Thread.current]
       end
 
       def wrapped_binding


### PR DESCRIPTION
See: https://github.com/alces-software/metalware/commit/f001dcf53eba43f4c0dd70df2dc33667f5156ede

Fixes: #278