### PR TITLE
Fix wrong host being used for `metal console`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ watch-rsync:
 		--name 'Metalware' \
 		--pattern '**/*' \
 		--exit \
+		--no-notify \
 		make rsync
 
 # Note: need to become root for Metalware; -t option allows coloured output.

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe Metalware::Commands::Console do
     describe 'when run for node' do
       it 'runs console info then activate commands for node' do
         expect(Metalware::SystemCommand).to receive(:run).with(
-          "ipmitool -H node01 -I lanplus -U bmcuser -P bmcpassword -e '&' sol info"
+          "ipmitool -H node01.bmc -I lanplus -U bmcuser -P bmcpassword -e '&' sol info"
         ).ordered.and_return(true)
         expect_any_instance_of(
           Metalware::Commands::Console
         ).to receive(:system).with(
-          "ipmitool -H node01 -I lanplus -U bmcuser -P bmcpassword -e '&' sol activate"
+          "ipmitool -H node01.bmc -I lanplus -U bmcuser -P bmcpassword -e '&' sol activate"
         )
 
         run_console('node01')

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -41,7 +41,7 @@ module Metalware
       end
 
       def console_command(type)
-        create_ipmitool_command(node, arguments: "-e '&' sol #{type}")
+        ipmi_command(node, arguments: "-e '&' sol #{type}")
       end
     end
   end

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -41,11 +41,7 @@ module Metalware
       end
 
       def console_command(type)
-        create_ipmitool_command(
-          node,
-          host: "#{node.name}.bmc",
-          arguments: "-e '&' sol #{type}"
-        )
+        create_ipmitool_command(node, arguments: "-e '&' sol #{type}")
       end
     end
   end

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -41,12 +41,9 @@ module Metalware
       end
 
       def console_command(type)
-        # XXX In Console we use `$node_name` as the host when running
-        # `ipmitool`, but in Ipmi and Power we use `$node_name.bmc` - is there
-        # any reason for this? Does this have any different effect?
         create_ipmitool_command(
           node,
-          host: node.name,
+          host: "#{node.name}.bmc",
           arguments: "-e '&' sol #{type}"
         )
       end

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -55,13 +55,12 @@ module Metalware
       end
 
       def ipmi_command(node)
-        opt = { host: "#{node.name}.bmc", arguments: command_argument }
-        create_ipmitool_command(node, **opt)
+        create_ipmitool_command(node,  arguments: command_argument)
       end
 
-      def create_ipmitool_command(node, host:, arguments:)
+      def create_ipmitool_command(node, arguments:)
         <<~COMMAND.squish
-          ipmitool -H #{host} -I lanplus #{render_credentials(node)}
+          ipmitool -H #{node.name}.bmc -I lanplus #{render_credentials(node)}
           #{arguments}
         COMMAND
       end

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -51,14 +51,11 @@ module Metalware
       end
 
       def run_baremetal(node)
-        puts "#{node.name}: #{SystemCommand.run(ipmi_command(node))}"
+        command = ipmi_command(node, arguments: ipmi_command_arguments)
+        puts "#{node.name}: #{SystemCommand.run(command)}"
       end
 
-      def ipmi_command(node)
-        create_ipmitool_command(node,  arguments: command_argument)
-      end
-
-      def create_ipmitool_command(node, arguments:)
+      def ipmi_command(node, arguments:)
         <<~COMMAND.squish
           ipmitool -H #{node.name}.bmc -I lanplus #{render_credentials(node)}
           #{arguments}
@@ -68,6 +65,11 @@ module Metalware
       def command_argument
         args[1]
       end
+
+      # By default the arguments passed to `ipmitool` are the same as the
+      # argument passed to the `metal` command, but this may be overridden by
+      # commands descended from this.
+      alias ipmi_command_arguments command_argument
 
       def render_credentials(node)
         bmc_config = node.config&.networks&.bmc

--- a/src/commands/overview.rb
+++ b/src/commands/overview.rb
@@ -33,9 +33,7 @@ module Metalware
       attr_reader :overview_data
 
       def setup
-        unless File.exist? FilePath.overview
-          MetalLog.warn 'overview.yaml is missing from the repo'
-        end
+        MetalLog.warn 'overview.yaml is missing from the repo' unless File.exist? FilePath.overview
         @overview_data = Data.load FilePath.overview
       end
 

--- a/src/commands/power.rb
+++ b/src/commands/power.rb
@@ -30,11 +30,7 @@ module Metalware
       private
 
       def ipmi_command(node)
-        create_ipmitool_command(
-          node,
-          host: "#{node.name}.bmc",
-          arguments: ipmi_command_arguments
-        )
+        create_ipmitool_command(node, arguments: ipmi_command_arguments)
       end
 
       def ipmi_command_arguments

--- a/src/commands/power.rb
+++ b/src/commands/power.rb
@@ -29,10 +29,6 @@ module Metalware
     class Power < Ipmi
       private
 
-      def ipmi_command(node)
-        create_ipmitool_command(node, arguments: ipmi_command_arguments)
-      end
-
       def ipmi_command_arguments
         case command_argument
         when 'on'


### PR DESCRIPTION
This PR fixes #326 (see 
https://github.com/alces-software/metalware/commit/5f001c04d0e9b617e146089d962e30986de53a50 for the main fix). Some related refactoring enabled by the `ipmi`-descended commands now being more similar is also included.