### PR TITLE
Initial plugin access in node namespace

### DIFF
--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -50,6 +50,14 @@ class FileSystem
     def enable_plugin(plugin_name)
       Metalware::Plugins.enable!(plugin_name)
     end
+
+    # Perform arbitrary other FileSystem setup.
+    # TODO Maybe everything/more things should be changed to just do this,
+    # rather than continuing to add new methods here every time we want to
+    # create a file in a new way?
+    def setup(&block)
+      block.call
+    end
   end
   include SetupMethods
 

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -244,8 +244,8 @@ RSpec.describe Metalware::Namespaces::Node do
           # Enable/disable plugins for node as needed.
           # XXX internal identifiers duplicated here also
           answers = {
-            "metalware_internal--plugin_enabled--#{node_enabled_plugin}" => true,
-            "metalware_internal--plugin_enabled--#{node_disabled_plugin}" => false
+            Metalware::Plugins.enabled_question_identifier(node_enabled_plugin) => true,
+            Metalware::Plugins.enabled_question_identifier(node_disabled_plugin) => false,
           }.to_json
           Metalware::Utils.run_command(
             Metalware::Commands::Configure::Node, node.name, answers: answers

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -210,4 +210,61 @@ RSpec.describe Metalware::Namespaces::Node do
       end
     end
   end
+
+  # Test `#plugins` without the rampant mocking above.
+  describe '#plugins' do
+    let :node { Metalware::Namespaces::Node.create(alces, 'node01') }
+    let :alces { Metalware::Namespaces::Alces.new(config) }
+    let :config { Metalware::Config.new }
+
+    # XXX Need to handle situation of plugin being enabled for node but not
+    # available globally?
+    # XXX handle enabled but unconfigured plugin for node here
+    let :node_enabled_plugin { 'node_enabled_plugin' }
+    let :node_disabled_plugin { 'node_disabled_plugin' }
+    let :globally_disabled_plugin { 'globally_disabled_plugin' }
+
+    before :each do
+      Metalware::Config.cache = config
+
+      FileSystem.root_setup do |fs|
+        fs.with_minimal_repo
+
+        # Create all test plugins.
+        [node_enabled_plugin, node_disabled_plugin, globally_disabled_plugin].each do |plugin|
+          fs.mkdir_p File.join(Metalware::FilePath.plugins_dir, plugin)
+        end
+
+        fs.setup do
+          # Enable these plugins globally.
+          [node_enabled_plugin, node_disabled_plugin].each do |plugin|
+            Metalware::Plugins.enable!(plugin)
+          end
+
+          # Enable/disable plugins for node as needed.
+          # XXX internal identifiers duplicated here also
+          answers = {
+            "metalware_internal--plugin_enabled--#{node_enabled_plugin}" => true,
+            "metalware_internal--plugin_enabled--#{node_disabled_plugin}" => false
+          }.to_json
+          Metalware::Utils.run_command(
+            Metalware::Commands::Configure::Node, node.name, answers: answers
+          )
+        end
+      end
+    end
+
+    after :each do
+      Metalware::Config.clear_cache
+    end
+
+    it 'only includes plugins enabled for node' do
+      node_plugin_names = []
+      node.plugins.each do |plugin|
+        node_plugin_names << plugin.name
+      end
+
+      expect(node_plugin_names).to eq [node_enabled_plugin]
+    end
+  end
 end

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -126,13 +126,11 @@ RSpec.describe Metalware::Validation::Loader do
             end
           end
 
-          # XXX Extract class for handling internal configure identifiers.
-          let :plugin_enabled_question_identifier { 'metalware_internal--plugin_enabled--example' }
-
           let :plugin_enabled_question do
             questions = sections_to_loaded_questions[section]
             questions.find do |question|
-              question.content.identifier == plugin_enabled_question_identifier
+              question.content.identifier ==
+                Metalware::Plugins.enabled_question_identifier('example')
             end
           end
 

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -62,6 +62,7 @@ module Metalware
     VAR_NAMED_PATH = '/var/named'
 
     CONFIGURE_SECTIONS = [:domain, :group, :node, :local].freeze
+    CONFIGURE_INTERNAL_QUESTION_PREFIX = 'metalware_internal'
 
     HASH_MERGER_DATA_STRUCTURE =
       Metalware::HashMergers::MetalRecursiveOpenStruct

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -3,6 +3,7 @@
 
 require 'build_methods'
 require 'build_files_retriever'
+require 'namespaces/plugin'
 
 module Metalware
   module Namespaces
@@ -73,6 +74,12 @@ module Metalware
         FilePath.event self
       end
 
+      def plugins
+        Plugins.enabled.map do |plugin|
+          Namespaces::Plugin.new(plugin) if plugin_enabled?(plugin)
+        end.compact
+      end
+
       private
 
       def white_list_for_hasher
@@ -118,6 +125,11 @@ module Metalware
         else
           BuildMethods::Kickstarts::Pxelinux
         end
+      end
+
+      def plugin_enabled?(plugin)
+        # XXX internal identifier duplicated here
+        answer.send("metalware_internal--plugin_enabled--#{plugin.name}".to_sym)
       end
     end
   end

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -128,8 +128,7 @@ module Metalware
       end
 
       def plugin_enabled?(plugin)
-        # XXX internal identifier duplicated here
-        answer.send("metalware_internal--plugin_enabled--#{plugin.name}".to_sym)
+        answer.send(plugin.enabled_question_identifier)
       end
     end
   end

--- a/src/namespaces/plugin.rb
+++ b/src/namespaces/plugin.rb
@@ -1,0 +1,10 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  module Namespaces
+    Plugin = Struct.new(:plugin) do
+      delegate :name, to: :plugin
+    end
+  end
+end

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -56,6 +56,14 @@ module Metalware
         update_enabled_plugins!(new_enabled_plugins)
       end
 
+      def enabled_question_identifier(plugin_name)
+        [
+          Constants::CONFIGURE_INTERNAL_QUESTION_PREFIX,
+          'plugin_enabled',
+          plugin_name,
+        ].join('--')
+      end
+
       private
 
       def validate_plugin_exists!(plugin_name)
@@ -121,6 +129,10 @@ module Metalware
     def configure_questions
       ConfigureQuestionsBuilder.build(self)
     end
+
+    def enabled_question_identifier
+      Plugins.enabled_question_identifier(name)
+    end
   end
 
   ConfigureQuestionsBuilder = Struct.new(:plugin) do
@@ -140,7 +152,7 @@ module Metalware
 
     def question_hash_for_section(section)
       {
-        identifier: "metalware_internal--plugin_enabled--#{plugin.name}",
+        identifier: plugin.enabled_question_identifier,
         question: "Should '#{plugin.name}' plugin be enabled for #{section}?",
         type: 'boolean',
         dependent: questions_for_section(section),


### PR DESCRIPTION
@WilliamMcCumstie Don't know if you want to have a quick look at this to check I'm not doing anything completely the wrong way with all the namespace stuff? There's not much in this PR, this is just the first step for making a `plugins` field containing information on the enabled plugins for each node available in the node namespace.

I'm submitting this now so I can merge some other stuff based on this, and then later submit some smaller PRs adding for you to have a look at adding the main parts of the plugin namespace.