### PR TITLE
Implement overview command for groups

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -156,6 +156,7 @@ module AlcesUtils
       allow(node).to receive(:hexadecimal_ip).and_return(hex)
     end
 
+    # TODO: Get the new node by reloading the genders file
     def mock_node(name, *genders)
       AlcesUtils.check_and_raise_fakefs_error
       raise_if_node_exists(name)
@@ -166,7 +167,6 @@ module AlcesUtils
         new_nodes = alces.nodes.reduce([node], &:push)
         metal_nodes = Metalware::Namespaces::MetalArray.new(new_nodes)
         allow(alces).to receive(:nodes).and_return(metal_nodes)
-        allow(alces).to receive(:node).and_return(node)
       end
     end
 
@@ -177,7 +177,7 @@ module AlcesUtils
       alces.instance_variable_set(:@group_cache, nil)
       group = alces.groups.find_by_name(name)
       with_blank_config_and_answer(group)
-      allow(alces).to receive(:group).and_return(group)
+      group
     end
 
     private

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -123,10 +123,6 @@ RSpec.describe AlcesUtils do
         expect(alces.groups.send(group).config.to_h).to be_empty
       end
 
-      it 'sets the group as the in scope group' do
-        expect(alces.group).to eq(alces.groups.send(group))
-      end
-
       # The mocking would otherwise alter the actual file
       it 'errors if FakeFS is off' do
         FakeFS.deactivate!
@@ -134,13 +130,20 @@ RSpec.describe AlcesUtils do
           AlcesUtils.mock(self) { mock_group(group2) }
         end.to raise_error(RuntimeError)
       end
+
+      it 'returns the new mocked group' do
+        name = 'my-super-new-group'
+        AlcesUtils.mock self do
+          expect(mock_group(name).name).to eq(name)
+        end
+      end
     end
 
     describe '#mock_node' do
       let :name { 'some_random_test_node3456734' }
 
       AlcesUtils.mock self, :each do
-        mock_node(name)
+        allow(alces).to receive(:node).and_return(mock_node(name))
       end
 
       it 'creates the mock node' do
@@ -173,13 +176,9 @@ RSpec.describe AlcesUtils do
 
         AlcesUtils.mock(self, :each) { mock_node(new_node, *genders) }
 
-        it 'sets the last mock node as alces.nodes' do
-          expect(alces.node.name).to eq(new_node)
-          expect(alces.nodes.length).to eq(3)
-        end
-
         it 'uses the genders input' do
-          expect(alces.node.genders).to eq(genders)
+          node = alces.nodes.find_by_name(new_node)
+          expect(node.genders).to eq(genders)
         end
       end
     end

--- a/spec/answers_table_creator_spec.rb
+++ b/spec/answers_table_creator_spec.rb
@@ -104,10 +104,8 @@ RSpec.describe Metalware::AnswersTableCreator do
 
   AlcesUtils.mock self, :each do
     answer(alces.domain, domain_answers)
-    mock_node(node_name, group_name)
-    answer(alces.node, node_answers)
-    mock_group(group_name)
-    answer(alces.group, group_answers)
+    answer(mock_node(node_name, group_name), node_answers)
+    answer(mock_group(group_name), group_answers)
   end
 
   describe '#domain_table' do

--- a/spec/build_files_retriever_spec.rb
+++ b/spec/build_files_retriever_spec.rb
@@ -40,9 +40,11 @@ RSpec.describe Metalware::BuildFilesRetriever do
     ],
   }.freeze
 
+  let :test_node_name { 'testnode01' }
+  let :test_node { alces.nodes.find_by_name(test_node_name) }
+
   AlcesUtils.mock self, :each do
-    mock_node('testnode01')
-    config(alces.node, files: TEST_FILES_HASH)
+    config(mock_node(test_node_name), files: TEST_FILES_HASH)
   end
 
   subject { Metalware::BuildFilesRetriever.new }
@@ -72,7 +74,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
         FileUtils.mkdir_p File.dirname(url_path)
         FileUtils.touch(url_path)
 
-        retrieved_files = subject.retrieve_for_node(alces.node)
+        retrieved_files = subject.retrieve_for_node(test_node)
 
         expect(retrieved_files[:namespace01][0]).to eq(
           raw: 'some/file_in_repo',
@@ -105,7 +107,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
           '/var/lib/metalware/cache/templates/url'
         )
 
-        subject.retrieve_for_node(alces.node)
+        subject.retrieve_for_node(test_node)
       end
     end
 
@@ -116,7 +118,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
 
       describe 'for repo file identifier' do
         it 'adds error to file entry' do
-          retrieved_files = subject.retrieve_for_node(alces.node)
+          retrieved_files = subject.retrieve_for_node(test_node)
 
           repo_file_entry = retrieved_files[:namespace01][0]
           template_path = "#{Metalware::FilePath.repo}/files/some/file_in_repo"
@@ -130,7 +132,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
 
       describe 'for absolute path file identifier' do
         it 'adds error to file entry' do
-          retrieved_files = subject.retrieve_for_node(alces.node)
+          retrieved_files = subject.retrieve_for_node(test_node)
 
           absolute_file_entry = retrieved_files[:namespace01][1]
           template_path = '/some/other/path'
@@ -149,7 +151,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
       end
 
       it 'adds error to file entry' do
-        retrieved_files = subject.retrieve_for_node(alces.node)
+        retrieved_files = subject.retrieve_for_node(test_node)
 
         url_file_entry = retrieved_files[:namespace01][2]
         url = 'http://example.com/url'
@@ -195,7 +197,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
         files: { some_section: [plugin_file_path] }
       )
 
-      plugin_namespace = Metalware::Namespaces::Plugin.new(plugin, node: alces.node)
+      plugin_namespace = Metalware::Namespaces::Plugin.new(plugin, node: test_node)
       retrieved_files = subject.retrieve_for_plugin(plugin_namespace)
 
       relative_rendered_path =

--- a/spec/build_methods/kickstarts/uefi_spec.rb
+++ b/spec/build_methods/kickstarts/uefi_spec.rb
@@ -34,16 +34,19 @@ RSpec.describe Metalware::BuildMethods::Kickstarts::UEFI do
     FileSystem.root_setup(&:with_minimal_repo)
   end
 
+  let :node_name { 'nodeA01' }
+  let :node { alces.nodes.find_by_name node_name }
+
   AlcesUtils.mock self, :each do
-    mock_node('nodeA01')
-    allow(alces.node).to receive(:hexadecimal_ip).and_return('00000000')
-    config(alces.node, build_method: :'uefi-kickstart')
+    n = mock_node node_name
+    allow(n).to receive(:hexadecimal_ip).and_return('00000000')
+    config(n, build_method: :'uefi-kickstart')
   end
 
   it 'renders the pxelinux template with correct save_path' do
     save_path = File.join(Metalware::FilePath.uefi_save, 'grub.cfg-00000000')
     FileUtils.mkdir(File.dirname(save_path))
-    alces.node.build_method.start_hook
+    node.build_method.start_hook
     expect(File.exist?(save_path)).to eq(true)
   end
 end

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -122,15 +122,15 @@ RSpec.describe Metalware::Commands::Build do
 
   context 'when called for group' do
     AlcesUtils.mock self, :each do
-      test_group = 'some_random_test_group'
+      test_group = test_group_name
       mock_group(test_group)
       ['nodeA00', 'nodeA01', 'nodeA02', 'nodeA03'].each do |node|
-        mock_node(node, test_group)
-        hexadecimal_ip(alces.node)
+        hexadecimal_ip(mock_node(node, test_group))
       end
     end
 
-    let :testnodes { alces.group }
+    let :test_group_name { 'some_random_test_group' }
+    let :testnodes { alces.groups.find_by_name test_group_name }
     let :delay_build { build_wait_time / 10 }
 
     it 'starts all the builds' do

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe Metalware::Commands::Console do
     end
 
     AlcesUtils.mock self, :each do
-      mock_node(node_name)
-      config(alces.node, node_config)
+      config(mock_node(node_name), node_config)
     end
 
     describe 'when run for node' do

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -1,4 +1,6 @@
 
+# frozen_string_literal: true
+
 require 'alces_utils'
 
 RSpec.describe Metalware::Commands::Console do
@@ -21,8 +23,8 @@ RSpec.describe Metalware::Commands::Console do
             defined: true,
             bmcuser: 'bmcuser',
             bmcpassword: 'bmcpassword',
-          }
-        }
+          },
+        },
       }
     end
 
@@ -46,4 +48,3 @@ RSpec.describe Metalware::Commands::Console do
     end
   end
 end
-

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -1,4 +1,6 @@
 
+# frozen_string_literal: true
+
 require 'alces_utils'
 
 RSpec.describe Metalware::Commands::Ipmi do
@@ -25,8 +27,8 @@ RSpec.describe Metalware::Commands::Ipmi do
             defined: true,
             bmcuser: 'bmcuser',
             bmcpassword: 'bmcpassword',
-          }
-        }
+          },
+        },
       }
     end
 

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -31,11 +31,9 @@ RSpec.describe Metalware::Commands::Ipmi do
     end
 
     AlcesUtils.mock self, :each do
-      mock_group(group)
-      config(alces.group, namespace_config)
+      config(mock_group(group), namespace_config)
       node_names.each do |node|
-        mock_node(node, group)
-        config(alces.node, namespace_config)
+        config(mock_node(node, group), namespace_config)
       end
     end
 

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -1,4 +1,4 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 
 require 'commands'
 require 'alces_utils'
@@ -10,7 +10,7 @@ RSpec.describe Metalware::Commands::Overview do
 
   AlcesUtils.mock self, :each do
     ['group1', 'group2', 'group3'].map do |group|
-      config(mock_group(group), { key: config_value })
+      config(mock_group(group), key: config_value)
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe Metalware::Commands::Overview do
   end
 
   it 'includes the group names' do
-    expect(header).to include("Group")
+    expect(header).to include('Group')
     alces.groups.each do |group|
       expect(body).to include(group.name)
     end
@@ -38,10 +38,9 @@ RSpec.describe Metalware::Commands::Overview do
 
   context 'with a mismatch between no. headers/bodies in overview.yaml' do
     before :each do
-      Metalware::Data.dump(Metalware::FilePath.overview, {
-        headers: ['I', 'have', '4', 'headers'],
-        fields: ['I', 'have', '5', 'body', 'parts'],
-      })
+      Metalware::Data.dump(Metalware::FilePath.overview,
+                           headers: ['I', 'have', '4', 'headers'],
+                           fields: ['I', 'have', '5', 'body', 'parts'])
     end
 
     it 'errors' do
@@ -58,7 +57,7 @@ RSpec.describe Metalware::Commands::Overview do
 
     before :each do
       Metalware::Data.dump Metalware::FilePath.overview,
-                           { headers: headers, fields: fields }
+                           headers: headers, fields: fields
     end
 
     it 'includes the headers in the table' do
@@ -74,4 +73,3 @@ RSpec.describe Metalware::Commands::Overview do
     end
   end
 end
-

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Metalware::Commands::Overview do
   include AlcesUtils
 
   AlcesUtils.mock self, :each do
-    ['group1', 'group2', 'group3'].map { |group| mock_group(group) }
+    ['group1', 'group2', 'group3'].map do |group|
+      mock_group(group)
+      config(alces.group, { key: 'config_value' })
+    end
   end
 
   def overview
@@ -44,6 +47,20 @@ RSpec.describe Metalware::Commands::Overview do
       AlcesUtils.redirect_std(:stderr) do
         expect { overview }.to raise_error(Metalware::DataError)
       end
+    end
+  end
+
+  context 'with a valid overview.yaml' do
+    let :headers { ['heading1', 'heading2', 'heading3'] }
+    let :fields { ['static', '<% group.config.value %>', nil] }
+
+    before :each do
+      Metalware::Data.dump Metalware::FilePath.overview,
+                           { headers: headers, fields: fields }
+    end
+
+    it 'includes the headers in the table' do
+      headers.each { |h| expect(header).to include(h) }
     end
   end
 end

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -1,7 +1,34 @@
 #frozen_string_literal: true
 
 require 'commands'
+require 'alces_utils'
 
 RSpec.describe Metalware::Commands::Overview do
-  it ''
+  include AlcesUtils
+
+  AlcesUtils.mock self, :each do
+    ['group1', 'group2', 'group3'].map { |group| mock_group(group) }
+  end
+
+  def overview
+    std = AlcesUtils.redirect_std(:stdout) do
+      Metalware::Utils.run_command(Metalware::Commands::Overview)
+    end
+    std[:stdout].read
+  end
+
+  def header
+    overview.lines[1]
+  end
+
+  def body
+    overview.lines[3..-2].join("\n")
+  end
+
+  it 'includes the group names' do
+    expect(header).to include("Group")
+    alces.groups.each do |group|
+      expect(body).to include(group.name)
+    end
+  end
 end

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -6,10 +6,12 @@ require 'alces_utils'
 RSpec.describe Metalware::Commands::Overview do
   include AlcesUtils
 
+  let :config_value { 'config_value' }
+
   AlcesUtils.mock self, :each do
     ['group1', 'group2', 'group3'].map do |group|
       mock_group(group)
-      config(alces.group, { key: 'config_value' })
+      config(alces.group, { key: config_value })
     end
   end
 
@@ -53,7 +55,7 @@ RSpec.describe Metalware::Commands::Overview do
   context 'with a valid overview.yaml' do
     let :static { 'static' }
     let :headers { ['heading1', 'heading2', 'heading3'] }
-    let :fields { [static, '<% group.config.value %>', nil] }
+    let :fields { [static, '<% group.config.value %>', ''] }
 
     before :each do
       Metalware::Data.dump Metalware::FilePath.overview,
@@ -66,6 +68,10 @@ RSpec.describe Metalware::Commands::Overview do
 
     it 'includes the static field in the table' do
       expect(body).to include(static)
+    end
+
+    it 'renders the fields' do
+      expect(body).to include(config_value)
     end
   end
 end

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -31,4 +31,20 @@ RSpec.describe Metalware::Commands::Overview do
       expect(body).to include(group.name)
     end
   end
+
+  context 'with a mismatch between no. headers/bodies in overview.yaml' do
+    before :each do
+      Metalware::Data.dump(Metalware::FilePath.overview, {
+        headers: ['I', 'have', '4', 'headers'],
+        fields: ['I', 'have', '5', 'body', 'parts'],
+      })
+    end
+
+    it 'errors' do
+      AlcesUtils.redirect_std(:stderr) do
+        expect { overview }.to raise_error(Metalware::DataError)
+      end
+    end
+  end
 end
+

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Metalware::Commands::Overview do
 
   AlcesUtils.mock self, :each do
     ['group1', 'group2', 'group3'].map do |group|
-      mock_group(group)
-      config(alces.group, { key: config_value })
+      config(mock_group(group), { key: config_value })
     end
   end
 

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe Metalware::Commands::Overview do
   end
 
   context 'with a valid overview.yaml' do
+    let :static { 'static' }
     let :headers { ['heading1', 'heading2', 'heading3'] }
-    let :fields { ['static', '<% group.config.value %>', nil] }
+    let :fields { [static, '<% group.config.value %>', nil] }
 
     before :each do
       Metalware::Data.dump Metalware::FilePath.overview,
@@ -61,6 +62,10 @@ RSpec.describe Metalware::Commands::Overview do
 
     it 'includes the headers in the table' do
       headers.each { |h| expect(header).to include(h) }
+    end
+
+    it 'includes the static field in the table' do
+      expect(body).to include(static)
     end
   end
 end

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Metalware::Commands::Overview do
   context 'with a valid overview.yaml' do
     let :static { 'static' }
     let :headers { ['heading1', 'heading2', 'heading3'] }
-    let :fields { [static, '<% group.config.value %>', ''] }
+    let :fields { [static, '<%= group.config.key %>', ''] }
 
     before :each do
       Metalware::Data.dump Metalware::FilePath.overview,

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -1,0 +1,7 @@
+#frozen_string_literal: true
+
+require 'commands'
+
+RSpec.describe Metalware::Commands::Overview do
+  it ''
+end

--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -1,4 +1,6 @@
 
+# frozen_string_literal: true
+
 require 'alces_utils'
 
 RSpec.describe Metalware::Commands::Power do
@@ -22,8 +24,8 @@ RSpec.describe Metalware::Commands::Power do
             defined: true,
             bmcuser: 'bmcuser',
             bmcpassword: 'bmcpassword',
-          }
-        }
+          },
+        },
       }
     end
 
@@ -57,7 +59,6 @@ RSpec.describe Metalware::Commands::Power do
           expect(Metalware::SystemCommand).to receive(:run).with(
             "ipmitool -H #{name}.bmc -I lanplus -U bmcuser -P bmcpassword chassis power on"
           ).ordered
-
         end
 
         run_power('nodes', 'on', gender: true, sleep: 0.5)

--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -28,11 +28,9 @@ RSpec.describe Metalware::Commands::Power do
     end
 
     AlcesUtils.mock self, :each do
-      mock_group(group)
-      config(alces.group, namespace_config)
+      config(mock_group(group), namespace_config)
       node_names.each do |node|
-        mock_node(node, group)
-        config(alces.node, namespace_config)
+        config(mock_node(node, group), namespace_config)
       end
     end
 

--- a/spec/namespaces/domain_spec.rb
+++ b/spec/namespaces/domain_spec.rb
@@ -8,7 +8,8 @@ require 'spec_utils'
 RSpec.describe Metalware::Namespaces::Node do
   include AlcesUtils
 
-  include_examples Metalware::Namespaces::HashMergerNamespace, :domain
+  include_examples Metalware::Namespaces::HashMergerNamespace,
+                   'alces.domain'
 
   before :each { SpecUtils.use_mock_determine_hostip_script(self) }
 

--- a/spec/namespaces/group_spec.rb
+++ b/spec/namespaces/group_spec.rb
@@ -6,9 +6,9 @@ require 'namespaces/alces'
 require 'spec_utils'
 
 RSpec.describe Metalware::Namespaces::Node do
-  context 'with mocked group' do
-    include AlcesUtils
+  include AlcesUtils
 
+  context 'with mocked group' do
     let :test_group { 'some_test_group' }
 
     AlcesUtils.mock self, :each do
@@ -18,6 +18,28 @@ RSpec.describe Metalware::Namespaces::Node do
 
     include_examples Metalware::Namespaces::HashMergerNamespace,
                      "alces.groups.first"
+  end
+
+  context 'with a mocked genders file' do
+    before :each do
+      AlcesUtils.mock self do
+        mock_group('group1')
+        mock_group('group2')
+      end
+
+      genders = <<~EOF.strip_heredoc
+        node[01-10]    group1,group2
+        nodeA    group2
+      EOF
+      File.write Metalware::FilePath.genders, genders
+    end
+
+    describe '#short_nodes_string' do
+      it 'can find the hosts list' do
+        group = alces.groups.find_by_name('group2')
+        expect(group.hostlist_nodes).to eq('node[01-10],nodeA')
+      end
+    end
   end
 end
 

--- a/spec/namespaces/group_spec.rb
+++ b/spec/namespaces/group_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Metalware::Namespaces::Node do
     end
 
     include_examples Metalware::Namespaces::HashMergerNamespace,
-                     "alces.groups.first"
+                     'alces.groups.first'
   end
 
   context 'with a mocked genders file' do
@@ -42,4 +42,3 @@ RSpec.describe Metalware::Namespaces::Node do
     end
   end
 end
-

--- a/spec/namespaces/group_spec.rb
+++ b/spec/namespaces/group_spec.rb
@@ -1,6 +1,7 @@
 
 # frozen_string_literal: true
 
+require 'shared_examples/hash_merger_namespace'
 require 'namespaces/alces'
 require 'spec_utils'
 
@@ -15,6 +16,8 @@ RSpec.describe Metalware::Namespaces::Node do
       mock_node('random_node', test_group)
     end
 
-    include_examples Metalware::Namespaces::HashMergerNamespace, :group
+    include_examples Metalware::Namespaces::HashMergerNamespace,
+                     "alces.groups.first"
   end
 end
+

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metalware::Namespaces::Node do
     end
 
     include_examples Metalware::Namespaces::HashMergerNamespace,
-                     "alces.nodes.first"
+                     'alces.nodes.first'
   end
 
   context 'without AlcesUtils' do

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe Metalware::Namespaces::Node do
     include AlcesUtils
 
     AlcesUtils.mock self, :each do
-      mock_node('test_node')
-      hexadecimal_ip(alces.node)
+      hexadecimal_ip(mock_node('test_node'))
       mock_group(AlcesUtils.default_group)
     end
 
-    include_examples Metalware::Namespaces::HashMergerNamespace, :node
+    include_examples Metalware::Namespaces::HashMergerNamespace,
+                     "alces.nodes.first"
   end
 
   context 'without AlcesUtils' do

--- a/spec/shared_examples/hash_merger_namespace.rb
+++ b/spec/shared_examples/hash_merger_namespace.rb
@@ -5,9 +5,9 @@ require 'namespaces/alces'
 require 'alces_utils'
 
 RSpec.shared_examples \
-  Metalware::Namespaces::HashMergerNamespace do |alces_method|
+  Metalware::Namespaces::HashMergerNamespace do |test_obj_str|
 
-  let :test_obj { alces.send(alces_method) }
+  let :test_obj { eval(test_obj_str) }
 
   let :test_config do
     {

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -299,6 +299,11 @@ commands:
       create: *orchestrate_create
       destroy: *orchestrate_destroy
 
+  overview:
+    syntax: metal overview [options]
+    summary: Gives an overview of the configured groups
+    action: Commands::Overview
+
   plugin:
     syntax: metal plugin [SUB_COMMAND] [options]
     summary: View and manage activated plugins

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Metalware.
+#
+# Alces Metalware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Metalware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Metalware, please visit:
+# https://github.com/alces-software/metalware
+#==============================================================================
+
+module Metalware
+  module Commands
+    class Overview < CommandHelpers::BaseCommand
+      private
+
+      def setup
+      end
+
+      def run
+      end
+    end
+  end
+end

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -35,12 +35,16 @@ module Metalware
         puts Terminal::Table.new(headings: headings, rows: rows)
       end
 
-      def headings
-        []
+      def rows
+        alces.groups.map { |group| row(group) }
       end
 
-      def rows
-        []
+      def headings
+        ['Group']
+      end
+
+      def row(group)
+        [group.name]
       end
     end
   end

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -43,11 +43,13 @@ module Metalware
       end
 
       def headings
-        ['Group'] << display_fields.headers
+        ['Group'].concat display_fields.headers
       end
 
       def row(group)
-        [group.name] << display_fields.fields
+        (['<%= group.name %>'].concat display_fields.fields).map do |field|
+          group.render_erb_template(field)
+        end
       end
 
       def display_fields

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -29,7 +29,7 @@ module Metalware
     class Overview < CommandHelpers::BaseCommand
       private
 
-      OVERVIEW_ERROR = 'Can not construct table from overview.yaml'.freeze
+      OVERVIEW_ERROR = 'Can not construct table from overview.yaml'
 
       def setup; end
 
@@ -56,9 +56,8 @@ module Metalware
         data = OpenStruct.new(Data.load(FilePath.overview))
         data.headers ||= []
         data.fields ||= []
-        unless data.headers.length == data.fields.length
-          raise DataError, OVERVIEW_ERROR
-        end
+        correct_length = (data.headers.length == data.fields.length)
+        raise DataError, OVERVIEW_ERROR unless correct_length
         data
       end
     end

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -29,9 +29,12 @@ module Metalware
     class Overview < CommandHelpers::BaseCommand
       private
 
+      OVERVIEW_ERROR = 'Can not construct table from overview.yaml'.freeze
+
       def setup; end
 
       def run
+        display_fields
         puts Terminal::Table.new(headings: headings, rows: rows)
       end
 
@@ -45,6 +48,16 @@ module Metalware
 
       def row(group)
         [group.name]
+      end
+
+      def display_fields
+        data = OpenStruct.new(Data.load(FilePath.overview))
+        data.headers ||= []
+        data.fields ||= []
+        unless data.headers.length == data.fields.length
+          raise DataError, OVERVIEW_ERROR
+        end
+        data
       end
     end
   end

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -22,15 +22,25 @@
 # https://github.com/alces-software/metalware
 #==============================================================================
 
+require 'terminal-table'
+
 module Metalware
   module Commands
     class Overview < CommandHelpers::BaseCommand
       private
 
-      def setup
-      end
+      def setup; end
 
       def run
+        puts Terminal::Table.new(headings: headings, rows: rows)
+      end
+
+      def headings
+        []
+      end
+
+      def rows
+        []
       end
     end
   end

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -47,7 +47,7 @@ module Metalware
       end
 
       def row(group)
-        [group.name]
+        [group.name] << display_fields.fields
       end
 
       def display_fields

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -43,7 +43,7 @@ module Metalware
       end
 
       def headings
-        ['Group']
+        ['Group'] << display_fields.headers
       end
 
       def row(group)

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -68,6 +68,10 @@ module Metalware
         '/var/lib/metalware/repo'
       end
 
+      def overview
+        File.join(repo, 'overview.yaml')
+      end
+
       def plugins_dir
         File.join(Constants::METALWARE_DATA_PATH, 'plugins')
       end

--- a/src/namespaces/group.rb
+++ b/src/namespaces/group.rb
@@ -22,6 +22,12 @@ module Metalware
         end
       end
 
+      def hostlist_nodes
+        @short_nodes_string ||= begin
+          NodeattrInterface.hostlist_nodes_in_gender(name)
+        end
+      end
+
       private
 
       def white_list_for_hasher

--- a/src/nodeattr_interface.rb
+++ b/src/nodeattr_interface.rb
@@ -41,6 +41,10 @@ module Metalware
         stdout.chomp.split(',')
       end
 
+      def hostlist_nodes_in_gender(gender)
+        nodeattr("-q #{gender}").chomp
+      end
+
       def genders_for_node(node)
         # If no node passed then it has no groups; without this we would run
         # `nodeattr -l` without args, which would give all groups.


### PR DESCRIPTION
This is the first step at implementing #284. The new `overview` command currently displays details about the group.

From the issue description it was determined that the overview command will be dependent on group answers and quite possible configs in the future. To prevent the core metalware repo from becoming dependent on a set answer structure, the content to be displayed is stored in a new repo file `overview.yaml`.

This `overview.yaml` file currently should contain two arrays: `headers` and `fields`. The headers unsurprisingly are the table headers. The fields array contains a list of strings to populate the overview table. All fields are rendered against the group and are intended to use `ERB` tags.

In the process of completing the PR, a bug was detected in `AlcesUtils`. Up until now, when ever a node or group was mocked, it would be partially set as in "scope". To make matters worse, both a group and node could be partially in scope. Note the `alces.scope` method itself was never mocked.

This made the behaviour of the mocked `alces` inconsistent with the real version. Until now, this hasn't been a problem in the spec as the `scope` wasn't changing within a single test.

To fix this bug, the mocking of scopes has been completely removed. This did require modifying the other specs which had previously used this behaviour. The majority of commits are reasonable small as each spec needed to be updated manually.

The usage of `AlcesUtils` is still fairly clunky. A more streamlined `dsl` for mocking nodes and groups would be ideal at some point in the future.