### PR TITLE
Certificate generation

### DIFF
--- a/src/vm.rb
+++ b/src/vm.rb
@@ -12,7 +12,7 @@ module Metalware
 
     def initialize(node)
       @node = node
-      certs = Certificates.new(node)
+      certs = Certificate.new(node)
       certs.generate && return unless certs.exist?
     end
 

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -65,9 +65,9 @@ module Metalware
 
     CERT_GENERATION_MSG = <<-EOF
     The following certificates have been generated, copy them
-    to the specified remote directory on julius:
+    to the specified remote directory on #{libvirt_host}:
 
-      from (local): #{CERTS_DIR}/julius-{key,cert}.pem
+      from (local): #{CERTS_DIR}/#{libvirt_host}-{key,cert}.pem
        to (remote): /etc/pki/libvirt/{servercert.pem,/private/serverkey.pem}
     EOF
 

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -4,6 +4,7 @@ require 'config'
 require 'libvirt'
 require 'metal_log'
 require 'namespaces/alces'
+require 'vm/certificate'
 
 module Metalware
   class Vm

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -63,14 +63,6 @@ module Metalware
 
     CERTS_DIR = '/var/lib/metalware/certs'
 
-    CERT_GENERATION_MSG = <<-EOF
-    The following certificates have been generated, copy them
-    to the specified remote directory on #{libvirt_host}:
-
-      from (local): #{CERTS_DIR}/#{libvirt_host}-{key,cert}.pem
-       to (remote): /etc/pki/libvirt/{servercert.pem,/private/serverkey.pem}
-    EOF
-
     def libvirt_host
       node.config.libvirt_host
     end
@@ -87,7 +79,7 @@ module Metalware
       generate_certificate_key
       generate_certificate_info
       generate_server_certificates
-      puts CERT_GENERATION_MSG
+      puts certificate_generation_message
       exit
     end
 
@@ -112,6 +104,16 @@ module Metalware
                         --load-ca-privkey #{CERTS_DIR}/cakey.pem \
                         --template #{CERTS_DIR}/#{libvirt_host}.info \
                         --outfile #{CERTS_DIR}/#{libvirt_host}-cert.pem")
+    end
+
+    def certificate_generation_message
+      <<-EOF
+  The following certificates have been generated, copy them
+  to the specified remote directory on #{libvirt_host}:
+
+    from (local): #{CERTS_DIR}/#{libvirt_host}-{key,cert}.pem
+     to (remote): /etc/pki/libvirt/{servercert.pem,/private/serverkey.pem}
+      EOF
     end
 
     def domain

--- a/src/vm.rb
+++ b/src/vm.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'config'
-require 'constants'
 require 'libvirt'
 require 'metal_log'
 require 'namespaces/alces'

--- a/src/vm/certificate.rb
+++ b/src/vm/certificate.rb
@@ -86,6 +86,6 @@ module Metalware
              to (remote): /etc/pki/libvirt/private/serverkey.pem
       EOF
       end
-  end
+    end
   end
 end

--- a/src/vm/certificate.rb
+++ b/src/vm/certificate.rb
@@ -3,82 +3,89 @@
 require 'active_support/core_ext/string/strip'
 
 module Metalware
-  class Vm::Certificate
-    attr_reader :node
+  class Vm
+    class Certificate
+      attr_reader :node
 
-    def initialize(node)
-      @node = node
-    end
-
-    def exist?
-      File.exist?(certificate_key_path)
-    end
-
-    def generate
-      generate_certificate_key
-      generate_certificate_info
-      generate_server_certificates
-      puts certificate_generation_message
-    end
-
-    private
-
-    CERTS_DIR = '/var/lib/metalware/certs'
-
-    def certificate_key_path
-      File.join(CERTS_DIR, "#{libvirt_host}-key.pem")
-    end
-
-    def certificate_info_path
-      File.join(CERTS_DIR, "#{libvirt_host}.info")
-    end
-
-    def ca_certificate_path
-      File.join(CERTS_DIR, 'cacert.pem')
-    end
-
-    def ca_privkey_path
-      File.join(CERTS_DIR, 'cakey.pem')
-    end
-
-    def certificate_path
-      File.join(CERTS_DIR, "#{libvirt_host}-cert.pem")
-    end
-
-    def generate_certificate_key
-      SystemCommand.run("certtool --generate-privkey > #{certificate_key_path}")
-    end
-
-    def generate_certificate_info
-      File.open(certificate_info_path, 'w') do |f|
-        f.puts 'organization = Alces Software'
-        f.puts "cn = #{libvirt_host}"
-        f.puts 'tls_www_server'
-        f.puts 'encryption_key'
-        f.puts 'signing_key'
+      def initialize(node)
+        @node = node
       end
-    end
 
-    def generate_server_certificates
-      SystemCommand.run("certtool --generate-certificate \
-                        --load-privkey #{certificate_key_path} \
-                        --load-ca-certificate #{ca_certificate_path} \
-                        --load-ca-privkey #{ca_privkey_path} \
-                        --template #{certificate_info_path} \
-                        --outfile #{certificate_path}")
-    end
+      def exist?
+        File.exist?(certificate_key_path)
+      end
 
-    def certificate_generation_message
-      <<-EOF
-  The following certificates have been generated, copy them
-  to the specified remote directory on #{libvirt_host}:
+      def generate
+        generate_certificate_key
+        generate_certificate_info
+        generate_server_certificates
+        puts certificate_generation_message
+        exit
+      end
 
-    from (local): #{certificate_path}
-     to (remote): /etc/pki/libvirt/servercert.pem
+      private
 
-    from (local): #{certificate_key_path}
-     to (remote): /etc/pki/libvirt/private/serverkey.pem
+      CERTS_DIR = '/var/lib/metalware/certs'
+
+      def libvirt_host
+        node.config.libvirt_host
+      end
+
+      def certificate_key_path
+        File.join(CERTS_DIR, "#{libvirt_host}-key.pem")
+      end
+
+      def certificate_info_path
+        File.join(CERTS_DIR, "#{libvirt_host}.info")
+      end
+
+      def ca_certificate_path
+        File.join(CERTS_DIR, 'cacert.pem')
+      end
+
+      def ca_privkey_path
+        File.join(CERTS_DIR, 'cakey.pem')
+      end
+
+      def certificate_path
+        File.join(CERTS_DIR, "#{libvirt_host}-cert.pem")
+      end
+
+      def generate_certificate_key
+        SystemCommand.run("certtool --generate-privkey > #{certificate_key_path}")
+      end
+
+      def generate_certificate_info
+        File.open(certificate_info_path, 'w') do |f|
+          f.puts 'organization = Alces Software'
+          f.puts "cn = #{libvirt_host}"
+          f.puts 'tls_www_server'
+          f.puts 'encryption_key'
+          f.puts 'signing_key'
+        end
+      end
+
+      def generate_server_certificates
+        SystemCommand.run("certtool --generate-certificate \
+                          --load-privkey #{certificate_key_path} \
+                          --load-ca-certificate #{ca_certificate_path} \
+                          --load-ca-privkey #{ca_privkey_path} \
+                          --template #{certificate_info_path} \
+                          --outfile #{certificate_path}")
+      end
+
+      def certificate_generation_message
+        <<~EOF
+          The following certificates have been generated, copy them
+          to the specified remote directory on #{libvirt_host}:
+
+            from (local): #{certificate_path}
+             to (remote): /etc/pki/libvirt/servercert.pem
+
+            from (local): #{certificate_key_path}
+             to (remote): /etc/pki/libvirt/private/serverkey.pem
       EOF
-    end
+      end
+  end
   end
 end

--- a/src/vm/certificate.rb
+++ b/src/vm/certificate.rb
@@ -20,7 +20,6 @@ module Metalware
         generate_certificate_info
         generate_server_certificates
         puts certificate_generation_message
-        exit
       end
 
       private

--- a/src/vm/certificate.rb
+++ b/src/vm/certificate.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/string/strip'
+
+module Metalware
+  class Vm::Certificate
+    attr_reader :node
+
+    def initialize(node)
+      @node = node
+    end
+
+    def exist?
+      File.exist?(certificate_key_path)
+    end
+
+    def generate
+      generate_certificate_key
+      generate_certificate_info
+      generate_server_certificates
+      puts certificate_generation_message
+      exit
+    end
+
+    private
+
+    CERTS_DIR = '/var/lib/metalware/certs'
+
+    def certificate_key_path
+      File.join(CERTS_DIR, "#{libvirt_host}-key.pem")
+    end
+
+    def certificate_info_path
+      File.join(CERTS_DIR, "#{libvirt_host}.info")
+    end
+
+    def ca_certificate_path
+      File.join(CERTS_DIR, 'cacert.pem')
+    end
+
+    def ca_privkey_path
+      File.join(CERTS_DIR, 'cakey.pem')
+    end
+
+    def certificate_path
+      File.join(CERTS_DIR, "#{libvirt_host}-cert.pem")
+    end
+
+    def generate_certificate_key
+      SystemCommand.run("certtool --generate-privkey > #{certificate_key_path}")
+    end
+
+    def generate_certificate_info
+      File.open(certificate_info_path, 'w') do |f|
+        f.puts 'organization = Alces Software'
+        f.puts "cn = #{libvirt_host}"
+        f.puts 'tls_www_server'
+        f.puts 'encryption_key'
+        f.puts 'signing_key'
+      end
+    end
+
+    def generate_server_certificates
+      SystemCommand.run("certtool --generate-certificate \
+                        --load-privkey #{certificate_key_path} \
+                        --load-ca-certificate #{ca_certificate_path} \
+                        --load-ca-privkey #{ca_privkey_path} \
+                        --template #{certificate_info_path} \
+                        --outfile #{certificate_path}")
+    end
+
+    def certificate_generation_message
+      <<-EOF
+The following certificates have been generated, copy them
+to the specified remote directory on #{libvirt_host}:
+
+  from (local): #{certificate_path}
+   to (remote): /etc/pki/libvirt/servercert.pem
+
+  from (local): #{certificate_key_path}
+   to (remote): /etc/pki/libvirt/private/serverkey.pem
+      EOF
+    end
+  end
+end

--- a/src/vm/certificate.rb
+++ b/src/vm/certificate.rb
@@ -75,7 +75,7 @@ module Metalware
       end
 
       def certificate_generation_message
-        <<~EOF
+        <<~EOF.strip_heredoc
           The following certificates have been generated, copy them
           to the specified remote directory on #{libvirt_host}:
 

--- a/src/vm/certificate.rb
+++ b/src/vm/certificate.rb
@@ -19,7 +19,6 @@ module Metalware
       generate_certificate_info
       generate_server_certificates
       puts certificate_generation_message
-      exit
     end
 
     private

--- a/src/vm/certificate.rb
+++ b/src/vm/certificate.rb
@@ -70,14 +70,14 @@ module Metalware
 
     def certificate_generation_message
       <<-EOF
-The following certificates have been generated, copy them
-to the specified remote directory on #{libvirt_host}:
+  The following certificates have been generated, copy them
+  to the specified remote directory on #{libvirt_host}:
 
-  from (local): #{certificate_path}
-   to (remote): /etc/pki/libvirt/servercert.pem
+    from (local): #{certificate_path}
+     to (remote): /etc/pki/libvirt/servercert.pem
 
-  from (local): #{certificate_key_path}
-   to (remote): /etc/pki/libvirt/private/serverkey.pem
+    from (local): #{certificate_key_path}
+     to (remote): /etc/pki/libvirt/private/serverkey.pem
       EOF
     end
   end


### PR DESCRIPTION
Addresses #280 - generates certificates for a `node`s `libvirt_host` the first time `Vm` class is run. These certificates have to be manually copied to the Libvirt host, then the command re-run afterwards. 