### PR TITLE
`Validation::Loader` and `Validation::Configure` refactoring

### DIFF
--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -147,22 +147,6 @@ RSpec.describe Metalware::Validation::Configure do
     }
   end
 
-  context 'without a hash input' do
-    it 'loads configure file from the repo' do
-      data = { domain: [], group: [] } # Intentionally incomplete
-      Metalware::Data.dump(file_path.configure_file, data)
-      v = Metalware::Validation::Configure.new(config)
-      expect(v.send(:raw_data)).to eq(data)
-    end
-  end
-
-  context 'with a hash input' do
-    it 'uses the hash as the data input' do
-      v = Metalware::Validation::Configure.new(config, correct_hash)
-      expect(v.send(:raw_data)).to eq(correct_hash)
-    end
-  end
-
   def run_configure_validation(my_hash = {})
     Metalware::Validation::Configure.new(config, my_hash).tree
   end

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+require 'validation/loader'
+
+RSpec.describe Metalware::Validation::Loader do
+  describe '#configure_data' do
+    let! :config do
+      # Need to create and cache a config before each test as this is expected
+      # by FilePath.
+      Metalware::Config.cache = Metalware::Config.new
+    end
+
+    let :configure_sections do
+      Metalware::Constants::CONFIGURE_SECTIONS
+    end
+
+    let :configure_questions_hash do
+      configure_sections.map do |section|
+        [
+          section, [{
+            identifier: "#{section}_identifier",
+            question: "#{section}_question",
+          }]
+        ]
+      end.to_h
+    end
+
+    let :filesystem do
+      FileSystem.setup do |fs|
+        fs.dump(Metalware::FilePath.configure_file, configure_questions_hash)
+      end
+    end
+
+    subject do
+      described_class.new(config)
+    end
+
+    after :each do
+      Metalware::Config.clear_cache
+    end
+
+    context 'when no plugins enabled' do
+      it 'loads repo configure.yaml questions for all sections' do
+        filesystem.test do
+          sections_to_loaded_questions = configure_sections.map do |section|
+            [section, subject.configure_data[section].children.map(&:content).map(&:to_h)]
+          end.to_h
+
+          configure_sections.each do |section|
+            questions = sections_to_loaded_questions[section]
+            question_identifiers = questions.map { |q| q[:identifier] }
+            expect(question_identifiers).to eq ["#{section}_identifier"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/hash_mergers/hash_merger.rb
+++ b/src/hash_mergers/hash_merger.rb
@@ -13,7 +13,7 @@ module Metalware
       def initialize(metalware_config)
         @metalware_config = metalware_config
         @file_path = FilePath.new(metalware_config)
-        @loader = Validation::Loader.new(metalware_config, cache_configure: true)
+        @loader = Validation::Loader.new(metalware_config)
         @cache = {}
       end
 

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -50,9 +50,9 @@ module Metalware
         end
       end
 
-      def initialize(config, data_hash = nil)
+      def initialize(config, questions_hash)
         @config = config
-        @raw_data = (data_hash || load_configure_file).freeze
+        @questions_hash = questions_hash.freeze
         raise_error_if_validation_failed
       end
 
@@ -60,7 +60,7 @@ module Metalware
         @tree ||= begin
           root_hash = {
             pass: true,
-            result: TopLevelSchema.call(data: raw_data),
+            result: TopLevelSchema.call(data: questions_hash),
           }
           Tree::TreeNode.new('ROOT', root_hash).tap do |root|
             add_children(root, root) do
@@ -76,12 +76,7 @@ module Metalware
 
       private
 
-      attr_reader :config, :raw_data
-
-      def load_configure_file
-        Data.load(FilePath.configure_file)
-      end
-
+      attr_reader :config, :questions_hash
       attr_accessor :failed_validation
 
       def raise_error_if_validation_failed
@@ -107,7 +102,7 @@ module Metalware
       end
 
       def make_section_node(root, section)
-        question_data = raw_data[section] || []
+        question_data = questions_hash[section] || []
         data = {
           section: section,
           result: DependantSchema.call(dependent: question_data),

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -39,7 +39,7 @@ module Metalware
 
       def configure_data
         return @configure_data if @configure_data
-        tree = Validation::Configure.new(config).tree
+        tree = Validation::Configure.new(config, repo_configure_data).tree
         @configure_data = tree if cache_configure
         tree
       end
@@ -73,6 +73,10 @@ module Metalware
                                            answer_section: section,
                                            configure_data: configure_data)
         validator.data
+      end
+
+      def repo_configure_data
+        Data.load(FilePath.configure_file)
       end
     end
   end

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -31,18 +31,13 @@ require 'data'
 module Metalware
   module Validation
     class Loader < LoadSaveBase
-      def initialize(metalware_config, cache_configure: false)
+      def initialize(metalware_config)
         @config = metalware_config
         @path = FilePath.new(config)
-        @cache_configure = cache_configure
       end
 
       def configure_data
-        if cache_configure
-          @configure_data ||= configure_data_tree
-        else
-          configure_data_tree
-        end
+        @configure_data ||= configure_data_tree
       end
 
       # Returns a tree
@@ -65,7 +60,7 @@ module Metalware
 
       private
 
-      attr_reader :path, :config, :cache_configure
+      attr_reader :path, :config
 
       def answer(absolute_path, section)
         yaml = Data.load(absolute_path)

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -38,10 +38,11 @@ module Metalware
       end
 
       def configure_data
-        return @configure_data if @configure_data
-        tree = Validation::Configure.new(config, repo_configure_data).tree
-        @configure_data = tree if cache_configure
-        tree
+        if cache_configure
+          @configure_data ||= configure_data_tree
+        else
+          configure_data_tree
+        end
       end
 
       # Returns a tree
@@ -73,6 +74,10 @@ module Metalware
                                            answer_section: section,
                                            configure_data: configure_data)
         validator.data
+      end
+
+      def configure_data_tree
+        Validation::Configure.new(config, repo_configure_data).tree
       end
 
       def repo_configure_data


### PR DESCRIPTION
This PR contains some refactoring of these classes to remove some unnecessary stuff and better separate what's handled by each class; a test covering the existing `Loader` behaviour is also included. See commits for full details of each change.

This is all in preparation for having the `Loader` also load configure questions for plugins, which will occur in a future PR; I'm submitting this separately in case you want to look at this PR independently to check I've not overlooked anything while doing this.