### PR TITLE
Add an domain overview section/table

### DIFF
--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -6,9 +6,24 @@ require 'alces_utils'
 RSpec.describe Metalware::Commands::Overview do
   include AlcesUtils
 
+  let :overview_yaml do
+    {
+      group: [
+        { header: 'heading1', value: static },
+        { header: 'heading2', value: '<%= group.config.key %>' },
+        { header: 'heading3', value: '' },
+        { header: 'missing-value' },
+        { value: 'missing-header' }
+      ]
+    }
+  end
+  let :static { 'static' }
+  let :headers { overview_yaml[:group].map { |h| h[:header] } }
+
   let :config_value { 'config_value' }
 
   AlcesUtils.mock self, :each do
+    Metalware::Data.dump Metalware::FilePath.overview, overview_yaml
     ['group1', 'group2', 'group3'].map do |group|
       config(mock_group(group), key: config_value)
     end
@@ -36,40 +51,18 @@ RSpec.describe Metalware::Commands::Overview do
     end
   end
 
-  context 'with a mismatch between no. headers/bodies in overview.yaml' do
-    before :each do
-      Metalware::Data.dump(Metalware::FilePath.overview,
-                           headers: ['I', 'have', '4', 'headers'],
-                           fields: ['I', 'have', '5', 'body', 'parts'])
-    end
-
-    it 'errors' do
-      AlcesUtils.redirect_std(:stderr) do
-        expect { overview }.to raise_error(Metalware::DataError)
-      end
+  it 'includes the headers in the table' do
+    headers.each do |h|
+      expect(header).to include(h) unless h.nil?
     end
   end
 
-  context 'with a valid overview.yaml' do
-    let :static { 'static' }
-    let :headers { ['heading1', 'heading2', 'heading3'] }
-    let :fields { [static, '<%= group.config.key %>', ''] }
+  it 'includes the static value in the table' do
+    expect(body).to include(static)
+  end
 
-    before :each do
-      Metalware::Data.dump Metalware::FilePath.overview,
-                           headers: headers, fields: fields
-    end
-
-    it 'includes the headers in the table' do
-      headers.each { |h| expect(header).to include(h) }
-    end
-
-    it 'includes the static field in the table' do
-      expect(body).to include(static)
-    end
-
-    it 'renders the fields' do
-      expect(body).to include(config_value)
-    end
+  it 'renders the values' do
+    expect(body).to include(config_value)
   end
 end
+

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -6,6 +6,16 @@ require 'alces_utils'
 RSpec.shared_context 'mock overview namespaces' do
   include AlcesUtils
   let :config_value { 'config_value' }
+  let :static { 'static' }
+  let :fields do
+    [
+      { header: 'heading1', value: static },
+      { header: 'heading2', value: '<%= scope.config.key %>' },
+      { header: 'heading3', value: '' },
+      { header: 'missing-value' },
+      { value: 'missing-header' }
+    ]
+  end
 
   AlcesUtils.mock self, :each do
     ['group1', 'group2', 'group3'].map do |group|
@@ -17,17 +27,36 @@ end
 RSpec.describe Metalware::Commands::Overview do
   include_context 'mock overview namespaces'
 
+  let :name_hash { { header: 'Group Name', value: '<%= group.name %>' } }
+
   def run_command
     AlcesUtils.redirect_std(:stdout) do
       Metalware::Utils.run_command(Metalware::Commands::Overview)
     end
   end
 
+  def expect_table_with(*inputs)
+    expect(Metalware::Commands::Overview::Table).to \
+      receive(:new).with(*inputs).and_call_original
+  end
+
   context 'without overview.yaml' do
     it 'includes the name in the group table' do
-      name_hash = { header: 'Group Name', value: '<%= group.name %>' }
-      expect(Metalware::Commands::Overview::Table).to \
-        receive(:new).with(alces.groups, [name_hash]).and_call_original
+      expect_table_with alces.groups, [name_hash]
+      run_command
+    end
+  end
+
+  context 'with a overview.yaml' do
+    let :overview_hash { { group: fields } }
+
+    before :each do
+      Metalware::Data.dump Metalware::FilePath.overview, overview_hash
+    end
+
+    it 'includes the group name and additional fields' do
+      combined_fields = [name_hash].concat fields
+      expect_table_with alces.groups, combined_fields
       run_command
     end
   end
@@ -36,15 +65,6 @@ end
 RSpec.describe Metalware::Commands::Overview::Table do
   include_context 'mock overview namespaces'
 
-  let :fields do
-    [
-      { header: 'heading1', value: static },
-      { header: 'heading2', value: '<%= scope.config.key %>' },
-      { header: 'heading3', value: '' },
-      { header: 'missing-value' },
-      { value: 'missing-header' }
-    ]
-  end
   let :namespaces { alces.groups }
 
   let :table do
@@ -59,7 +79,6 @@ RSpec.describe Metalware::Commands::Overview::Table do
     table.lines[3..-2].join("\n")
   end
 
-  let :static { 'static' }
   let :headers { fields.map { |h| h[:header] } }
 
   it 'includes the headers in the table' do

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -3,17 +3,32 @@
 require 'commands'
 require 'alces_utils'
 
-RSpec.describe Metalware::Commands::Overview::Group do
+RSpec.shared_context 'overview setup' do
   include AlcesUtils
 
   let :config_value { 'config_value' }
   let :overview_data { Metalware::Data.load Metalware::FilePath.overview }
+  let :overview_yaml do
+    {
+      group: [
+        { header: 'heading1', value: static },
+        { header: 'heading2', value: '<%= group.config.key %>' },
+        { header: 'heading3', value: '' },
+        { header: 'missing-value' },
+        { value: 'missing-header' }
+      ]
+    }
+  end
 
   AlcesUtils.mock self, :each do
     ['group1', 'group2', 'group3'].map do |group|
       config(mock_group(group), key: config_value)
     end
   end
+end
+
+RSpec.describe Metalware::Commands::Overview::Group do
+  include_context 'overview setup'
 
   let :table do
     Metalware::Commands::Overview::Group.new(alces, overview_data).table.render
@@ -34,17 +49,6 @@ RSpec.describe Metalware::Commands::Overview::Group do
   end
 
   context 'with a configure.yaml' do
-    let :overview_yaml do
-      {
-        group: [
-          { header: 'heading1', value: static },
-          { header: 'heading2', value: '<%= group.config.key %>' },
-          { header: 'heading3', value: '' },
-          { header: 'missing-value' },
-          { value: 'missing-header' }
-        ]
-      }
-    end
     let :static { 'static' }
     let :headers { overview_yaml[:group].map { |h| h[:header] } }
 
@@ -73,5 +77,9 @@ RSpec.describe Metalware::Commands::Overview::Group do
       expect(body).to include(config_value)
     end
   end
+end
+
+RSpec.describe Metalware::Commands::Overview::Group do
+  include_context 'overview setup'
 end
 

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -60,4 +60,3 @@ RSpec.describe Metalware::Commands::Overview do
     end
   end
 end
-

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Metalware::Commands::Overview::Group do
   include AlcesUtils
 
   let :config_value { 'config_value' }
+  let :overview_data { Metalware::Data.load Metalware::FilePath.overview }
 
   AlcesUtils.mock self, :each do
     ['group1', 'group2', 'group3'].map do |group|
@@ -14,8 +15,8 @@ RSpec.describe Metalware::Commands::Overview::Group do
     end
   end
 
-  def table
-    Metalware::Commands::Overview::Group.new(alces).table.render
+  let :table do
+    Metalware::Commands::Overview::Group.new(alces, overview_data).table.render
   end
 
   def header

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -6,24 +6,9 @@ require 'alces_utils'
 RSpec.describe Metalware::Commands::Overview do
   include AlcesUtils
 
-  let :overview_yaml do
-    {
-      group: [
-        { header: 'heading1', value: static },
-        { header: 'heading2', value: '<%= group.config.key %>' },
-        { header: 'heading3', value: '' },
-        { header: 'missing-value' },
-        { value: 'missing-header' }
-      ]
-    }
-  end
-  let :static { 'static' }
-  let :headers { overview_yaml[:group].map { |h| h[:header] } }
-
   let :config_value { 'config_value' }
 
   AlcesUtils.mock self, :each do
-    Metalware::Data.dump Metalware::FilePath.overview, overview_yaml
     ['group1', 'group2', 'group3'].map do |group|
       config(mock_group(group), key: config_value)
     end
@@ -44,25 +29,51 @@ RSpec.describe Metalware::Commands::Overview do
     overview.lines[3..-2].join("\n")
   end
 
-  it 'includes the group names' do
-    expect(header).to include('Group')
-    alces.groups.each do |group|
-      expect(body).to include(group.name)
+  context 'without a configure.yaml' do
+    it 'does not error' do
+      expect { overview }.not_to raise_error
     end
   end
 
-  it 'includes the headers in the table' do
-    headers.each do |h|
-      expect(header).to include(h) unless h.nil?
+  context 'with a configure.yaml' do
+    let :overview_yaml do
+      {
+        group: [
+          { header: 'heading1', value: static },
+          { header: 'heading2', value: '<%= group.config.key %>' },
+          { header: 'heading3', value: '' },
+          { header: 'missing-value' },
+          { value: 'missing-header' }
+        ]
+      }
     end
-  end
+    let :static { 'static' }
+    let :headers { overview_yaml[:group].map { |h| h[:header] } }
 
-  it 'includes the static value in the table' do
-    expect(body).to include(static)
-  end
+    before :each do
+      Metalware::Data.dump Metalware::FilePath.overview, overview_yaml
+    end
 
-  it 'renders the values' do
-    expect(body).to include(config_value)
+    it 'includes the group names' do
+      expect(header).to include('Group')
+      alces.groups.each do |group|
+        expect(body).to include(group.name)
+      end
+    end
+
+    it 'includes the headers in the table' do
+      headers.each do |h|
+        expect(header).to include(h) unless h.nil?
+      end
+    end
+
+    it 'includes the static value in the table' do
+      expect(body).to include(static)
+    end
+
+    it 'renders the values' do
+      expect(body).to include(config_value)
+    end
   end
 end
 

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -3,35 +3,29 @@
 require 'commands'
 require 'alces_utils'
 
-RSpec.shared_context 'overview setup' do
+RSpec.describe Metalware::Commands::Overview::Table do
   include AlcesUtils
 
   let :config_value { 'config_value' }
-  let :overview_data { Metalware::Data.load Metalware::FilePath.overview }
-  let :overview_yaml do
-    {
-      group: [
-        { header: 'heading1', value: static },
-        { header: 'heading2', value: '<%= group.config.key %>' },
-        { header: 'heading3', value: '' },
-        { header: 'missing-value' },
-        { value: 'missing-header' }
-      ]
-    }
+  let :fields do
+    [
+      { header: 'heading1', value: static },
+      { header: 'heading2', value: '<%= scope.config.key %>' },
+      { header: 'heading3', value: '' },
+      { header: 'missing-value' },
+      { value: 'missing-header' }
+    ]
   end
+  let :namespaces { alces.groups }
 
   AlcesUtils.mock self, :each do
     ['group1', 'group2', 'group3'].map do |group|
       config(mock_group(group), key: config_value)
     end
   end
-end
-
-RSpec.describe Metalware::Commands::Overview::Group do
-  include_context 'overview setup'
 
   let :table do
-    Metalware::Commands::Overview::Group.new(alces, overview_data).table.render
+    Metalware::Commands::Overview::Table.new(namespaces, fields).render
   end
 
   def header
@@ -42,44 +36,30 @@ RSpec.describe Metalware::Commands::Overview::Group do
     table.lines[3..-2].join("\n")
   end
 
-  context 'without a configure.yaml' do
-    it 'does not error' do
-      expect { table }.not_to raise_error
+  let :static { 'static' }
+  let :headers { fields.map { |h| h[:header] } }
+
+  # TODO: Make a Commands::Overview spec and move this into it
+  # This no longer is applicable here
+  xit 'includes the group names' do
+    expect(header).to include('Group')
+    alces.groups.each do |group|
+      expect(body).to include(group.name)
     end
   end
 
-  context 'with a configure.yaml' do
-    let :static { 'static' }
-    let :headers { overview_yaml[:group].map { |h| h[:header] } }
-
-    before :each do
-      Metalware::Data.dump Metalware::FilePath.overview, overview_yaml
-    end
-
-    it 'includes the group names' do
-      expect(header).to include('Group')
-      alces.groups.each do |group|
-        expect(body).to include(group.name)
-      end
-    end
-
-    it 'includes the headers in the table' do
-      headers.each do |h|
-        expect(header).to include(h) unless h.nil?
-      end
-    end
-
-    it 'includes the static value in the table' do
-      expect(body).to include(static)
-    end
-
-    it 'renders the values' do
-      expect(body).to include(config_value)
+  it 'includes the headers in the table' do
+    headers.each do |h|
+      expect(header).to include(h) unless h.nil?
     end
   end
-end
 
-RSpec.describe Metalware::Commands::Overview::Group do
-  include_context 'overview setup'
+  it 'includes the static value in the table' do
+    expect(body).to include(static)
+  end
+
+  it 'renders the values' do
+    expect(body).to include(config_value)
+  end
 end
 

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -58,7 +58,12 @@ RSpec.describe Metalware::Commands::Overview do
   end
 
   context 'with a overview.yaml' do
-    let :overview_hash { { group: fields } }
+    let :overview_hash do
+      {
+        domain: [{ header: 'h1', value: 'v1' }, { header: 'h2', value: 'v2' }],
+        group: fields,
+      }
+    end
 
     before :each do
       Metalware::Data.dump Metalware::FilePath.overview, overview_hash
@@ -67,6 +72,11 @@ RSpec.describe Metalware::Commands::Overview do
     it 'includes the group name and additional fields' do
       combined_fields = [name_hash].concat fields
       expect_table_with alces.groups, combined_fields
+      run_command
+    end
+
+    it 'includes the additional domain table fields' do
+      expect_table_with [alces.domain], overview_hash[:domain]
       run_command
     end
   end

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -3,7 +3,7 @@
 require 'commands'
 require 'alces_utils'
 
-RSpec.describe Metalware::Commands::Overview do
+RSpec.describe Metalware::Commands::Overview::Group do
   include AlcesUtils
 
   let :config_value { 'config_value' }
@@ -14,24 +14,21 @@ RSpec.describe Metalware::Commands::Overview do
     end
   end
 
-  def overview
-    std = AlcesUtils.redirect_std(:stdout) do
-      Metalware::Utils.run_command(Metalware::Commands::Overview)
-    end
-    std[:stdout].read
+  def table
+    Metalware::Commands::Overview::Group.new(alces).table.render
   end
 
   def header
-    overview.lines[1]
+    table.lines[1]
   end
 
   def body
-    overview.lines[3..-2].join("\n")
+    table.lines[3..-2].join("\n")
   end
 
   context 'without a configure.yaml' do
     it 'does not error' do
-      expect { overview }.not_to raise_error
+      expect { table }.not_to raise_error
     end
   end
 

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -35,14 +35,24 @@ RSpec.describe Metalware::Commands::Overview do
     end
   end
 
+  before :each do
+    allow(Metalware::Commands::Overview::Table).to \
+      receive(:new).with(any_args).and_call_original
+  end
+
   def expect_table_with(*inputs)
     expect(Metalware::Commands::Overview::Table).to \
-      receive(:new).with(*inputs).and_call_original
+      receive(:new).once.with(*inputs).and_call_original
   end
 
   context 'without overview.yaml' do
     it 'includes the name in the group table' do
       expect_table_with alces.groups, [name_hash]
+      run_command
+    end
+
+    it 'makes an empty domain table' do
+      expect_table_with [alces.domain], []
       run_command
     end
   end

--- a/spec/fixtures/shared_context/overview.rb
+++ b/spec/fixtures/shared_context/overview.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal
+# frozen_string_literal: true
 
 require 'alces_utils'
 
@@ -13,7 +13,7 @@ RSpec.shared_context 'overview context' do
       { header: 'heading2', value: '<%= scope.config.key %>' },
       { header: 'heading3', value: '' },
       { header: 'missing-value' },
-      { value: 'missing-header' }
+      { value: 'missing-header' },
     ]
   end
 
@@ -23,4 +23,3 @@ RSpec.shared_context 'overview context' do
     end
   end
 end
-

--- a/spec/fixtures/shared_context/overview.rb
+++ b/spec/fixtures/shared_context/overview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal
+
+require 'alces_utils'
+
+RSpec.shared_context 'overview context' do
+  include AlcesUtils
+
+  let :config_value { 'config_value' }
+  let :static { 'static' }
+  let :fields do
+    [
+      { header: 'heading1', value: static },
+      { header: 'heading2', value: '<%= scope.config.key %>' },
+      { header: 'heading3', value: '' },
+      { header: 'missing-value' },
+      { value: 'missing-header' }
+    ]
+  end
+
+  AlcesUtils.mock self, :each do
+    ['group1', 'group2', 'group3'].map do |group|
+      config(mock_group(group), key: config_value)
+    end
+  end
+end
+

--- a/spec/overview/table_spec.rb
+++ b/spec/overview/table_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'overview/table'
+require 'fixtures/shared_context/overview'
+
+RSpec.describe Metalware::Overview::Table do
+  include_context 'overview context'
+
+  let :namespaces { alces.groups }
+
+  let :table do
+    Metalware::Overview::Table.new(namespaces, fields).render
+  end
+
+  def header
+    table.lines[1]
+  end
+
+  def body
+    table.lines[3..-2].join("\n")
+  end
+
+  let :headers { fields.map { |h| h[:header] } }
+
+  it 'includes the headers in the table' do
+    headers.each do |h|
+      expect(header).to include(h) unless h.nil?
+    end
+  end
+
+  it 'includes the static value in the table' do
+    expect(body).to include(static)
+  end
+
+  it 'renders the values' do
+    expect(body).to include(config_value)
+  end
+end
+

--- a/spec/overview/table_spec.rb
+++ b/spec/overview/table_spec.rb
@@ -36,4 +36,3 @@ RSpec.describe Metalware::Overview::Table do
     expect(body).to include(config_value)
   end
 end
-

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -70,7 +70,14 @@ module Metalware
       end
 
       def run
-        puts Group.new(alces, overview_data).table
+        print_groups_table
+      end
+
+      def print_groups_table
+        fields_from_yaml = []
+        name_field = { header: 'Group Name', value: '<%= group.name %>' }
+        fields = [name_field].concat fields_from_yaml
+        puts Table.new(alces.groups, fields).render
       end
     end
   end

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -33,6 +33,9 @@ module Metalware
       attr_reader :overview_data
 
       def setup
+        unless File.exist? FilePath.overview
+          MetalLog.warn 'overview.yaml is missing from the repo'
+        end
         @overview_data = Data.load FilePath.overview
       end
 

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -27,45 +27,36 @@ require 'terminal-table'
 module Metalware
   module Commands
     class Overview < CommandHelpers::BaseCommand
-      class Domain
-        attr_reader :alces
+      class Table
+        attr_reader :fields
+        attr_reader :namespaces
 
-        def initialize(alces, overview_data)
-          @alces = alces
-        end
-      end
-
-      class Group
-        attr_reader :display
-        attr_reader :alces
-
-        def initialize(alces, overview_data)
-          @alces = alces
-          raw = { group: [] }.merge(overview_data)
-          @display = OpenStruct.new(
-            headers: raw[:group].map { |h| h[:header] || '' },
-            values: raw[:group].map { |h| h[:value] || '' }
-          )
+        def initialize(namespaces, fields)
+          @fields = fields
+          @namespaces = namespaces
         end
 
-        def table
-          Terminal::Table.new(headings: headings, rows: rows)
+        def render
+          Terminal::Table.new(headings: headers, rows: rows).render
         end
 
         private
 
-        def headings
-          ['Group'].concat display.headers
+        def headers
+          fields.map { |f| f[:header] }
+        end
+
+        def unrendered_values
+          fields.map { |f| f[:value] || '' }
         end
 
         def rows
-          alces.groups.map { |group| row(group) }
+          namespaces.map { |namespace| row(namespace) }
         end
 
-        def row(group)
-          name = '<%= group.name %>'
-          ([name].concat display.values).map do |value|
-            group.render_erb_template(value)
+        def row(namespace)
+          unrendered_values.map do |value|
+            namespace.render_erb_template(value)
           end
         end
       end

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -34,7 +34,7 @@ module Metalware
       attr_reader :display_group
 
       def setup
-        raw = Data.load FilePath.overview
+        raw = { group: [] }.merge(Data.load FilePath.overview)
         @display_group = OpenStruct.new(
           headers: raw[:group].map { |h| h[:header] || '' },
           values: raw[:group].map { |h| h[:value] || '' }
@@ -62,3 +62,4 @@ module Metalware
     end
   end
 end
+

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -75,7 +75,8 @@ module Metalware
       end
 
       def print_domain_table
-        puts Table.new([alces.domain], []).render
+        fields = overview_data[:domain] || []
+        puts Table.new([alces.domain], fields).render
       end
 
       def print_groups_table

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -27,13 +27,21 @@ require 'terminal-table'
 module Metalware
   module Commands
     class Overview < CommandHelpers::BaseCommand
+      class Domain
+        attr_reader :alces
+
+        def initialize(alces, overview_data)
+          @alces = alces
+        end
+      end
+
       class Group
         attr_reader :display
         attr_reader :alces
 
-        def initialize(alces)
+        def initialize(alces, overview_data)
           @alces = alces
-          raw = { group: [] }.merge(Data.load FilePath.overview)
+          raw = { group: [] }.merge(overview_data)
           @display = OpenStruct.new(
             headers: raw[:group].map { |h| h[:header] || '' },
             values: raw[:group].map { |h| h[:value] || '' }
@@ -64,12 +72,14 @@ module Metalware
 
       private
 
-      attr_reader :element
+      attr_reader :overview_data
 
-      def setup; end
+      def setup
+        @overview_data = Data.load FilePath.overview
+      end
 
       def run
-        puts Group.new(alces).table
+        puts Group.new(alces, overview_data).table
       end
     end
   end

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -29,8 +29,6 @@ module Metalware
     class Overview < CommandHelpers::BaseCommand
       private
 
-      OVERVIEW_ERROR = 'Can not construct table from overview.yaml'
-
       attr_reader :display_group
 
       def setup

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -70,7 +70,12 @@ module Metalware
       end
 
       def run
+        print_domain_table
         print_groups_table
+      end
+
+      def print_domain_table
+        puts Table.new([alces.domain], []).render
       end
 
       def print_groups_table

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -55,4 +55,3 @@ module Metalware
     end
   end
 end
-

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -74,7 +74,7 @@ module Metalware
       end
 
       def print_groups_table
-        fields_from_yaml = []
+        fields_from_yaml = overview_data[:group] || []
         name_field = { header: 'Group Name', value: '<%= group.name %>' }
         fields = [name_field].concat fields_from_yaml
         puts Table.new(alces.groups, fields).render

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -23,44 +23,11 @@
 #==============================================================================
 
 require 'terminal-table'
+require 'overview/table'
 
 module Metalware
   module Commands
     class Overview < CommandHelpers::BaseCommand
-      class Table
-        attr_reader :fields
-        attr_reader :namespaces
-
-        def initialize(namespaces, fields)
-          @fields = fields
-          @namespaces = namespaces
-        end
-
-        def render
-          Terminal::Table.new(headings: headers, rows: rows).render
-        end
-
-        private
-
-        def headers
-          fields.map { |f| f[:header] }
-        end
-
-        def unrendered_values
-          fields.map { |f| f[:value] || '' }
-        end
-
-        def rows
-          namespaces.map { |namespace| row(namespace) }
-        end
-
-        def row(namespace)
-          unrendered_values.map do |value|
-            namespace.render_erb_template(value)
-          end
-        end
-      end
-
       private
 
       attr_reader :overview_data
@@ -76,14 +43,14 @@ module Metalware
 
       def print_domain_table
         fields = overview_data[:domain] || []
-        puts Table.new([alces.domain], fields).render
+        puts Metalware::Overview::Table.new([alces.domain], fields).render
       end
 
       def print_groups_table
         fields_from_yaml = overview_data[:group] || []
         name_field = { header: 'Group Name', value: '<%= group.name %>' }
         fields = [name_field].concat fields_from_yaml
-        puts Table.new(alces.groups, fields).render
+        puts Metalware::Overview::Table.new(alces.groups, fields).render
       end
     end
   end

--- a/src/namespaces/group.rb
+++ b/src/namespaces/group.rb
@@ -31,7 +31,7 @@ module Metalware
       private
 
       def white_list_for_hasher
-        super.concat([:index, :nodes])
+        super.concat([:index, :nodes, :hostlist_nodes])
       end
 
       def hash_merger_input

--- a/src/nodeattr_interface.rb
+++ b/src/nodeattr_interface.rb
@@ -41,7 +41,6 @@ module Metalware
         stdout.chomp.split(',')
       end
 
-
       # The hostlist notation is: nodeA[01-10],nodeB
       def hostlist_nodes_in_gender(gender)
         nodeattr("-q #{gender}").chomp

--- a/src/nodeattr_interface.rb
+++ b/src/nodeattr_interface.rb
@@ -41,6 +41,8 @@ module Metalware
         stdout.chomp.split(',')
       end
 
+
+      # The hostlist notation is: nodeA[01-10],nodeB
       def hostlist_nodes_in_gender(gender)
         nodeattr("-q #{gender}").chomp
       end

--- a/src/overview/table.rb
+++ b/src/overview/table.rb
@@ -37,4 +37,3 @@ module Metalware
     end
   end
 end
-

--- a/src/overview/table.rb
+++ b/src/overview/table.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Metalware
+  module Overview
+    class Table
+      attr_reader :fields
+      attr_reader :namespaces
+
+      def initialize(namespaces, fields)
+        @fields = fields
+        @namespaces = namespaces
+      end
+
+      def render
+        Terminal::Table.new(headings: headers, rows: rows).render
+      end
+
+      private
+
+      def headers
+        fields.map { |f| f[:header] }
+      end
+
+      def unrendered_values
+        fields.map { |f| f[:value] || '' }
+      end
+
+      def rows
+        namespaces.map { |namespace| row(namespace) }
+      end
+
+      def row(namespace)
+        unrendered_values.map do |value|
+          namespace.render_erb_template(value)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This PR address the issues highlighted in #316 and adds the last few features that fixes #284.

The structure for `overview.yaml` has been updated to use a single array of hashes. This allows the `header` and `value` to be set together and thus prevents issues with length miss-matches. The validation has thus been removed because it will not cause an error anymore.

Instead, if any field is missing, it will be rendered as an empty string. This should make it more flexible to add an removed columns without having to do it all at once.

A domain table has also been added which contains a single row that is rendered in the `domain` scope. Otherwise the table operates in almost the exact same way as the group table with the exception it does not have a name column. To do this, the table generation code has been generalised into a separate class. This makes testing the command easier.