### PR TITLE
Allow the spec version of `alces` to be reset

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -172,8 +172,6 @@ module AlcesUtils
       raise_if_node_exists(name)
       add_node_to_genders_file(name, *genders)
       Metalware::Namespaces::Node.create(alces, name).tap do |node|
-        with_blank_config_and_answer(node)
-        hexadecimal_ip(node)
         new_nodes = alces.nodes.reduce([node], &:push)
         metal_nodes = Metalware::Namespaces::MetalArray.new(new_nodes)
         allow(alces).to receive(:nodes).and_return(metal_nodes)
@@ -186,7 +184,6 @@ module AlcesUtils
       alces.instance_variable_set(:@groups, nil)
       alces.instance_variable_set(:@group_cache, nil)
       group = alces.groups.find_by_name(name)
-      with_blank_config_and_answer(group)
       group
     end
 

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -25,7 +25,10 @@ module AlcesUtils
 
         # `alces` is defined as a method so it can be reset
         define_method :alces { Metalware::Namespaces::Alces.new }
-        define_method :reset_alces { @spec_alces = nil }
+        define_method :reset_alces do
+          @spec_alces = nil
+          alces
+        end
 
         #
         # Mocks nodeattr to use faked genders file

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -204,6 +204,11 @@ RSpec.describe AlcesUtils do
         new_alces = Metalware::Namespaces::Alces.new
         expect(new_alces).to eq(alces)
       end
+
+      it 'returns the new version of alces' do
+        return_from_reset_alces = reset_alces
+        expect(return_from_reset_alces).to eq(alces)
+      end
     end
   end
 

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -119,10 +119,6 @@ RSpec.describe AlcesUtils do
         expect(alces.groups.send(group2).name).to eq(group2)
       end
 
-      it 'sets the config to blank' do
-        expect(alces.groups.send(group).config.to_h).to be_empty
-      end
-
       # The mocking would otherwise alter the actual file
       it 'errors if FakeFS is off' do
         FakeFS.deactivate!
@@ -157,11 +153,6 @@ RSpec.describe AlcesUtils do
 
       it 'adds the node to default test group' do
         expect(alces.node.genders).to eq([AlcesUtils.default_group])
-      end
-
-      it 'creates the node with a blank config and answer' do
-        expect(alces.node.config.to_h).to be_empty
-        expect(alces.node.answer.to_h).to be_empty
       end
 
       it 'errors if the node already exists' do

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -182,6 +182,29 @@ RSpec.describe AlcesUtils do
         end
       end
     end
+
+    describe '#reset_alces' do
+      before :each do
+        @old_alces = alces
+        AlcesUtils.mock(self) do
+          config(alces.domain, key: 'I should be deleted in the reset')
+        end
+        reset_alces
+      end
+
+      it 'resets alces to a new instance' do
+        expect(alces).not_to eq(@old_alces)
+      end
+
+      it 'removes the old config mocking' do
+        expect(alces.domain.config.keys).to be_nil
+      end
+
+      it 'sets the Alces.new method to return the new alces object' do
+        new_alces = Metalware::Namespaces::Alces.new
+        expect(new_alces).to eq(alces)
+      end
+    end
   end
 
   describe '#redirect_std' do


### PR DESCRIPTION
This allows the mocked version of alces to be reset in the spec. Typically this shouldn't be needed in most cases as only one version of alces exists. However if the command being tested changes a file used to generate `alces`, then it can't be reloaded from within the `spec`.

This change allows greater control over what is being mocked. Please note, any mocked nodes and groups will still exist as they alter the `genders` and `group_cache` files. However mocked `config` and `answer` will be reset as this is done the `alces` object itself.