### PR TITLE
Fix/simplify defaults

### DIFF
--- a/spec/hash_mergers/answer_spec.rb
+++ b/spec/hash_mergers/answer_spec.rb
@@ -1,0 +1,105 @@
+
+# frozen_string_literal: true
+
+require 'hash_mergers'
+require 'alces_utils'
+require 'data'
+require 'file_path'
+
+RSpec.describe Metalware::HashMergers::Answer do
+  include AlcesUtils
+
+  let :group { AlcesUtils.mock(self) { mock_group('new_group') } }
+  let :node do
+    AlcesUtils.mock(self) { mock_node('new_node', group.name) }
+  end
+
+  let :identifier { :question_identifier }
+  let :questions do
+    {
+      domain: [{
+        identifier: identifier.to_s,
+        question: 'Ask domain question?',
+        default: 'domain-default',
+      }],
+      group: [{
+        identifier: identifier.to_s,
+        question: 'Ask group question?',
+        default: 'group-default', # Should be ignored
+      }],
+      node: [{
+        identifier: identifier.to_s,
+        question: 'Ask node question?',
+        default: 'node-default', # Should be ignored
+      }],
+      local: []
+    }
+  end
+
+  def answers(namespace)
+    case namespace
+    when Metalware::Namespaces::Domain
+      'domain_answer'
+    when Metalware::Namespaces::Group
+      'group_answer'
+    when Metalware::Namespaces::Node
+      'node_answer'
+    else
+      raise 'unexpected error'
+    end
+  end
+
+  before :each do
+    Metalware::Data.dump Metalware::FilePath.configure_file, questions
+  end
+
+  shared_examples 'run contexts with shared' do |spec_group|
+    context 'when loading domain answers' do
+      subject { alces.domain }
+      include_examples spec_group
+    end
+
+    context 'when loading group answers' do
+      subject { group }
+      include_examples spec_group
+    end
+
+    context 'when loading node answers' do
+      subject { node }
+      include_examples spec_group
+    end
+  end
+
+  context 'without answer files' do
+    shared_examples 'uses the domain default' do
+      it 'uses the domain default' do
+        expect(subject.answer.send(identifier)).to eq('domain-default')
+      end
+    end
+    include_examples 'run contexts with shared', 'uses the domain default'
+  end
+
+  context 'with answer files' do
+    before :each do
+      Metalware::Data.dump(
+        Metalware::FilePath.domain_answers,
+        identifier => answers(alces.domain)
+      )
+      Metalware::Data.dump(
+        Metalware::FilePath.group_answers(group.name),
+        identifier => answers(group)
+      )
+      Metalware::Data.dump(
+        Metalware::FilePath.node_answers(node.name),
+        identifier => answers(node)
+      )
+    end
+
+    shared_examples 'uses the saved answer' do
+      it 'uses the saved answer' do
+        expect(subject.answer.send(identifier)).to eq(answers(subject))
+      end
+    end
+    include_examples 'run contexts with shared', 'uses the saved answer'
+  end
+end

--- a/src/hash_mergers/answer.rb
+++ b/src/hash_mergers/answer.rb
@@ -9,25 +9,18 @@ module Metalware
       private
 
       def hash_array(*a)
-        default_array(*a).concat super
+        super.unshift(domain_answers)
       end
 
-      def default_array(groups:, node:)
-        [default_hash(:domain)]
-      end
-
-      def default_hash(section)
-        section_default(section).each_with_object({}) do |(key, value), memo|
-          memo[key] = value.default unless value.default.nil?
-        end
+      def domain_answers
+        loader.flattened_configure_section(:domain)
+              .reject { |_k, value| value.default.nil? }
+              .map { |key, value| [key, value.default] }
+              .to_h
       end
 
       def load_yaml(section, section_name)
         loader.section_answers(section, section_name)
-      end
-
-      def section_default(section)
-        loader.flattened_configure_section(section)
       end
     end
   end

--- a/src/hash_mergers/answer.rb
+++ b/src/hash_mergers/answer.rb
@@ -13,14 +13,7 @@ module Metalware
       end
 
       def default_array(groups:, node:)
-        [default_hash(:domain)].tap do |x|
-          x.push(default_hash(:group)) if groups
-          if node == 'local'
-            x.push(default_hash(:local))
-          elsif node
-            x.push(default_hash(:node))
-          end
-        end
+        [default_hash(:domain)]
       end
 
       def default_hash(section)


### PR DESCRIPTION
Based on #334, please merge it first.

This simplifies the merging of the answers hash. The use of multiple hashes to determine the default has never been used in practice and does not have a spec. I believe it also has a bug within it, however it is hard to tell without the `spec` or being used.

Instead only the `domain` level default shall be used. This greatly simplifies how the default is generated. There maybe a few edge cases where certain questions that aren't defined at the domain level can't have defaults. However these can be addressed after `Configurator` is refactored (next PR).