### PR TITLE
Plugin configs

### DIFF
--- a/spec/namespaces/plugin_spec.rb
+++ b/spec/namespaces/plugin_spec.rb
@@ -1,16 +1,35 @@
 
 # frozen_string_literal: true
 
+require 'spec_utils'
+
 RSpec.describe Metalware::Namespaces::Plugin do
-  let :plugin_dir_path { File.join(Metalware::FilePath.plugins_dir, 'my_plugin') }
+  include AlcesUtils
+
   let :config { Metalware::Config.new }
+
+  let :node do
+    Metalware::Namespaces::Node.create(alces, node_name)
+  end
+  let :node_name { 'some_node' }
+  let :node_group_name { 'some_group' }
+
+  let :plugin_name { 'my_plugin' }
+  let :plugin do
+    Metalware::Plugins.all.find { |plugin| plugin.name == plugin_name }
+  end
+
+  subject { described_class.new(node, plugin) }
 
   before :each do
     Metalware::Config.cache = config
 
     FileSystem.root_setup do |fs|
       fs.setup do
-        FileUtils.mkdir_p plugin_dir_path
+        plugin_config_dir = File.join(file_path.plugins_dir, plugin_name, 'config')
+        FileUtils.mkdir_p plugin_config_dir
+
+        File.write(file_path.genders, "#{node_name} #{node_group_name}\n")
       end
     end
   end
@@ -19,13 +38,34 @@ RSpec.describe Metalware::Namespaces::Plugin do
     Metalware::Config.clear_cache
   end
 
-  subject do
-    described_class.new(Metalware::Plugins.all.first)
-  end
-
   describe '#name' do
     it 'returns plugin name' do
       expect(subject.name).to eq 'my_plugin'
+    end
+  end
+
+  describe '#config' do
+    it 'provides access to merged plugin config for node' do
+      {
+        plugin.domain_config => {
+          domain_parameter: 'domain_value',
+          group_parameter: 'domain_value',
+          node_parameter: 'domain_value',
+        },
+        plugin.group_config(node_group_name) => {
+          group_parameter: 'group_value',
+          node_parameter: 'group_value',
+        },
+        plugin.node_config(node_name) => {
+          node_parameter: 'node_value',
+        }
+      }.each do |plugin_config, config_data|
+        Metalware::Data.dump(plugin_config, config_data)
+      end
+
+      expect(subject.config.domain_parameter).to eq('domain_value')
+      expect(subject.config.group_parameter).to eq('group_value')
+      expect(subject.config.node_parameter).to eq('node_value')
     end
   end
 end

--- a/spec/namespaces/plugin_spec.rb
+++ b/spec/namespaces/plugin_spec.rb
@@ -67,5 +67,13 @@ RSpec.describe Metalware::Namespaces::Plugin do
       expect(subject.config.group_parameter).to eq('group_value')
       expect(subject.config.node_parameter).to eq('node_value')
     end
+
+    it 'supports templating, with access to node namespace values' do
+      Metalware::Data.dump(plugin.domain_config, {
+        node_name: '<%= node.name %>',
+      })
+
+      expect(subject.config.node_name).to eq(node.name)
+    end
   end
 end

--- a/spec/namespaces/plugin_spec.rb
+++ b/spec/namespaces/plugin_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metalware::Namespaces::Plugin do
     Metalware::Plugins.all.find { |plugin| plugin.name == plugin_name }
   end
 
-  subject { described_class.new(node, plugin) }
+  subject { described_class.new(plugin, node: node) }
 
   before :each do
     Metalware::Config.cache = config

--- a/src/hash_mergers/plugin_config.rb
+++ b/src/hash_mergers/plugin_config.rb
@@ -1,0 +1,27 @@
+
+# frozen_string_literal: true
+
+require 'hash_mergers/hash_merger'
+
+module Metalware
+  module HashMergers
+    class PluginConfig < HashMerger
+      def initialize(metal_config:, plugin:)
+        @plugin = plugin
+        super(metal_config)
+      end
+
+      private
+
+      attr_reader :plugin
+
+      def load_yaml(section, section_name)
+        # XXX This is the same as `HashMergers::Config`, just using `plugin`
+        # rather than `file_path`.
+        args = [section_name].compact
+        config_file = plugin.send("#{section}_config", *args)
+        Data.load(config_file)
+      end
+    end
+  end
+end

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -76,7 +76,7 @@ module Metalware
 
       def plugins
         @plugins ||= Plugins.enabled.map do |plugin|
-          Namespaces::Plugin.new(plugin) if plugin_enabled?(plugin)
+          Namespaces::Plugin.new(self, plugin) if plugin_enabled?(plugin)
         end.compact
       end
 

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -76,7 +76,7 @@ module Metalware
 
       def plugins
         @plugins ||= Plugins.enabled.map do |plugin|
-          Namespaces::Plugin.new(self, plugin) if plugin_enabled?(plugin)
+          Namespaces::Plugin.new(plugin, node: self) if plugin_enabled?(plugin)
         end.compact
       end
 

--- a/src/namespaces/plugin.rb
+++ b/src/namespaces/plugin.rb
@@ -15,10 +15,10 @@ module Metalware
       # meaningful for this namespace.
       undef :answer, :render_erb_template
 
-      def initialize(node_namespace, plugin)
-        @node_namespace = node_namespace
+      def initialize(plugin, node:)
+        @node_namespace = node
         @plugin = plugin
-        alces = node_namespace.send(:alces)
+        alces = node.send(:alces)
         super(alces, plugin.name)
       end
 

--- a/src/namespaces/plugin.rb
+++ b/src/namespaces/plugin.rb
@@ -11,6 +11,10 @@ module Metalware
     class Plugin < HashMergerNamespace
       delegate :name, to: :plugin
 
+      # These methods are defined in HashMergerNamespace, but are not
+      # meaningful for this namespace.
+      undef :answer, :render_erb_template
+
       def initialize(node_namespace, plugin)
         @node_namespace = node_namespace
         @plugin = plugin

--- a/src/namespaces/plugin.rb
+++ b/src/namespaces/plugin.rb
@@ -40,7 +40,7 @@ module Metalware
       end
 
       def additional_dynamic_namespace
-        {}
+        { node: node_namespace }
       end
     end
   end

--- a/src/namespaces/plugin.rb
+++ b/src/namespaces/plugin.rb
@@ -1,10 +1,47 @@
 
 # frozen_string_literal: true
 
+require 'namespaces/hash_merger_namespace'
+
+# A Plugin namespace contains the values configured for a particular plugin for
+# a particular node.
+
 module Metalware
   module Namespaces
-    Plugin = Struct.new(:plugin) do
+    class Plugin < HashMergerNamespace
       delegate :name, to: :plugin
+
+      def initialize(node_namespace, plugin)
+        @node_namespace = node_namespace
+        @plugin = plugin
+        alces = node_namespace.send(:alces)
+        super(alces, plugin.name)
+      end
+
+      def config
+        @config ||= run_hash_merger(plugin_config_hash_merger)
+      end
+
+      private
+
+      attr_reader :node_namespace, :plugin
+
+      def plugin_config_hash_merger
+        HashMergers::PluginConfig.new(
+          metal_config: alces.send(:metal_config),
+          plugin: plugin
+        )
+      end
+
+      def hash_merger_input
+        # The plugin config should be merged in the same order as specified in
+        # the containing node namespace.
+        node_namespace.send(:hash_merger_input)
+      end
+
+      def additional_dynamic_namespace
+        {}
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds support for accessing the plugin config for a node via the plugin namespaces. One plugin namespace is available for every plugin enabled for every node, and is accessible via the `node.plugins` array for each node. The plugin configs are merged in the same way and include the same groups as the containing node namespace's configs.

As with https://github.com/alces-software/metalware/pull/299 I'm going to merge this straight through so I can also merge branches based on this, but would be useful if you could take a look when you get a chance as this touches a lot of the namespaces stuff.