### PR TITLE
Condense build event output

### DIFF
--- a/src/build_event.rb
+++ b/src/build_event.rb
@@ -82,11 +82,11 @@ module Metalware
       path_arr = file.split(File::SEPARATOR)
       event = path_arr[-1]
       node_str = path_arr[-2]
-      puts "#{node_str}: #{event}"
       content = File.read(file).chomp
-      puts content unless content.empty?
-      puts
       FileUtils.rm file
+      print "#{node_str}: #{event}"
+      print " - #{content}" unless content.empty?
+      puts
     end
   end
 end


### PR DESCRIPTION
Based on #317, please merge it first. Fixes #287 

This branch was going to have multiple fixes, however in the end it only had one. It condenses the output during build to be on a single line. It required a small change to the print method to remove the additional lines.