### PR TITLE
IPMI command fixes

### DIFF
--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -56,7 +56,7 @@ module Metalware
       end
 
       def command(host)
-        "ipmitool -H #{host}.bmc #{render_credentials} #{render_command}"
+        "ipmitool -H #{host}.bmc -I lanplus #{render_credentials} #{render_command}"
       end
 
       def render_command

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -52,7 +52,7 @@ module Metalware
       end
 
       def run_baremetal(node)
-        puts "#{node}: #{SystemCommand.run(command(node))}"
+        puts "#{node.name}: #{SystemCommand.run(command(node.name))}"
       end
 
       def command(host)


### PR DESCRIPTION
This addresses #296 - the whole `node` object was being given when it just requires `node.name` in order to correctly run. Also added `-I lanplus` to the rendered command as @ColonelPanicks pointed out this is required.

Tested this on @ColonelPanicks running controller