### PR TITLE
Remove missed reference to Config

### DIFF
--- a/src/commands/template.rb
+++ b/src/commands/template.rb
@@ -42,7 +42,7 @@ module Metalware
       end
 
       def run
-        Staging.template(Config.cache) do |templater|
+        Staging.template do |templater|
           build_methods.each do |build_method|
             build_method.render_staging_templates(templater)
           end


### PR DESCRIPTION
This was missed in the recent refactor to remove the Config class (see https://github.com/alces-software/metalware/pull/303). This class now no longer exists and this argument is unneeded. Likely this was missed as there is no test coverage for the `template` command and I must have missed it when grepping for leftover usage of Config.