### PR TITLE
Fix/ipmi genders

### DIFF
--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -63,11 +63,16 @@ RSpec.describe Metalware::Commands::Ipmi do
       end
     end
 
-    context 'when run for group' do
+    shared_examples 'runs on each node' do
       it 'runs given ipmi command on each node' do
         node_names.each { |name| expect_ipmi_cmd(name) }
-        run_ipmi('nodes', 'sel list', gender: true)
+        run_ipmi(test_gender, 'sel list', gender: true)
       end
+    end
+
+    context 'when run for group' do
+      let :test_gender { group }
+      include_examples 'runs on each node'
     end
   end
 end

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Metalware::Commands::Ipmi do
 
     let :node_names { ['node01', 'node02', 'node03'] }
     let :group { 'nodes' }
+    let :gender { 'my_super_awesome_gender' }
     let :namespace_config do
       {
         networks: {
@@ -34,8 +35,9 @@ RSpec.describe Metalware::Commands::Ipmi do
 
     AlcesUtils.mock self, :each do
       config(mock_group(group), namespace_config)
-      node_names.each do |node|
-        config(mock_node(node, group), namespace_config)
+      node_names.each do |name|
+        node = mock_node(name, group, gender)
+        config(node, namespace_config)
       end
     end
 

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Metalware::Commands::Ipmi do
     end
   end
 
-  describe 'when run on bare metal' do
+  context 'when run on bare metal' do
     # XXX The setup for these tests is duplicated from those for power; should
     # DRY this up.
 
@@ -48,7 +48,7 @@ RSpec.describe Metalware::Commands::Ipmi do
         receive(:run).with(*with_args).and_call_original
     end
 
-    describe 'when run for node' do
+    context 'when run for node' do
       it 'runs given ipmi command on node' do
         expect(Metalware::SystemCommand).to receive(:run).once.with(
           'ipmitool -H node01.bmc -I lanplus -U bmcuser -P bmcpassword sel list'
@@ -58,7 +58,7 @@ RSpec.describe Metalware::Commands::Ipmi do
       end
     end
 
-    describe 'when run for group' do
+    context 'when run for group' do
       it 'runs given ipmi command on each node' do
         node_names.each do |name|
           expect(Metalware::SystemCommand).to receive(:run).with(

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -74,5 +74,10 @@ RSpec.describe Metalware::Commands::Ipmi do
       let :test_gender { group }
       include_examples 'runs on each node'
     end
+
+    context 'when run for a gender' do
+      let :test_gender { gender }
+      include_examples 'runs on each node'
+    end
   end
 end

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -45,6 +45,7 @@ module Metalware
         # `ipmitool`, but in Ipmi and Power we use `$node_name.bmc` - is there
         # any reason for this? Does this have any different effect?
         create_ipmitool_command(
+          node,
           host: node.name,
           arguments: "-e '&' sol #{type}"
         )

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -60,10 +60,10 @@ module Metalware
       end
 
       def create_ipmitool_command(node, host:, arguments:)
-        <<~ECMD.squish
+        <<~COMMAND.squish
           ipmitool -H #{host} -I lanplus #{render_credentials(node)}
           #{arguments}
-        ECMD
+        COMMAND
       end
 
       def command_argument

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -51,18 +51,14 @@ module Metalware
       end
 
       def run_baremetal(node)
-        puts "#{node.name}: #{SystemCommand.run(ipmi_command(node.name))}"
+        puts "#{node.name}: #{SystemCommand.run(ipmi_command(node))}"
       end
 
-      def ipmi_command(node_name)
-        create_ipmitool_command(
-          host: "#{node_name}.bmc",
-          arguments: command_argument
-        )
-      end
-
-      def create_ipmitool_command(host:, arguments:)
-        "ipmitool -H #{host} -I lanplus #{render_credentials} #{arguments}"
+      def ipmi_command(node)
+        <<~EOF.squish
+          ipmitool -H #{node.name}.bmc -I lanplus #{render_credentials}
+          #{command_argument}
+        EOF
       end
 
       def command_argument

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -56,8 +56,8 @@ module Metalware
 
       def ipmi_command(node)
         <<~EOF.squish
-          ipmitool -H #{node.name}.bmc -I lanplus #{render_credentials}
-          #{command_argument}
+          ipmitool -H #{node.name}.bmc -I lanplus
+          #{render_credentials(node)} #{command_argument}
         EOF
       end
 
@@ -65,10 +65,9 @@ module Metalware
         args[1]
       end
 
-      def render_credentials
-        object = options.gender ? group : node
-        raise MetalwareError, "BMC network not defined for #{object.name}" unless object.config.networks.bmc.defined
-        bmc_config = object.config.networks.bmc
+      def render_credentials(node)
+        bmc_config = node.config&.networks&.bmc
+        raise MetalwareError, "BMC network not defined for #{node.name}" unless bmc_config&.defined
         "-U #{bmc_config.bmcuser} -P #{bmc_config.bmcpassword}"
       end
 

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -55,10 +55,10 @@ module Metalware
       end
 
       def ipmi_command(node)
-        <<~EOF.squish
+        <<~ECMD.squish
           ipmitool -H #{node.name}.bmc -I lanplus
           #{render_credentials(node)} #{command_argument}
-        EOF
+        ECMD
       end
 
       def command_argument

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -55,9 +55,14 @@ module Metalware
       end
 
       def ipmi_command(node)
+        opt = { host: "#{node.name}.bmc", arguments: command_argument }
+        create_ipmitool_command(node, **opt)
+      end
+
+      def create_ipmitool_command(node, host:, arguments:)
         <<~ECMD.squish
-          ipmitool -H #{node.name}.bmc -I lanplus
-          #{render_credentials(node)} #{command_argument}
+          ipmitool -H #{host} -I lanplus #{render_credentials(node)}
+          #{arguments}
         ECMD
       end
 

--- a/src/commands/power.rb
+++ b/src/commands/power.rb
@@ -29,9 +29,10 @@ module Metalware
     class Power < Ipmi
       private
 
-      def ipmi_command(node_name)
+      def ipmi_command(node)
         create_ipmitool_command(
-          host: "#{node_name}.bmc",
+          node,
+          host: "#{node.name}.bmc",
           arguments: ipmi_command_arguments
         )
       end


### PR DESCRIPTION
Fixes #323 

The reason why `ipmi` (and thus `power`) did not work with secondary gender groups is becomes of how the credentials where being rendered. It was still assuming that the nodes where in a group and would have a `group.config` containing the `bmc` password.

As genders do not have `config`s, this approach is no longer feasible. Instead, the credentials need to be rendered individually for each node. This should allow it to work in all situations.

The remaining commits clean up to code and the spec.