### PR TITLE
Allow metal commands to run on secondary groups

### DIFF
--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -137,19 +137,19 @@ RSpec.describe Metalware::Commands::Build do
       testnodes.nodes do |node|
         expect(node).to receive(:start_hook).once
       end
-      run_build(testnodes, delay_report_built: delay_build, group: true)
+      run_build(testnodes, delay_report_built: delay_build, gender: true)
     end
 
     it 'completes all the nodes once built' do
       testnodes.nodes do |node|
         expect(node).to receive(:complete_hook).once
       end
-      run_build(testnodes, delay_report_built: delay_build, group: true)
+      run_build(testnodes, delay_report_built: delay_build, gender: true)
     end
 
     it 'finishes once all the nodes are built' do
       expect do
-        run_build(testnodes, delay_report_built: delay_build, group: true)
+        run_build(testnodes, delay_report_built: delay_build, gender: true)
       end.not_to raise_error
     end
 
@@ -158,7 +158,7 @@ RSpec.describe Metalware::Commands::Build do
         built_nodes = testnodes.nodes.dup
         built_nodes.shift # The first node will not be built
         th = Thread.new do
-          run_build(testnodes, group: true)
+          run_build(testnodes, gender: true)
           sleep(build_wait_time / 10)
           built_nodes.each { |n| FileUtils n.build_complete_path }
         end

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metalware::Commands::Console do
     before :each do
       allow(
         Metalware::NodeattrInterface
-      ).to receive(:groups_for_node).and_return(['nodes'])
+      ).to receive(:genders_for_node).and_return(['nodes'])
       allow(
         Metalware::NodeattrInterface
       ).to receive(:all_nodes).and_return(node_names)

--- a/spec/commands/each_spec.rb
+++ b/spec/commands/each_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe Metalware::Commands::Each do
       receive(:new).and_return(double('answer', merge: {}))
   end
 
-  def run_command_echo(node, group = false)
+  def run_command_echo(node, gender = false)
     FakeFS.deactivate!
-    opt = OpenStruct.new(group: group)
+    opt = OpenStruct.new(gender: gender)
     file = Tempfile.new
     file.close
     cmd = "echo <%= node.name %> >> #{file.path}"
@@ -75,7 +75,7 @@ RSpec.describe Metalware::Commands::Each do
     expect(output).to eq("node01\n")
   end
 
-  it 'runs the command over a group' do
+  it 'runs the command over a gender' do
     expected = (1..3).inject('') { |str, num| "#{str}testnode0#{num}\n" }
     output = run_command_echo('nodes', true)
     expect(output).to eq(expected)

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Metalware::Commands::Ipmi do
 
     let :node_names { ['node01', 'node02', 'node03'] }
     let :group { 'nodes' }
-    let :node_config do
+    let :namespace_config do
       {
         networks: {
           bmc: {
@@ -32,9 +32,10 @@ RSpec.describe Metalware::Commands::Ipmi do
 
     AlcesUtils.mock self, :each do
       mock_group(group)
+      config(alces.group, namespace_config)
       node_names.each do |node|
         mock_node(node, group)
-        config(alces.node, node_config)
+        config(alces.node, namespace_config)
       end
     end
 

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -38,10 +38,11 @@ RSpec.describe Metalware::Commands::Ipmi do
       end
     end
 
+    # Allow the system command to receive `nodeattr` commands
     before :each do
-      FileSystem.root_setup do |fs|
-        fs.with_minimal_repo
-      end
+      with_args = [/\Anodeattr.*/, an_instance_of(Hash)]
+      allow(Metalware::SystemCommand).to \
+        receive(:run).with(*with_args).and_call_original
     end
 
     describe 'when run for node' do
@@ -62,7 +63,7 @@ RSpec.describe Metalware::Commands::Ipmi do
           ).ordered
         end
 
-        run_ipmi('nodes', 'sel list', group: true)
+        run_ipmi('nodes', 'sel list', gender: true)
       end
     end
   end

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metalware::Commands::Ipmi do
     before :each do
       allow(
         Metalware::NodeattrInterface
-      ).to receive(:groups_for_node).and_return(['nodes'])
+      ).to receive(:genders_for_node).and_return(['nodes'])
       allow(
         Metalware::NodeattrInterface
       ).to receive(:all_nodes).and_return(node_names)

--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Metalware::Commands::Power do
 
       allow(
         Metalware::NodeattrInterface
-      ).to receive(:groups_for_node).and_return(['nodes'])
+      ).to receive(:genders_for_node).and_return(['nodes'])
       allow(
         Metalware::NodeattrInterface
       ).to receive(:all_nodes).and_return(node_names)

--- a/spec/commands/remove/group_spec.rb
+++ b/spec/commands/remove/group_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Metalware::Commands::Remove::Group do
 
   def expected_deleted_files(group)
     Metalware::NodeattrInterface
-      .nodes_in_primary_group(group)
+      .nodes_in_group(group)
       .map { |node| "nodes/#{node}.yaml" }
       .unshift(["groups/#{group}.yaml"])
       .map { |f| File.join(Metalware::FilePath.answer_files, f) }

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe '`metal build`' do
     expect(files.empty?).to be true
   end
 
-  def build_node(name, group: false)
-    options = OpenStruct.new(group ? { group: true } : {})
+  def build_node(name, gender: false)
+    options = OpenStruct.new gender: gender
     filesystem.test do
       thr = Thread.new do
         begin
@@ -138,7 +138,7 @@ RSpec.describe '`metal build`' do
     let :nodes { ['testnode01', 'testnode02', 'testnode03'] }
 
     it 'works' do
-      build_node('nodes', group: true) do |thread|
+      build_node('nodes', gender: true) do |thread|
         wait_longer_than_build_poll
         expect(thread).to be_alive
 
@@ -215,7 +215,7 @@ RSpec.describe '`metal build`' do
       end
 
       it 'exits on second interrupt' do
-        build_node('nodes', group: true) do |thread|
+        build_node('nodes', gender: true) do |thread|
           touch_complete_file('testnode01')
 
           wait_longer_than_build_poll
@@ -239,7 +239,7 @@ RSpec.describe '`metal build`' do
         end
 
         it 'handles "yes" to interrupt prompt' do
-          build_node('nodes', group: true) do |thread|
+          build_node('nodes', gender: true) do |thread|
             stdin.puts('yes')
             stdin.rewind
 
@@ -262,7 +262,7 @@ RSpec.describe '`metal build`' do
         end
 
         it 'handles "no" to interrupt prompt' do
-          build_node('nodes', group: true) do |thread|
+          build_node('nodes', gender: true) do |thread|
             stdin.puts('no')
             stdin.rewind
 

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Metalware::Namespaces::Node do
       allow(Metalware::NodeattrInterface).to \
         receive(:groups_for_node).and_return(['primary_group'])
       allow(Metalware::NodeattrInterface).to \
-        receive(:nodes_in_group).and_return(node_array)
+        receive(:nodes_in_gender).and_return(node_array)
       allow(Metalware::NodeattrInterface).to \
         receive(:all_nodes).and_return(node_array)
     end

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Metalware::Namespaces::Node do
     #
     before :each do
       allow(Metalware::NodeattrInterface).to \
-        receive(:groups_for_node).and_return(['primary_group'])
+        receive(:genders_for_node).and_return(['primary_group'])
       allow(Metalware::NodeattrInterface).to \
         receive(:nodes_in_gender).and_return(node_array)
       allow(Metalware::NodeattrInterface).to \

--- a/spec/nodeattr_interface_spec.rb
+++ b/spec/nodeattr_interface_spec.rb
@@ -50,22 +50,22 @@ RSpec.describe Metalware::NodeattrInterface do
       FileSystem.root_setup(&:with_genders_fixtures)
     end
 
-    describe '#nodes_in_group' do
+    describe '#nodes_in_gender' do
       it 'returns names of all nodes in the given gender group' do
         expect(
-          Metalware::NodeattrInterface.nodes_in_group('masters')
+          Metalware::NodeattrInterface.nodes_in_gender('masters')
         ).to eq(['login1'])
         expect(
-          Metalware::NodeattrInterface.nodes_in_group('nodes')
+          Metalware::NodeattrInterface.nodes_in_gender('nodes')
         ).to eq(['testnode01', 'testnode02', 'testnode03'])
         expect(
-          Metalware::NodeattrInterface.nodes_in_group('cluster')
+          Metalware::NodeattrInterface.nodes_in_gender('cluster')
         ).to eq(['login1', 'testnode01', 'testnode02', 'testnode03'])
       end
 
       it 'raises if cannot find gender group' do
         expect do
-          Metalware::NodeattrInterface.nodes_in_group('non_existent')
+          Metalware::NodeattrInterface.nodes_in_gender('non_existent')
         end.to raise_error Metalware::NoGenderGroupError
       end
     end

--- a/spec/nodeattr_interface_spec.rb
+++ b/spec/nodeattr_interface_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Metalware::NodeattrInterface do
       end
     end
 
-    describe '#nodes_in_primary_group' do
+    describe '#nodes_in_group' do
       it 'returns only the nodes in the primary group' do
-        nodes = Metalware::NodeattrInterface.nodes_in_primary_group('group1')
+        nodes = Metalware::NodeattrInterface.nodes_in_group('group1')
         expect(nodes).to contain_exactly('nodeA01', 'nodeA02')
       end
     end

--- a/spec/nodeattr_interface_spec.rb
+++ b/spec/nodeattr_interface_spec.rb
@@ -70,20 +70,20 @@ RSpec.describe Metalware::NodeattrInterface do
       end
     end
 
-    describe '#groups_for_node' do
+    describe '#genders_for_node' do
       it 'returns groups for given node, ordered as in genders' do
         testnode_groups = ['testnodes', 'nodes', 'cluster']
         expect(
-          Metalware::NodeattrInterface.groups_for_node('testnode01')
+          Metalware::NodeattrInterface.genders_for_node('testnode01')
         ).to eq(testnode_groups)
         expect(
-          Metalware::NodeattrInterface.groups_for_node('testnode02')
+          Metalware::NodeattrInterface.genders_for_node('testnode02')
         ).to eq(['pregroup'] + testnode_groups + ['postgroup'])
       end
 
       it 'raises if cannot find node' do
         expect do
-          Metalware::NodeattrInterface.groups_for_node('non_existent')
+          Metalware::NodeattrInterface.genders_for_node('non_existent')
         end.to raise_error Metalware::NodeNotInGendersError
       end
     end

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -1,9 +1,9 @@
 anchor_options:
-  group_option: &group_option
-    tags: [-g, --group]
+  gender_option: &gender_option
+    tags: [-g, --gender]
     type: String
     description: >
-          Switch NODE_IDENTIFIER to specify a gender group rather than a single
+          Switch NODE_IDENTIFIER to specify a gender, rather than a single
           node
   configure_answers_option: &configure_answers_option
     tags: [-a ANSWERS_MAPPING, --answers ANSWERS_MAPPING]
@@ -69,14 +69,14 @@ subcommands:
     summary: Creates a new virtual machine or group of machines
     action: Commands::Orchestrate::Create
     options:
-      - *group_option
+      - *gender_option
 
   orchestrate_destroy: &orchestrate_destroy
     syntax: metal orchestrate destroy NODE_IDENTIFIER [options]
     summary: Destroys a single or group of virtual machines
     action: Commands::Orchestrate::Destroy
     options:
-      - *group_option
+      - *gender_option
 
   remove_group: &remove_group
     syntax: metal remove group GROUP_NAME [options]
@@ -201,7 +201,7 @@ commands:
 
     action: Commands::Build
     options:
-      - *group_option
+      - *gender_option
 
   configure:
     syntax: metal configure [SUB_COMMAND] [options]
@@ -229,7 +229,7 @@ commands:
       by the templater and supports erb tags.
     action: Commands::Each
     options:
-      - *group_option
+      - *gender_option
 
   edit:
     syntax: metal edit FILE [options]
@@ -290,7 +290,7 @@ commands:
        Perform ipmi commands on single or multiple machines
     action: Commands::Ipmi
     options:
-      - *group_option
+      - *gender_option
 
   orchestrate:
     syntax: metal orchestrate [SUB_COMMAND] [options]
@@ -331,7 +331,7 @@ commands:
       reset     - Warm reset the node
     action: Commands::Power
     options:
-      - *group_option
+      - *gender_option
       - tags: [-s SECONDS, --sleep SECONDS]
         type: Float
         default: 0.5
@@ -370,7 +370,7 @@ commands:
       node(s).
     action: Commands::Status
     options:
-      - *group_option
+      - *gender_option
       - tags: [--wait-limit WAIT_LIMIT]
         type: Integer
         default: 10
@@ -407,7 +407,7 @@ commands:
       can be reviewed before the are moved into place using the sync command.
     action: Commands::Template
     options:
-      - *group_option
+      - *gender_option
 
   view-answers:
     syntax: metal view-answers [SUB_COMMAND] [options]

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -17,24 +17,25 @@ module Metalware
       end
 
       def nodes
-        @nodes ||= begin
-          nodes = if options.gender
-                    NodeattrInterface.nodes_in_gender(node_identifier)
-                  else
-                    node_identifier
-                  end
-          raise_missing unless nodes
-          Array.wrap(nodes).map { |n| alces.nodes.find_by_name(n) }
-        end
+        raise_missing unless node_names
+        @nodes ||= node_names.map { |n| alces.nodes.find_by_name(n) }
+      end
+
+      def node_names
+        @node_names ||= if options.gender
+                          NodeattrInterface.nodes_in_gender(node_identifier)
+                        else
+                          [node_identifier]
+                        end
       end
 
       def raise_missing
-        msg = if options.gender
-                MISSING_GENDER_WARNING + node_identifier
-              else
-                MISSING_NODE_WARNING + node_identifier
-              end
+        msg = warning + node_identifier
         raise InvalidInput, msg
+      end
+
+      def warning
+        options.gender ? MISSING_GENDER_WARNING : MISSING_NODE_WARNING
       end
     end
   end

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -25,12 +25,12 @@ module Metalware
         end
       end
 
-      MISSING_GROUP_WARNING = 'Could not find group: '
+      MISSING_GENDER_WARNING = 'Could not find nodes for gender: '
       MISSING_NODE_WARNING = 'Could not find node: '
 
       def raise_missing
         msg = if options.gender
-                MISSING_GROUP_WARNING.to_s + node_identifier
+                MISSING_GENDER_WARNING.to_s + node_identifier
               else
                 MISSING_NODE_WARNING.to_s + node_identifier
               end

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -6,12 +6,15 @@ module Metalware
     module NodeIdentifier
       private
 
+      MISSING_GENDER_WARNING = 'Could not find nodes for gender: '
+      MISSING_NODE_WARNING = 'Could not find node: '
+
+      attr_reader :node_identifier
+
       def pre_setup(*a)
         super(*a)
         @node_identifier = args.first
       end
-
-      attr_reader :node_identifier
 
       def nodes
         @nodes ||= begin
@@ -24,9 +27,6 @@ module Metalware
           Array.wrap(nodes).map { |n| alces.nodes.find_by_name(n) }
         end
       end
-
-      MISSING_GENDER_WARNING = 'Could not find nodes for gender: '
-      MISSING_NODE_WARNING = 'Could not find node: '
 
       def raise_missing
         msg = if options.gender

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -15,7 +15,7 @@ module Metalware
 
       def nodes
         @nodes ||= begin
-          nodes = if options.group
+          nodes = if options.gender
                     NodeattrInterface.nodes_in_gender(node_identifier)
                                      .map do |node|
                                        alces.nodes.find_by_name node

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -16,7 +16,10 @@ module Metalware
       def nodes
         @nodes ||= begin
           nodes = if options.group
-                    group&.nodes
+                    NodeattrInterface.nodes_in_gender(node_identifier)
+                                     .map do |node|
+                                       alces.nodes.find_by_name node
+                                     end
                   else
                     alces.nodes.find_by_name(node_identifier)
                   end

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -25,18 +25,11 @@ module Metalware
         end
       end
 
-      def group
-        @group ||= begin
-          return unless options.group
-          alces.groups.find_by_name(node_identifier)
-        end
-      end
-
       MISSING_GROUP_WARNING = 'Could not find group: '
       MISSING_NODE_WARNING = 'Could not find node: '
 
       def raise_missing
-        msg = if options.group
+        msg = if options.gender
                 MISSING_GROUP_WARNING.to_s + node_identifier
               else
                 MISSING_NODE_WARNING.to_s + node_identifier

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -17,14 +17,11 @@ module Metalware
         @nodes ||= begin
           nodes = if options.gender
                     NodeattrInterface.nodes_in_gender(node_identifier)
-                                     .map do |node|
-                                       alces.nodes.find_by_name node
-                                     end
                   else
-                    alces.nodes.find_by_name(node_identifier)
+                    node_identifier
                   end
           raise_missing unless nodes
-          Array.wrap nodes
+          Array.wrap(nodes).map { |n| alces.nodes.find_by_name(n) }
         end
       end
 

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -30,9 +30,9 @@ module Metalware
 
       def raise_missing
         msg = if options.gender
-                MISSING_GENDER_WARNING.to_s + node_identifier
+                MISSING_GENDER_WARNING + node_identifier
               else
-                MISSING_NODE_WARNING.to_s + node_identifier
+                MISSING_NODE_WARNING + node_identifier
               end
         raise InvalidInput, msg
       end

--- a/src/command_helpers/node_identifier.rb
+++ b/src/command_helpers/node_identifier.rb
@@ -24,7 +24,7 @@ module Metalware
                     alces.nodes.find_by_name(node_identifier)
                   end
           raise_missing unless nodes
-          Array(nodes)
+          Array.wrap nodes
         end
       end
 

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -85,9 +85,6 @@ module Metalware
         {
           repo: repo_dependencies,
           configure: ['domain.yaml'],
-          optional: {
-            configure: ["groups/#{group&.name}.yaml"],
-          },
         }
       end
 

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -77,15 +77,11 @@ module Metalware
       end
 
       def group
-        alces.groups.find_by_name(args[0])
+        alces.groups.find_by_name(node_identifier)
       end
 
       def node
         alces.nodes.find_by_name(node_names[0])
-      end
-
-      def node_names
-        @node_names ||= nodes.map(&:name)
       end
 
       def vm?(node)

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -70,7 +70,7 @@ module Metalware
       end
 
       def render_credentials
-        object = options.group ? group : node
+        object = options.gender ? group : node
         raise MetalwareError, "BMC network not defined for #{object.name}" unless object.config.networks.bmc.defined
         bmc_config = object.config.networks.bmc
         "-U #{bmc_config.bmcuser} -P #{bmc_config.bmcpassword}"

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -81,7 +81,7 @@ module Metalware
       end
 
       def node
-        alces.nodes.find_by_name(node_names[0])
+        alces.nodes.find_by_name(node_identifier)
       end
 
       def vm?(node)

--- a/src/commands/remove/group.rb
+++ b/src/commands/remove/group.rb
@@ -62,7 +62,7 @@ module Metalware
         end
 
         def list_of_answer_files
-          NodeattrInterface.nodes_in_primary_group(primary_group)
+          NodeattrInterface.nodes_in_group(primary_group)
                            .map { |node| FilePath.node_answers(node) }
                            .unshift(FilePath.group_answers(primary_group))
         end

--- a/src/gui/app/models/group.rb
+++ b/src/gui/app/models/group.rb
@@ -26,7 +26,7 @@ class Group < ApplicationModel
     # use, e.g. when we build a group nodes in that group but without it as
     # their primary group will still be included, but they won't be included
     # here.
-    Metalware::NodeattrInterface.nodes_in_primary_group(name).map do |name|
+    Metalware::NodeattrInterface.nodes_in_group(name).map do |name|
       Metalware::Node.new(config, name)
     end
   end

--- a/src/namespaces/group.rb
+++ b/src/namespaces/group.rb
@@ -15,7 +15,7 @@ module Metalware
 
       def nodes
         @nodes ||= begin
-          arr = NodeattrInterface.nodes_in_group(name).map do |node_name|
+          arr = NodeattrInterface.nodes_in_gender(name).map do |node_name|
             alces.nodes.send(node_name)
           end
           MetalArray.new(arr)

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -27,7 +27,7 @@ module Metalware
       end
 
       def genders
-        @genders ||= NodeattrInterface.groups_for_node(name)
+        @genders ||= NodeattrInterface.genders_for_node(name)
       end
 
       def index

--- a/src/nodeattr_interface.rb
+++ b/src/nodeattr_interface.rb
@@ -35,7 +35,7 @@ module Metalware
         end.keys
       end
 
-      def nodes_in_group(group)
+      def nodes_in_gender(group)
         stdout = nodeattr("-c #{group}")
         raise NoGenderGroupError, "Could not find gender group: #{group}" if stdout.empty?
         stdout.chomp.split(',')

--- a/src/nodeattr_interface.rb
+++ b/src/nodeattr_interface.rb
@@ -29,7 +29,7 @@ require 'system_command'
 module Metalware
   module NodeattrInterface
     class << self
-      def nodes_in_primary_group(primary_group)
+      def nodes_in_group(primary_group)
         nodes_to_groups.select do |_node, groups|
           groups.first == primary_group
         end.keys

--- a/src/nodeattr_interface.rb
+++ b/src/nodeattr_interface.rb
@@ -29,9 +29,9 @@ require 'system_command'
 module Metalware
   module NodeattrInterface
     class << self
-      def nodes_in_group(primary_group)
-        nodes_to_groups.select do |_node, groups|
-          groups.first == primary_group
+      def nodes_in_group(group)
+        nodes_to_genders.select do |_node, genders|
+          genders.first == group
         end.keys
       end
 
@@ -41,7 +41,7 @@ module Metalware
         stdout.chomp.split(',')
       end
 
-      def groups_for_node(node)
+      def genders_for_node(node)
         # If no node passed then it has no groups; without this we would run
         # `nodeattr -l` without args, which would give all groups.
         return [] unless node
@@ -76,7 +76,7 @@ module Metalware
 
       private
 
-      def nodes_to_groups
+      def nodes_to_genders
         nodeattr('--expand')
           .split("\n")
           .map(&:split)

--- a/src/nodeattr_interface.rb
+++ b/src/nodeattr_interface.rb
@@ -35,9 +35,9 @@ module Metalware
         end.keys
       end
 
-      def nodes_in_gender(group)
-        stdout = nodeattr("-c #{group}")
-        raise NoGenderGroupError, "Could not find gender group: #{group}" if stdout.empty?
+      def nodes_in_gender(gender)
+        stdout = nodeattr("-c #{gender}")
+        raise NoGenderGroupError, "Could not find gender: #{gender}" if stdout.empty?
         stdout.chomp.split(',')
       end
 


### PR DESCRIPTION
Fixes #286 

Relatively small PR to allow metal commands to run on non-primary groups.

The first commit renames one of the `nodeattr` commands. Metalware makes a distinction between `groups` (which are configured) and `genders` which come from the genders file. The command actually returns nodes in a gender and not nodes in a group.

From this, `alces.groups.<name>.nodes` returns all the nodes in the `gender` called name. Thus not all the nodes belong to that primary group. This means using the namespace to get the list of nodes unnecessarily limits the commands to primary groups.

Instead the nodeattr query is directly done by the command allowing secondary groups to be used.