### PR TITLE
Fix various power and ipmi issues

### DIFF
--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -1,0 +1,70 @@
+
+require 'alces_utils'
+
+RSpec.describe Metalware::Commands::Console do
+  def run_console(node_name, **options)
+    AlcesUtils.redirect_std(:stdout) do
+      Metalware::Utils.run_command(
+        Metalware::Commands::Console, node_name, **options
+      )
+    end
+  end
+
+  describe 'when run on bare metal' do
+    # XXX The setup for these tests is duplicated from those for power;
+    # should DRY this up.
+
+    let :node_names { ['node01', 'node02', 'node03'] }
+
+    before :each do
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:groups_for_node).and_return(['nodes'])
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:all_nodes).and_return(node_names)
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:nodes_in_group).and_return(node_names)
+
+      FileSystem.root_setup do |fs|
+        fs.with_minimal_repo
+
+        domain_config_path = Metalware::FilePath.domain_config
+        fs.create(domain_config_path)
+
+        fs.setup do
+          Metalware::Data.dump(domain_config_path, {
+            networks: {
+              bmc: {
+                defined: true,
+                bmcuser: 'bmcuser',
+                bmcpassword: 'bmcpassword',
+              }
+            }
+          })
+
+          Metalware::Utils.run_command(
+            Metalware::Commands::Configure::Group, 'nodes'
+          )
+        end
+      end
+    end
+
+    describe 'when run for node' do
+      it 'runs console info then activate commands for node' do
+        expect(Metalware::SystemCommand).to receive(:run).with(
+          "ipmitool -H node01 -U bmcuser -P bmcpassword -e '&' -I lanplus sol info"
+        ).ordered.and_return(true)
+        expect_any_instance_of(
+          Metalware::Commands::Console
+        ).to receive(:system).with(
+          "ipmitool -H node01 -U bmcuser -P bmcpassword -e '&' -I lanplus sol activate"
+        )
+
+        run_console('node01')
+      end
+    end
+  end
+end
+

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe Metalware::Commands::Console do
     describe 'when run for node' do
       it 'runs console info then activate commands for node' do
         expect(Metalware::SystemCommand).to receive(:run).with(
-          "ipmitool -H node01 -U bmcuser -P bmcpassword -e '&' -I lanplus sol info"
+          "ipmitool -H node01 -I lanplus -U bmcuser -P bmcpassword -e '&' sol info"
         ).ordered.and_return(true)
         expect_any_instance_of(
           Metalware::Commands::Console
         ).to receive(:system).with(
-          "ipmitool -H node01 -U bmcuser -P bmcpassword -e '&' -I lanplus sol activate"
+          "ipmitool -H node01 -I lanplus -U bmcuser -P bmcpassword -e '&' sol activate"
         )
 
         run_console('node01')

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -1,0 +1,76 @@
+
+require 'alces_utils'
+
+RSpec.describe Metalware::Commands::Ipmi do
+  def run_ipmi(node_identifier, command, **options)
+    AlcesUtils.redirect_std(:stdout) do
+      Metalware::Utils.run_command(
+        Metalware::Commands::Ipmi, node_identifier, command, **options
+      )
+    end
+  end
+
+  describe 'when run on bare metal' do
+    # XXX The setup for these tests is duplicated from those for power; should
+    # DRY this up.
+
+    let :node_names { ['node01', 'node02', 'node03'] }
+
+    before :each do
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:groups_for_node).and_return(['nodes'])
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:all_nodes).and_return(node_names)
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:nodes_in_group).and_return(node_names)
+
+      FileSystem.root_setup do |fs|
+        fs.with_minimal_repo
+
+        domain_config_path = Metalware::FilePath.domain_config
+        fs.create(domain_config_path)
+
+        fs.setup do
+          Metalware::Data.dump(domain_config_path, {
+            networks: {
+              bmc: {
+                defined: true,
+                bmcuser: 'bmcuser',
+                bmcpassword: 'bmcpassword',
+              }
+            }
+          })
+
+          Metalware::Utils.run_command(
+            Metalware::Commands::Configure::Group, 'nodes'
+          )
+        end
+      end
+    end
+
+    describe 'when run for node' do
+      it 'runs given ipmi command on node' do
+        expect(Metalware::SystemCommand).to receive(:run).once.with(
+          'ipmitool -H node01.bmc -I lanplus -U bmcuser -P bmcpassword sel list'
+        )
+
+        run_ipmi('node01', 'sel list')
+      end
+    end
+
+    describe 'when run for group' do
+      it 'runs given ipmi command on each node' do
+        node_names.each do |name|
+          expect(Metalware::SystemCommand).to receive(:run).with(
+            "ipmitool -H #{name}.bmc -I lanplus -U bmcuser -P bmcpassword sel list"
+          ).ordered
+        end
+
+        run_ipmi('nodes', 'sel list', group: true)
+      end
+    end
+  end
+end

--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -1,0 +1,79 @@
+
+require 'alces_utils'
+
+RSpec.describe Metalware::Commands::Power do
+  def run_power(node_identifier, command, **options)
+    AlcesUtils.redirect_std(:stdout) do
+      Metalware::Utils.run_command(
+        Metalware::Commands::Power, node_identifier, command, **options
+      )
+    end
+  end
+
+  describe 'when run on bare metal' do
+    let :node_names { ['node01', 'node02', 'node03'] }
+
+    before :each do
+      # XXX Factor out this setup in a reusable but still clear form. An
+      # alternative approach would be to use AlcesUtils, but this seems
+      # convoluted and unclear and mocks too many things for me to trust it.
+      # This approach is at least explicit about the preconditions which must
+      # be met before this command can be run.
+
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:groups_for_node).and_return(['nodes'])
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:all_nodes).and_return(node_names)
+      allow(
+        Metalware::NodeattrInterface
+      ).to receive(:nodes_in_group).and_return(node_names)
+
+      FileSystem.root_setup do |fs|
+        fs.with_minimal_repo
+
+        domain_config_path = Metalware::FilePath.domain_config
+        fs.create(domain_config_path)
+
+        fs.setup do
+          Metalware::Data.dump(domain_config_path, {
+            networks: {
+              bmc: {
+                defined: true,
+                bmcuser: 'bmcuser',
+                bmcpassword: 'bmcpassword',
+              }
+            }
+          })
+
+          Metalware::Utils.run_command(
+            Metalware::Commands::Configure::Group, 'nodes'
+          )
+        end
+      end
+    end
+
+    describe 'when run for node' do
+      it 'runs appropriate ipmi command for given command and node' do
+        expect(Metalware::SystemCommand).to receive(:run).once.with(
+          'ipmitool -H node01.bmc -I lanplus -U bmcuser -P bmcpassword chassis power on'
+        )
+
+        run_power('node01', 'on')
+      end
+    end
+
+    describe 'when run for group' do
+      it 'runs appropriate ipmi command for given command on each node' do
+        node_names.each do |name|
+          expect(Metalware::SystemCommand).to receive(:run).with(
+            "ipmitool -H #{name}.bmc -I lanplus -U bmcuser -P bmcpassword chassis power on"
+          ).ordered
+        end
+
+        run_power('nodes', 'on', group: true)
+      end
+    end
+  end
+end

--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -65,14 +65,15 @@ RSpec.describe Metalware::Commands::Power do
     end
 
     describe 'when run for group' do
-      it 'runs appropriate ipmi command for given command on each node' do
+      it 'runs appropriate ipmi command followed by sleep for each node' do
         node_names.each do |name|
           expect(Metalware::SystemCommand).to receive(:run).with(
             "ipmitool -H #{name}.bmc -I lanplus -U bmcuser -P bmcpassword chassis power on"
           ).ordered
+
         end
 
-        run_power('nodes', 'on', group: true)
+        run_power('nodes', 'on', group: true, sleep: 0.5)
       end
     end
   end

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -204,7 +204,7 @@ commands:
       - *group_option
 
   configure:
-    syntax: metal configure [options]
+    syntax: metal configure [SUB_COMMAND] [options]
     summary: Configure different aspects of this Metalware installation
     subcommands:
       domain: *configure_domain
@@ -297,14 +297,14 @@ commands:
           The IPMI tool command to run, for example `sel list`
 
   orchestrate:
-    syntax: metal orchestrate [COMMAND] [options]
+    syntax: metal orchestrate [SUB_COMMAND] [options]
     summary: Orchestrate virtual machines
     subcommands:
       create: *orchestrate_create
       destroy: *orchestrate_destroy
 
   plugin:
-    syntax: metal plugin [options]
+    syntax: metal plugin [SUB_COMMAND] [options]
     summary: View and manage activated plugins
     subcommands:
       list: *plugin_list
@@ -338,7 +338,7 @@ commands:
       - *group_option
 
   remove:
-    syntax: metal remove [options]
+    syntax: metal remove [SUB_COMMAND] [options]
     summary: Remove metalware controlled files/ objects
     # Description can be added for subcommand
     subcommands:
@@ -354,7 +354,7 @@ commands:
     action: Commands::Render
 
   repo:
-    syntax: metal repo [options]
+    syntax: metal repo [SUB_COMMAND] [options]
     summary: Manage template and config repository
     # description can also be used for subcommands
     subcommands:
@@ -409,7 +409,7 @@ commands:
       - *group_option
 
   view-answers:
-    syntax: metal view-answers [options]
+    syntax: metal view-answers [SUB_COMMAND] [options]
     summary: View configured answers
     subcommands:
       domain: *view-answers_domain

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -291,10 +291,6 @@ commands:
     action: Commands::Ipmi
     options:
       - *group_option
-      - tags: [-c COMMAND, --command COMMAND]
-        type: String
-        description: >
-          The IPMI tool command to run, for example `sel list`
 
   orchestrate:
     syntax: metal orchestrate [SUB_COMMAND] [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -336,6 +336,11 @@ commands:
     action: Commands::Power
     options:
       - *group_option
+      - tags: [-s SECONDS, --sleep SECONDS]
+        type: Float
+        default: 0.5
+        description: >
+          Time to wait between running power command on each node.
 
   remove:
     syntax: metal remove [SUB_COMMAND] [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -154,7 +154,7 @@ subcommands:
       Commands::ViewAnswers::Group
 
   view-answers_node: &view-answers_node
-    syntax: metal view-answers node NODE_NAME [options]
+    syntax: metal view-answers node NODE [options]
     summary: View configured answers for a node
     description: >
       View configuration questions along with configured answers for given
@@ -213,7 +213,7 @@ commands:
       local: *configure_local
 
   console:
-    syntax: metal console NODE_IDENTIFIER [options]
+    syntax: metal console NODE_NAME [options]
     summary: Display a node's console in the terminal
     description: >
       Displays the console of a node in the terminal. The console command
@@ -284,7 +284,7 @@ commands:
           node name in the hunter cache
 
   ipmi:
-    syntax: metal ipmi NODE_IDENTIFIER [COMMAND] [options]
+    syntax: metal ipmi NODE_IDENTIFIER COMMAND [options]
     summary: Perform ipmi commands on single or multiple machines
     description: >
        Perform ipmi commands on single or multiple machines
@@ -308,7 +308,7 @@ commands:
       deactivate: *plugin_deactivate
 
   power:
-    syntax: metal power NODE_IDENTIFIER [COMMAND] [options]
+    syntax: metal power NODE_IDENTIFIER COMMAND [options]
     summary: Run power commands on a node.
     description: >
       Allows ipmi power commands to be run on a node or group

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -33,15 +33,21 @@ module Metalware
         raise MetalwareError, 'Console not supported on virtual machines' if vm?(node)
         raise MetalwareError, "Unable to connect to #{node.name}" unless valid_connection?
         puts 'Establishing SOL connection, type &. to exit..'
-        system(command('activate'))
-      end
-
-      def command(type)
-        "ipmitool -H #{node.name} -I lanplus #{render_credentials} -e '&' sol #{type}"
+        system(console_command('activate'))
       end
 
       def valid_connection?
-        SystemCommand.run(command('info'))
+        SystemCommand.run(console_command('info'))
+      end
+
+      def console_command(type)
+        # XXX In Console we use `$node_name` as the host when running
+        # `ipmitool`, but in Ipmi and Power we use `$node_name.bmc` - is there
+        # any reason for this? Does this have any different effect?
+        create_ipmitool_command(
+          host: node.name,
+          arguments: "-e '&' sol #{type}"
+        )
       end
     end
   end

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -37,7 +37,7 @@ module Metalware
       end
 
       def command(type)
-        "ipmitool -H #{node.name} #{render_credentials} -e '&' -I lanplus sol #{type}"
+        "ipmitool -H #{node.name} -I lanplus #{render_credentials} -e '&' sol #{type}"
       end
 
       def valid_connection?

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -46,9 +46,8 @@ module Metalware
       end
 
       def run_vm(node)
-        command = args[1]
         libvirt = Metalware::Vm.new(node)
-        libvirt.send(command)
+        libvirt.send(original_command)
       end
 
       def run_baremetal(node)
@@ -60,7 +59,11 @@ module Metalware
       end
 
       def render_command
-        options.command
+        original_command
+      end
+
+      def original_command
+        args[1]
       end
 
       def render_credentials

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -37,6 +37,7 @@ module Metalware
       def run
         nodes.each do |node|
           ipmi(node)
+          sleep options.sleep if options.sleep
         end
       end
 

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -47,22 +47,25 @@ module Metalware
 
       def run_vm(node)
         libvirt = Metalware::Vm.new(node)
-        libvirt.send(original_command)
+        libvirt.send(command_argument)
       end
 
       def run_baremetal(node)
-        puts "#{node.name}: #{SystemCommand.run(command(node.name))}"
+        puts "#{node.name}: #{SystemCommand.run(ipmi_command(node.name))}"
       end
 
-      def command(host)
-        "ipmitool -H #{host}.bmc -I lanplus #{render_credentials} #{render_command}"
+      def ipmi_command(node_name)
+        create_ipmitool_command(
+          host: "#{node_name}.bmc",
+          arguments: command_argument
+        )
       end
 
-      def render_command
-        original_command
+      def create_ipmitool_command(host:, arguments:)
+        "ipmitool -H #{host} -I lanplus #{render_credentials} #{arguments}"
       end
 
-      def original_command
+      def command_argument
         args[1]
       end
 

--- a/src/commands/power.rb
+++ b/src/commands/power.rb
@@ -29,8 +29,15 @@ module Metalware
     class Power < Ipmi
       private
 
-      def render_command
-        case args[1].to_s
+      def ipmi_command(node_name)
+        create_ipmitool_command(
+          host: "#{node_name}.bmc",
+          arguments: ipmi_command_arguments
+        )
+      end
+
+      def ipmi_command_arguments
+        case command_argument
         when 'on'
           'chassis power on'
         when 'off'
@@ -48,7 +55,7 @@ module Metalware
         when 'sensor'
           'sensor'
         else
-          raise MetalwareError, "Invalid power command: #{args[1]}"
+          raise MetalwareError, "Invalid power command: #{command_argument}"
         end
       end
     end


### PR DESCRIPTION
This PR:

- fixes #304, by adding a new `--sleep`/`-s` argument to `power` which tells it to sleep for this long between each power command; this defaults to 0.5 (seconds);

- adds a few smoke tests to the `ipmi`, `power`, and `console` commands so we have some test coverage for these;

- fixes a few minor issues and inconsistencies with these commands;

- refactors these commands a little bit to make the control flow a bit more obvious and less convoluted.