### PR TITLE
Fix re-prompting for boolean questions on initial configure

### DIFF
--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -340,6 +340,22 @@ RSpec.describe Metalware::Configurator do
       expect(output.read.scan(/\?/).count).to eq(2)
     end
 
+    it 're-prompts for answer to boolean questions until valid answer given' do
+      define_questions(domain: [
+                         {
+                           identifier: 'boolean_q',
+                           type: 'boolean',
+                           question: 'Boolean question',
+                         },
+                       ])
+
+      configure_with_answers(['foo', 'yes'])
+
+      # Should be `true` (from the `yes`) rather than `false`, which 'foo' was
+      # previously accepted and interpreted as.
+      expect(answers).to eq(boolean_q: true)
+    end
+
     it 'allows optional questions to have empty answers' do
       define_questions(domain: [
                          {

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Metalware::Configurator do
                          },
                        ])
 
-      configure_with_answers(['foo', 1, true])
+      configure_with_answers(['foo', 1, 'yes'])
 
       output.rewind
       output_lines = output.read.split("\n")

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -276,10 +276,20 @@ module Metalware
 
           if default_input
             highline_question.default = default_input
-          elsif answer_required?
+          elsif validate_answer_given?
             highline_question.validate = ensure_answer_given
           end
         end
+      end
+
+      def validate_answer_given?
+        # Do not override built-in HighLine validation for `agree` questions,
+        # which will already cause the question to be re-prompted until a valid
+        # answer is given (rather than just accepting any non-empty answer, as
+        # our `ensure_answer_given` does).
+        return false if type == :boolean
+
+        answer_required?
       end
 
       # Whether an answer to this question is required at this level; an answer


### PR DESCRIPTION
Fixes #329; see https://github.com/alces-software/metalware/commit/e132297b76a087bc843a03c906dffb728e8316dc for details of issue and fix.