### PR TITLE
Plugin configuration

### DIFF
--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -38,7 +38,7 @@ class FileSystem
   # called on a `FileSystemConfigurator` instance and will then be correctly
   # invoked when `FileSystem.test` is run with that instance. If these were run
   # directly outside of a `test` block then the real file system would be used.
-  delegate :mkdir_p, :touch, to: FileUtils
+  delegate :mkdir_p, :touch, :rm_rf, to: FileUtils
   delegate :write, to: File
   delegate :dump, to: Metalware::Data
   delegate :enable!, to: Metalware::Plugins

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -46,7 +46,10 @@ class FileSystem
     delegate :mkdir_p, :touch, :rm_rf, to: FileUtils
     delegate :write, to: File
     delegate :dump, to: Metalware::Data
-    delegate :enable!, to: Metalware::Plugins
+
+    def enable_plugin(plugin_name)
+      Metalware::Plugins.enable!(plugin_name)
+    end
   end
   include SetupMethods
 

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -34,14 +34,21 @@ class FileSystem
   # `test` on the resulting object, or to call `FileSystem.test` directly.
   private_class_method :new
 
-  # Delegate file system handling methods appropriately here, so these can be
-  # called on a `FileSystemConfigurator` instance and will then be correctly
-  # invoked when `FileSystem.test` is run with that instance. If these were run
-  # directly outside of a `test` block then the real file system would be used.
-  delegate :mkdir_p, :touch, :rm_rf, to: FileUtils
-  delegate :write, to: File
-  delegate :dump, to: Metalware::Data
-  delegate :enable!, to: Metalware::Plugins
+  module SetupMethods
+    # This module contains all methods to be called on a FileSystem to set up
+    # the underlying FakeFS. All methods are appropriately delegated here, so
+    # these can be called on a `FileSystemConfigurator` instance and will then
+    # be correctly invoked when `FileSystem.test` is run with that instance.
+    # This module is necessary as if any of the original methods were run
+    # directly outside of a `test` block then the real file system would be
+    # used.
+
+    delegate :mkdir_p, :touch, :rm_rf, to: FileUtils
+    delegate :write, to: File
+    delegate :dump, to: Metalware::Data
+    delegate :enable!, to: Metalware::Plugins
+  end
+  include SetupMethods
 
   def self.root_setup
     FakeFS.without do

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -41,6 +41,7 @@ class FileSystem
   delegate :mkdir_p, :touch, to: FileUtils
   delegate :write, to: File
   delegate :dump, to: Metalware::Data
+  delegate :enable!, to: Metalware::Plugins
 
   def self.root_setup
     FakeFS.without do

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -158,6 +158,35 @@ RSpec.describe Metalware::Validation::Loader do
               ).to eq "[example] example_plugin_#{section}_dependent_question"
             end
           end
+
+          context 'when no configure.yaml for plugin' do
+            # XXX DRY up
+            before :each do
+              plugin_dir = File.join(Metalware::FilePath.plugins_dir, 'example')
+              filesystem.rm_rf plugin_dir
+              filesystem.mkdir_p plugin_dir
+            end
+
+            # XXX DRY up
+            it 'includes generated plugin enabled question' do
+              filesystem.test do
+                question_content = plugin_enabled_question.content
+
+                expect(
+                  question_content.question
+                ).to eq "Should 'example' plugin be enabled for #{section}?"
+                expect(
+                  question_content.type
+                ).to eq 'boolean'
+              end
+            end
+
+            it 'generated question has no dependents' do
+              filesystem.test do
+                expect(plugin_enabled_question.children).to be_empty
+              end
+            end
+          end
         end
       end
     end

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe Metalware::Validation::Loader do
       end
     end
 
+    RSpec.shared_examples 'includes_generated_plugin_enabled_question' do |section|
+      it 'includes generated plugin enabled question' do
+        filesystem.test do
+          question_content = plugin_enabled_question.content
+
+          expect(
+            question_content.question
+          ).to eq "Should 'example' plugin be enabled for #{section}?"
+          expect(
+            question_content.type
+          ).to eq 'boolean'
+        end
+      end
+    end
+
     subject do
       described_class.new(config)
     end
@@ -127,19 +142,7 @@ RSpec.describe Metalware::Validation::Loader do
           end
 
           include_examples 'loads_repo_configure_questions', section
-
-          it 'includes generated plugin enabled question' do
-            filesystem.test do
-              question_content = plugin_enabled_question.content
-
-              expect(
-                question_content.question
-              ).to eq "Should 'example' plugin be enabled for #{section}?"
-              expect(
-                question_content.type
-              ).to eq 'boolean'
-            end
-          end
+          include_examples 'includes_generated_plugin_enabled_question', section
 
           it "generated question includes plugin questions for #{section} as dependents" do
             filesystem.test do
@@ -166,19 +169,7 @@ RSpec.describe Metalware::Validation::Loader do
               filesystem.mkdir_p example_plugin_dir
             end
 
-            # XXX DRY up
-            it 'includes generated plugin enabled question' do
-              filesystem.test do
-                question_content = plugin_enabled_question.content
-
-                expect(
-                  question_content.question
-                ).to eq "Should 'example' plugin be enabled for #{section}?"
-                expect(
-                  question_content.type
-                ).to eq 'boolean'
-              end
-            end
+            include_examples 'includes_generated_plugin_enabled_question', section
 
             it 'generated question has no dependents' do
               filesystem.test do

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Metalware::Validation::Loader do
     end
 
     let :example_plugin_configure_questions_hash do
-      # XXX DRY up parts of this and above?
       configure_sections.map do |section|
         [
           section, [{

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -67,16 +67,17 @@ RSpec.describe Metalware::Validation::Loader do
 
     let :filesystem do
       FileSystem.setup do |fs|
-        file_path = Metalware::FilePath
-
-        fs.dump(file_path.configure_file, configure_questions_hash)
+        fs.dump(Metalware::FilePath.configure_file, configure_questions_hash)
 
         # Create example plugin.
-        example_plugin_dir = File.join(file_path.plugins_dir, 'example')
         fs.mkdir_p example_plugin_dir
         example_plugin_configure_file = File.join(example_plugin_dir, 'configure.yaml')
         fs.dump(example_plugin_configure_file, example_plugin_configure_questions_hash)
       end
+    end
+
+    let :example_plugin_dir do
+      File.join(Metalware::FilePath.plugins_dir, 'example')
     end
 
     let :sections_to_loaded_questions do
@@ -160,11 +161,9 @@ RSpec.describe Metalware::Validation::Loader do
           end
 
           context 'when no configure.yaml for plugin' do
-            # XXX DRY up
             before :each do
-              plugin_dir = File.join(Metalware::FilePath.plugins_dir, 'example')
-              filesystem.rm_rf plugin_dir
-              filesystem.mkdir_p plugin_dir
+              filesystem.rm_rf example_plugin_dir
+              filesystem.mkdir_p example_plugin_dir
             end
 
             # XXX DRY up

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -79,16 +79,18 @@ RSpec.describe Metalware::Validation::Loader do
       end
     end
 
+    let :sections_to_loaded_questions do
+      configure_sections.map do |section|
+        [section, subject.configure_data[section].children]
+      end.to_h
+    end
+
     RSpec.shared_examples 'loads_repo_configure_questions' do
       it 'loads repo configure.yaml questions for all sections' do
         filesystem.test do
-          sections_to_loaded_questions = configure_sections.map do |section|
-            [section, subject.configure_data[section].children.map(&:content).map(&:to_h)]
-          end.to_h
-
           configure_sections.each do |section|
             questions = sections_to_loaded_questions[section]
-            question_identifiers = questions.map { |q| q[:identifier] }
+            question_identifiers = questions.map { |q| q.content.identifier }
             expect(question_identifiers).to include "#{section}_identifier"
           end
         end
@@ -117,11 +119,6 @@ RSpec.describe Metalware::Validation::Loader do
       # XXX Split this massive test up
       it 'includes generated plugin question with plugin questions as dependents' do
         filesystem.test do
-          # XXX DRY up with above
-          sections_to_loaded_questions = configure_sections.map do |section|
-            [section, subject.configure_data[section].children]
-          end.to_h
-
           # XXX Extract class for handling internal configure identifiers.
           plugin_enabled_identifier = 'metalware_internal--plugin_enabled--example'
 

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -64,17 +64,6 @@ RSpec.describe Metalware::Validation::Loader do
       end.to_h
     end
 
-    let :filesystem do
-      FileSystem.setup do |fs|
-        fs.dump(Metalware::FilePath.configure_file, configure_questions_hash)
-
-        # Create example plugin.
-        fs.mkdir_p example_plugin_dir
-        example_plugin_configure_file = File.join(example_plugin_dir, 'configure.yaml')
-        fs.dump(example_plugin_configure_file, example_plugin_configure_questions_hash)
-      end
-    end
-
     let :example_plugin_dir do
       File.join(Metalware::FilePath.plugins_dir, 'example')
     end
@@ -87,31 +76,38 @@ RSpec.describe Metalware::Validation::Loader do
 
     RSpec.shared_examples 'loads_repo_configure_questions' do |section|
       it 'loads repo configure.yaml questions' do
-        filesystem.test do
-          questions = sections_to_loaded_questions[section]
-          question_identifiers = questions.map { |q| q.content.identifier }
-          expect(question_identifiers).to include "#{section}_identifier"
-        end
+        questions = sections_to_loaded_questions[section]
+        question_identifiers = questions.map { |q| q.content.identifier }
+        expect(question_identifiers).to include "#{section}_identifier"
       end
     end
 
     RSpec.shared_examples 'includes_generated_plugin_enabled_question' do |section|
       it 'includes generated plugin enabled question' do
-        filesystem.test do
-          question_content = plugin_enabled_question.content
+        question_content = plugin_enabled_question.content
 
-          expect(
-            question_content.question
-          ).to eq "Should 'example' plugin be enabled for #{section}?"
-          expect(
-            question_content.type
-          ).to eq 'boolean'
-        end
+        expect(
+          question_content.question
+        ).to eq "Should 'example' plugin be enabled for #{section}?"
+        expect(
+          question_content.type
+        ).to eq 'boolean'
       end
     end
 
     subject do
       described_class.new(config)
+    end
+
+    before :each do
+      FileSystem.root_setup do |fs|
+        fs.dump(Metalware::FilePath.configure_file, configure_questions_hash)
+
+        # Create example plugin.
+        fs.mkdir_p example_plugin_dir
+        example_plugin_configure_file = File.join(example_plugin_dir, 'configure.yaml')
+        fs.dump(example_plugin_configure_file, example_plugin_configure_questions_hash)
+      end
     end
 
     after :each do
@@ -127,7 +123,9 @@ RSpec.describe Metalware::Validation::Loader do
 
         context 'when plugin enabled' do
           before :each do
-            filesystem.enable_plugin('example')
+            FileSystem.root_setup do |fs|
+              fs.enable_plugin('example')
+            end
           end
 
           # XXX Extract class for handling internal configure identifiers.
@@ -144,36 +142,34 @@ RSpec.describe Metalware::Validation::Loader do
           include_examples 'includes_generated_plugin_enabled_question', section
 
           it "generated question includes plugin questions for #{section} as dependents" do
-            filesystem.test do
-              plugin_question = plugin_enabled_question.children.first
-              plugin_question_content = plugin_question.content
-              expect(plugin_question_content.identifier).to eq "example_plugin_#{section}_identifier"
+            plugin_question = plugin_enabled_question.children.first
+            plugin_question_content = plugin_question.content
+            expect(plugin_question_content.identifier).to eq "example_plugin_#{section}_identifier"
 
-              # NOTE: plugin name has been prepended to question to indicate
-              # where this question comes from.
-              expect(plugin_question_content.question).to eq "[example] example_plugin_#{section}_question"
+            # NOTE: plugin name has been prepended to question to indicate
+            # where this question comes from.
+            expect(plugin_question_content.question).to eq "[example] example_plugin_#{section}_question"
 
-              plugin_dependent_question = plugin_question.children.first
+            plugin_dependent_question = plugin_question.children.first
 
-              # As above, plugin name has been prepended to dependent question.
-              expect(
-                plugin_dependent_question.content.question
-              ).to eq "[example] example_plugin_#{section}_dependent_question"
-            end
+            # As above, plugin name has been prepended to dependent question.
+            expect(
+              plugin_dependent_question.content.question
+            ).to eq "[example] example_plugin_#{section}_dependent_question"
           end
 
           context 'when no configure.yaml for plugin' do
             before :each do
-              filesystem.rm_rf example_plugin_dir
-              filesystem.mkdir_p example_plugin_dir
+              FileSystem.root_setup do |fs|
+                fs.rm_rf example_plugin_dir
+                fs.mkdir_p example_plugin_dir
+              end
             end
 
             include_examples 'includes_generated_plugin_enabled_question', section
 
             it 'generated question has no dependents' do
-              filesystem.test do
-                expect(plugin_enabled_question.children).to be_empty
-              end
+              expect(plugin_enabled_question.children).to be_empty
             end
           end
         end

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Metalware::Validation::Loader do
 
         context 'when plugin enabled' do
           before :each do
-            filesystem.enable!('example')
+            filesystem.enable_plugin('example')
           end
 
           # XXX Extract class for handling internal configure identifiers.

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -49,18 +49,16 @@ RSpec.describe Metalware::Validation::Loader do
 
     let :example_plugin_configure_questions_hash do
       configure_sections.map do |section|
-        [
-          section, [{
-            identifier: "example_plugin_#{section}_identifier",
-            question: "example_plugin_#{section}_question",
-            dependent: [
-              {
-                identifier: "example_plugin_#{section}_dependent_identifier",
-                question: "example_plugin_#{section}_dependent_question",
-              }
-            ]
-          }]
-        ]
+        dependent_question = {
+          identifier: "example_plugin_#{section}_dependent_identifier",
+          question: "example_plugin_#{section}_dependent_question",
+        }
+        top_level_question = {
+          identifier: "example_plugin_#{section}_identifier",
+          question: "example_plugin_#{section}_question",
+          dependent: [dependent_question]
+        }
+        [section, [top_level_question]]
       end.to_h
     end
 

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -83,6 +83,7 @@ module Metalware
       end
 
       def plugin_directories
+        return [] unless plugins_dir.exist?
         plugins_dir.children.select(&:directory?)
       end
 
@@ -115,6 +116,57 @@ module Metalware
 
     def enable!
       Plugins.enable!(name)
+    end
+
+    # XXX Extract class for loading plugin questions?
+    def configure_questions
+      Constants::CONFIGURE_SECTIONS.map do |section|
+        [section, question_tree_for_section(section)]
+      end.to_h
+    end
+
+    private
+
+    def question_tree_for_section(section)
+      {
+        identifier: "metalware_internal--plugin_enabled--#{name}",
+        question: "Should '#{name}' plugin be enabled for #{section}?",
+        type: 'boolean',
+        dependent: questions_for_section(section),
+      }
+    end
+
+    def questions_for_section(section)
+      configure_data[section].map { |q| namespace_question_tree(q) }
+    end
+
+    def configure_data
+      @configure_data ||= Data.load(configure_file_path)
+    end
+
+    def configure_file_path
+      File.join(path, 'configure.yaml')
+    end
+
+    def namespace_question_tree(question_hash)
+      # Prepend plugin name to question text, as well as recursively to all
+      # dependent questions, so source of plugin questions is clear when
+      # configuring.
+      question_hash.map do |k, v|
+        new_value = case k
+                    when :question
+                      "#{plugin_identifier} #{v}"
+                    when :dependent
+                      v.map { |q| namespace_question_tree(q) }
+                    else
+                      v
+                    end
+        [k, new_value]
+      end.to_h
+    end
+
+    def plugin_identifier
+      "[#{name}]"
     end
   end
 end

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -132,13 +132,13 @@ module Metalware
 
     def build
       Constants::CONFIGURE_SECTIONS.map do |section|
-        [section, question_tree_for_section(section)]
+        [section, question_hash_for_section(section)]
       end.to_h
     end
 
     private
 
-    def question_tree_for_section(section)
+    def question_hash_for_section(section)
       {
         identifier: "metalware_internal--plugin_enabled--#{plugin.name}",
         question: "Should '#{plugin.name}' plugin be enabled for #{section}?",
@@ -148,7 +148,7 @@ module Metalware
     end
 
     def questions_for_section(section)
-      configure_data[section].map { |q| namespace_question_tree(q) }
+      configure_data[section].map { |q| namespace_question_hash(q) }
     end
 
     def configure_data
@@ -167,7 +167,7 @@ module Metalware
       File.join(plugin.path, 'configure.yaml')
     end
 
-    def namespace_question_tree(question_hash)
+    def namespace_question_hash(question_hash)
       # Prepend plugin name to question text, as well as recursively to all
       # dependent questions, so source of plugin questions is clear when
       # configuring.
@@ -176,7 +176,7 @@ module Metalware
                     when :question
                       "#{plugin_identifier} #{v}"
                     when :dependent
-                      v.map { |q| namespace_question_tree(q) }
+                      v.map { |q| namespace_question_hash(q) }
                     else
                       v
                     end

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -118,8 +118,19 @@ module Metalware
       Plugins.enable!(name)
     end
 
-    # XXX Extract class for loading plugin questions?
     def configure_questions
+      ConfigureQuestionsBuilder.build(self)
+    end
+  end
+
+  ConfigureQuestionsBuilder = Struct.new(:plugin) do
+    private_class_method :new
+
+    def self.build(plugin)
+      new(plugin).build
+    end
+
+    def build
       Constants::CONFIGURE_SECTIONS.map do |section|
         [section, question_tree_for_section(section)]
       end.to_h
@@ -129,8 +140,8 @@ module Metalware
 
     def question_tree_for_section(section)
       {
-        identifier: "metalware_internal--plugin_enabled--#{name}",
-        question: "Should '#{name}' plugin be enabled for #{section}?",
+        identifier: "metalware_internal--plugin_enabled--#{plugin.name}",
+        question: "Should '#{plugin.name}' plugin be enabled for #{section}?",
         type: 'boolean',
         dependent: questions_for_section(section),
       }
@@ -145,7 +156,7 @@ module Metalware
     end
 
     def configure_file_path
-      File.join(path, 'configure.yaml')
+      File.join(plugin.path, 'configure.yaml')
     end
 
     def namespace_question_tree(question_hash)
@@ -166,7 +177,7 @@ module Metalware
     end
 
     def plugin_identifier
-      "[#{name}]"
+      "[#{plugin.name}]"
     end
   end
 end

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -152,7 +152,15 @@ module Metalware
     end
 
     def configure_data
-      @configure_data ||= Data.load(configure_file_path)
+      @configure_data ||= default_configure_data.merge(
+        Data.load(configure_file_path)
+      )
+    end
+
+    def default_configure_data
+      Constants::CONFIGURE_SECTIONS.map do |section|
+        [section, []]
+      end.to_h
     end
 
     def configure_file_path

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -37,7 +37,9 @@ module Metalware
       end
 
       def configure_data
-        @configure_data ||= configure_data_tree
+        # XXX Extract object for loading configure data?
+        @configure_data ||=
+          Validation::Configure.new(config, combined_configure_data).tree
       end
 
       # Returns a tree
@@ -69,11 +71,6 @@ module Metalware
                                            answer_section: section,
                                            configure_data: configure_data)
         validator.data
-      end
-
-      # XXX Extract object for loading configure data?
-      def configure_data_tree
-        Validation::Configure.new(config, combined_configure_data).tree
       end
 
       def combined_configure_data


### PR DESCRIPTION
This PR adds support for configuring enabled plugins via the standard `metal configure` process. It's based on https://github.com/alces-software/metalware/pull/291 so take a look at that first.

The key commit here is https://github.com/alces-software/metalware/commit/6512013b8541a87f1b84452b6a09b5e6a0facf2d, which contains the main change to loading of configure questions and a rough test for this, as well as an overall description of how this works. Later commits then mostly contain refactoring to tidy things up following this change, apart from https://github.com/alces-software/metalware/commit/c7644f15e0cc432664b28217021b464918e40cc6 which adds handling for the situation where no `configure.yaml` file exists for a plugin. So it would be particularly useful if you could take a look at these two commits and tell me if the main changes here seem reasonable; feel free to look at the other refactoring and let me know what you think as well if you like.