### PR TITLE
Dev/clean up configurator

### DIFF
--- a/spec/hash_mergers/answer_spec.rb
+++ b/spec/hash_mergers/answer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Metalware::HashMergers::Answer do
         question: 'Ask node question?',
         default: 'node-default', # Should be ignored
       }],
-      local: []
+      local: [],
     }
   end
 

--- a/spec/question_tree_spec.rb
+++ b/spec/question_tree_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Metalware::QuestionTree do
     }
   end
 
-  let :identifiers { identifier_hash.values }
+  let :identifiers { identifier_hash.values.map(&:to_sym) }
 
   let :question_hash do
     {

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -100,7 +100,7 @@ module Metalware
         section_question_tree.filtered_each do |node_q|
           content = node_q.content
           content.identifier = content.identifier.to_sym
-          content.question = create_question(content, (idx += 1))
+          content.question = create_question(node_q, (idx += 1))
           enum << [node_q, content]
         end
       end
@@ -139,7 +139,7 @@ module Metalware
                          else
                            raw_answer
                          end
-        memo[content.identifier] = content.answer unless content.answer.nil?
+        memo[node_q.identifier] = content.answer unless content.answer.nil?
       end
     end
 
@@ -211,18 +211,15 @@ module Metalware
       saver.section_answers(answers, questions_section, name)
     end
 
-    def create_question(properties, index)
-      default = default_hash[properties.identifier]
+    def create_question(node_q, index)
+      default = default_hash[node_q.identifier]
+      indicator = progress_indicator(index)
+      old_answer = old_answers[node_q.identifier]
 
       # TODO: Remove default as an input and save the default in the
       # properties object. The same can be done with the old_answer
       # TODO: Break out the Question object into seperate file
-      Question.new(
-        default: default,
-        properties: properties,
-        old_answer: old_answers[properties.identifier],
-        progress_indicator: progress_indicator(index)
-      )
+      node_q.create_question(default, indicator, old_answer)
     end
 
     def progress_indicator(index)

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -94,14 +94,6 @@ module Metalware
       save_answers(answers)
     end
 
-    def questions
-      Enumerator.new do |enum|
-        section_question_tree.filtered_each do |node_q|
-          enum << node_q
-        end
-      end
-    end
-
     private
 
     attr_reader :alces,
@@ -128,7 +120,7 @@ module Metalware
     # it needs to be saved again so it is not lost.
     def ask_questions
       idx = 0
-      questions.with_object({}) do |node_q, memo|
+      section_question_tree.filtered_each.with_object({}) do |node_q, memo|
         idx += 1
         next unless ask_question_based_on_parent_answer(node_q)
         content = node_q.content

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -123,7 +123,7 @@ module Metalware
 
         raw_answer = question.ask
         answer = if raw_answer == node_q.default
-                   nil # TODO workout whats going on here
+                   nil # TODO: workout whats going on here
                  else
                    raw_answer
                  end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -99,7 +99,6 @@ module Metalware
         idx = 0
         section_question_tree.filtered_each do |node_q|
           content = node_q.content
-          content.identifier = content.identifier.to_sym
           content.question = create_question(node_q, (idx += 1))
           enum << [node_q, content]
         end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -126,12 +126,12 @@ module Metalware
         content = node_q.content
         question = create_question(node_q, idx)
         raw_answer = question.ask(highline)
-        content.answer = if raw_answer == content.default
-                           content.old_answer.nil? ? nil : answer
-                         else
-                           raw_answer
-                         end
-        memo[node_q.identifier] = content.answer unless content.answer.nil?
+        node_q.answer = if raw_answer == content.default
+                          content.old_answer.nil? ? nil : answer
+                        else
+                          raw_answer
+                        end
+        memo[node_q.identifier] = node_q.answer unless node_q.answer.nil?
       end
     end
 
@@ -144,7 +144,7 @@ module Metalware
       if node_q.question? && !node_q.parent.question?
         true
       # Conditionally ask the question if the parent answer is truthy
-      elsif node_q.parent.content.answer
+      elsif node_q.parent.answer
         true
       # Otherwise don't ask the question
       else

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -24,16 +24,11 @@
 
 require 'active_support/core_ext/hash'
 require 'active_support/string_inquirer'
-require 'highline'
-require 'patches/highline'
 require 'validation/loader'
 require 'validation/saver'
 require 'file_path'
 require 'group_cache'
 require 'configurator/question'
-
-HighLine::Question.prepend Metalware::Patches::HighLine::Question
-HighLine::Menu.prepend Metalware::Patches::HighLine::Menu
 
 module Metalware
   class Configurator
@@ -84,7 +79,6 @@ module Metalware
       name: nil
     )
       @alces = alces
-      @highline = HighLine.new
       @questions_section = questions_section
       @name = (questions_section == :local ? 'local' : name)
     end
@@ -97,7 +91,6 @@ module Metalware
     private
 
     attr_reader :alces,
-                :highline,
                 :questions_section,
                 :name
 
@@ -128,7 +121,7 @@ module Metalware
         question.progress_indicator = progress_indicator(idx)
         question.old_answer = old_answers[identifier]
 
-        raw_answer = question.ask(highline)
+        raw_answer = question.ask
         answer = if raw_answer == node_q.default
                    nil # TODO workout whats going on here
                  else

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -123,12 +123,12 @@ module Metalware
       section_question_tree.filtered_each.with_object({}) do |node_q, memo|
         idx += 1
         next unless ask_question_based_on_parent_answer(node_q)
+        question = node_q.create_question
 
-        default = default_hash[node_q.identifier]
-        indicator = progress_indicator(idx)
-        old_answer = old_answers[node_q.identifier]
+        question.default = default_hash[node_q.identifier]
+        question.progress_indicator = progress_indicator(idx)
+        question.old_answer = old_answers[node_q.identifier]
 
-        question = node_q.create_question(default, indicator, old_answer)
         raw_answer = question.ask(highline)
         answer = if raw_answer == node_q.default
                    nil # TODO workout whats going on here

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -96,9 +96,8 @@ module Metalware
     def questions
       Enumerator.new do |enum|
         idx = 0
-        section_question_tree.each do |node_q|
+        section_question_tree.filtered_each do |node_q|
           content = node_q.content
-          next if content.section
           content.identifier = content.identifier.to_sym
           content.question = create_question(content, (idx += 1))
           enum << [node_q, content]

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -96,10 +96,7 @@ module Metalware
 
     def questions
       Enumerator.new do |enum|
-        idx = 0
         section_question_tree.filtered_each do |node_q|
-          content = node_q.content
-          content.question = create_question(node_q, (idx += 1))
           enum << node_q
         end
       end
@@ -130,9 +127,12 @@ module Metalware
     # saved. If there is an old_answer then it is the default. In this case
     # it needs to be saved again so it is not lost.
     def ask_questions
+      idx = 0
       questions.with_object({}) do |node_q, memo|
+        idx += 1
         next unless ask_question_based_on_parent_answer(node_q)
         content = node_q.content
+        content.question = create_question(node_q, idx)
         raw_answer = content.question.ask(highline)
         content.answer = if raw_answer == content.default
                            content.old_answer.nil? ? nil : answer

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -127,7 +127,7 @@ module Metalware
         question = create_question(node_q, idx)
         raw_answer = question.ask(highline)
         node_q.answer = if raw_answer == content.default
-                          content.old_answer.nil? ? nil : answer
+                          nil # TODO workout whats going on here
                         else
                           raw_answer
                         end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -123,7 +123,12 @@ module Metalware
       section_question_tree.filtered_each.with_object({}) do |node_q, memo|
         idx += 1
         next unless ask_question_based_on_parent_answer(node_q)
-        question = create_question(node_q, idx)
+
+        default = default_hash[node_q.identifier]
+        indicator = progress_indicator(idx)
+        old_answer = old_answers[node_q.identifier]
+
+        question = node_q.create_question(default, indicator, old_answer)
         raw_answer = question.ask(highline)
         node_q.answer = if raw_answer == node_q.default
                           nil # TODO workout whats going on here
@@ -200,17 +205,6 @@ module Metalware
 
     def save_answers(answers)
       saver.section_answers(answers, questions_section, name)
-    end
-
-    def create_question(node_q, index)
-      default = default_hash[node_q.identifier]
-      indicator = progress_indicator(index)
-      old_answer = old_answers[node_q.identifier]
-
-      # TODO: Remove default as an input and save the default in the
-      # properties object. The same can be done with the old_answer
-      # TODO: Break out the Question object into seperate file
-      node_q.create_question(default, indicator, old_answer)
     end
 
     def progress_indicator(index)

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -123,10 +123,9 @@ module Metalware
       section_question_tree.filtered_each.with_object({}) do |node_q, memo|
         idx += 1
         next unless ask_question_based_on_parent_answer(node_q)
-        content = node_q.content
         question = create_question(node_q, idx)
         raw_answer = question.ask(highline)
-        node_q.answer = if raw_answer == content.default
+        node_q.answer = if raw_answer == node_q.default
                           nil # TODO workout whats going on here
                         else
                           raw_answer

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -100,7 +100,7 @@ module Metalware
         section_question_tree.filtered_each do |node_q|
           content = node_q.content
           content.question = create_question(node_q, (idx += 1))
-          enum << [node_q, content]
+          enum << node_q
         end
       end
     end
@@ -130,8 +130,9 @@ module Metalware
     # saved. If there is an old_answer then it is the default. In this case
     # it needs to be saved again so it is not lost.
     def ask_questions
-      questions.with_object({}) do |(node_q, content), memo|
+      questions.with_object({}) do |node_q, memo|
         next unless ask_question_based_on_parent_answer(node_q)
+        content = node_q.content
         raw_answer = content.question.ask(highline)
         content.answer = if raw_answer == content.default
                            content.old_answer.nil? ? nil : answer

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -30,6 +30,7 @@ require 'validation/loader'
 require 'validation/saver'
 require 'file_path'
 require 'group_cache'
+require 'configurator/question'
 
 HighLine::Question.prepend Metalware::Patches::HighLine::Question
 HighLine::Menu.prepend Metalware::Patches::HighLine::Menu
@@ -230,140 +231,6 @@ module Metalware
 
     def total_questions
       section_question_tree.questions_length
-    end
-
-    class Question
-      attr_reader \
-        :choices,
-        :default,
-        :identifier,
-        :old_answer,
-        :progress_indicator,
-        :question,
-        :required,
-        :type
-
-      def initialize(
-        default:,
-        old_answer: nil,
-        progress_indicator:,
-        properties:
-      )
-        @choices = properties.choices
-        @default = default
-        @identifier = properties.identifier
-        @old_answer = old_answer
-        @progress_indicator = progress_indicator
-        @question = properties.question
-        @required = !properties.optional
-        @type = type_for(properties[:type])
-      end
-
-      def ask(highline)
-        ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'
-        send(ask_method, highline) { |q| configure_question(q) }
-      end
-
-      private
-
-      def configure_question(highline_question)
-        highline_question.readline = use_readline?
-        highline_question.default = default_input
-        if validate_answer_given?
-          highline_question.validate = ensure_answer_given
-        end
-      end
-
-      def validate_answer_given?
-        # Do not override built-in HighLine validation for `agree` questions,
-        # which will already cause the question to be re-prompted until a valid
-        # answer is given (rather than just accepting any non-empty answer, as
-        # our `ensure_answer_given` does).
-        return false if type.boolean?
-
-        answer_required?
-      end
-
-      # Whether an answer to this question is required at this level; an answer
-      # will not be required if there is already an answer from the question
-      # default or a higher level answer file (the `default`), or if the
-      # question is not `required`.
-      def answer_required?
-        !default && required
-      end
-
-      def use_readline?
-        # Don't provide readline bindings for boolean questions, in this case
-        # they cause an issue where the question is repeated twice if no/bad
-        # input is entered, and they are not really necessary in this case.
-        return false if type.boolean?
-
-        Metalware::Configurator.use_readline
-      end
-
-      def default_input
-        type.boolean? ? boolean_default_input : current_answer_value
-      end
-
-      def boolean_default_input
-        return nil if current_answer_value.nil?
-
-        # Default for a boolean question which has a previous answer should be
-        # set to the input HighLine's `agree` expects, i.e. 'yes' or 'no'.
-        current_answer_value ? 'yes' : 'no'
-      end
-
-      # The answer value this question at this level would currently take.
-      def current_answer_value
-        old_answer.nil? ? default : old_answer
-      end
-
-      def ask_boolean_question(highline)
-        highline.agree(question_text + ' [yes/no]') { |q| yield q }
-      end
-
-      def ask_choice_question(highline)
-        highline.choose(*choices) do |menu|
-          menu.prompt = question_text
-          yield menu
-        end
-      end
-
-      def ask_integer_question(highline)
-        highline.ask(question_text, Integer) { |q| yield q }
-      end
-
-      def ask_string_question(highline)
-        highline.ask(question_text) { |q| yield q }
-      end
-
-      def question_text
-        "#{question.strip} #{progress_indicator}"
-      end
-
-      def type_for(value)
-        ActiveSupport::StringInquirer.new(value || 'string')
-      end
-
-      def ensure_answer_given
-        HighLinePrettyValidateProc.new('a non-empty input') do |input|
-          !input.empty?
-        end
-      end
-
-      class HighLinePrettyValidateProc < Proc
-        def initialize(print_message, &b)
-          # NOTE: print_message is prefaced with "must match" when used by
-          # HighLine validate
-          @print_message = print_message
-          super(&b)
-        end
-
-        # HighLine uses the result of inspect to generate the message to display
-        def inspect
-          @print_message
-        end
-      end
     end
   end
 end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -124,8 +124,8 @@ module Metalware
         idx += 1
         next unless ask_question_based_on_parent_answer(node_q)
         content = node_q.content
-        content.question = create_question(node_q, idx)
-        raw_answer = content.question.ask(highline)
+        question = create_question(node_q, idx)
+        raw_answer = question.ask(highline)
         content.answer = if raw_answer == content.default
                            content.old_answer.nil? ? nil : answer
                          else

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -130,12 +130,12 @@ module Metalware
 
         question = node_q.create_question(default, indicator, old_answer)
         raw_answer = question.ask(highline)
-        node_q.answer = if raw_answer == node_q.default
-                          nil # TODO workout whats going on here
-                        else
-                          raw_answer
-                        end
-        memo[node_q.identifier] = node_q.answer unless node_q.answer.nil?
+        answer = if raw_answer == node_q.default
+                   nil # TODO workout whats going on here
+                 else
+                   raw_answer
+                 end
+        memo[node_q.identifier] = answer unless answer.nil?
       end
     end
 

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -15,7 +15,6 @@ module Metalware
         @default = default
         @old_answer = old_answer
         @progress_indicator = progress_indicator
-        @type = type_for(question_node.type)
       end
 
       def ask(highline)
@@ -29,8 +28,7 @@ module Metalware
         :question_node,
         :default,
         :old_answer,
-        :progress_indicator,
-        :type
+        :progress_indicator
 
       delegate :identifier, :choices, :optional, :question,
                to: :question_node
@@ -104,7 +102,8 @@ module Metalware
         "#{question.strip} #{progress_indicator}"
       end
 
-      def type_for(value)
+      def type
+        value = question_node.type
         ActiveSupport::StringInquirer.new(value || 'string')
       end
 

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -5,17 +5,11 @@ require 'active_support/core_ext/module/delegation'
 module Metalware
   class Configurator
     class Question
-      def initialize(
-        question_node,
-        default:,
-        old_answer: nil,
-        progress_indicator:
-      )
+      def initialize(question_node)
         @question_node = question_node
-        @default = default
-        @old_answer = old_answer
-        @progress_indicator = progress_indicator
       end
+
+      attr_accessor :default, :old_answer, :progress_indicator
 
       def ask(highline)
         ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'
@@ -25,11 +19,7 @@ module Metalware
 
       private
 
-      attr_reader \
-        :question_node,
-        :default,
-        :old_answer,
-        :progress_indicator
+      attr_reader :question_node
 
       delegate :identifier, :choices, :optional, :text,
                to: :question_node

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -38,27 +38,21 @@ module Metalware
       def configure_question(highline_question)
         highline_question.readline = use_readline?
         highline_question.default = default_input
-        if validate_answer_given?
-          highline_question.validate = ensure_answer_given
-        end
+        validate_highline_answer_given(highline_question)
       end
 
-      def validate_answer_given?
+      def validate_highline_answer_given(highline_question)
         # Do not override built-in HighLine validation for `agree` questions,
-        # which will already cause the question to be re-prompted until a valid
-        # answer is given (rather than just accepting any non-empty answer, as
-        # our `ensure_answer_given` does).
+        # which will already cause the question to be re-prompted until
+        # a valid answer is given (rather than just accepting any non-empty
+        # answer, as our `ensure_answer_given` does).
         return false if type.boolean?
 
-        answer_required?
-      end
-
-      # Whether an answer to this question is required at this level; an answer
-      # will not be required if there is already an answer from the question
-      # default or a higher level answer file (the `default`), or if the
-      # question is not `required`.
-      def answer_required?
-        !(default || optional)
+        # The answer does not need to be given if there is a default or if
+        # it is optional
+        if !(default || optional)
+          highline_question.validate = ensure_answer_given
+        end
       end
 
       def use_readline?

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -1,0 +1,140 @@
+
+# frozen_string_literal: true
+
+module Metalware
+  class Configurator
+    class Question
+      attr_reader \
+        :choices,
+        :default,
+        :identifier,
+        :old_answer,
+        :progress_indicator,
+        :question,
+        :required,
+        :type
+
+      def initialize(
+        default:,
+        old_answer: nil,
+        progress_indicator:,
+        properties:
+      )
+        @choices = properties.choices
+        @default = default
+        @identifier = properties.identifier
+        @old_answer = old_answer
+        @progress_indicator = progress_indicator
+        @question = properties.question
+        @required = !properties.optional
+        @type = type_for(properties[:type])
+      end
+
+      def ask(highline)
+        ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'
+        send(ask_method, highline) { |q| configure_question(q) }
+      end
+
+      private
+
+      def configure_question(highline_question)
+        highline_question.readline = use_readline?
+        highline_question.default = default_input
+        if validate_answer_given?
+          highline_question.validate = ensure_answer_given
+        end
+      end
+
+      def validate_answer_given?
+        # Do not override built-in HighLine validation for `agree` questions,
+        # which will already cause the question to be re-prompted until a valid
+        # answer is given (rather than just accepting any non-empty answer, as
+        # our `ensure_answer_given` does).
+        return false if type.boolean?
+
+        answer_required?
+      end
+
+      # Whether an answer to this question is required at this level; an answer
+      # will not be required if there is already an answer from the question
+      # default or a higher level answer file (the `default`), or if the
+      # question is not `required`.
+      def answer_required?
+        !default && required
+      end
+
+      def use_readline?
+        # Don't provide readline bindings for boolean questions, in this case
+        # they cause an issue where the question is repeated twice if no/bad
+        # input is entered, and they are not really necessary in this case.
+        return false if type.boolean?
+
+        Metalware::Configurator.use_readline
+      end
+
+      def default_input
+        type.boolean? ? boolean_default_input : current_answer_value
+      end
+
+      def boolean_default_input
+        return nil if current_answer_value.nil?
+
+        # Default for a boolean question which has a previous answer should be
+        # set to the input HighLine's `agree` expects, i.e. 'yes' or 'no'.
+        current_answer_value ? 'yes' : 'no'
+      end
+
+      # The answer value this question at this level would currently take.
+      def current_answer_value
+        old_answer.nil? ? default : old_answer
+      end
+
+      def ask_boolean_question(highline)
+        highline.agree(question_text + ' [yes/no]') { |q| yield q }
+      end
+
+      def ask_choice_question(highline)
+        highline.choose(*choices) do |menu|
+          menu.prompt = question_text
+          yield menu
+        end
+      end
+
+      def ask_integer_question(highline)
+        highline.ask(question_text, Integer) { |q| yield q }
+      end
+
+      def ask_string_question(highline)
+        highline.ask(question_text) { |q| yield q }
+      end
+
+      def question_text
+        "#{question.strip} #{progress_indicator}"
+      end
+
+      def type_for(value)
+        ActiveSupport::StringInquirer.new(value || 'string')
+      end
+
+      def ensure_answer_given
+        HighLinePrettyValidateProc.new('a non-empty input') do |input|
+          !input.empty?
+        end
+      end
+
+      class HighLinePrettyValidateProc < Proc
+        def initialize(print_message, &b)
+          # NOTE: print_message is prefaced with "must match" when used by
+          # HighLine validate
+          @print_message = print_message
+          super(&b)
+        end
+
+        # HighLine uses the result of inspect to generate the message to display
+        def inspect
+          @print_message
+        end
+      end
+    end
+  end
+end

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -41,13 +41,12 @@ module Metalware
         # which will already cause the question to be re-prompted until
         # a valid answer is given (rather than just accepting any non-empty
         # answer, as our `ensure_answer_given` does).
-        return false if type.boolean?
+        return if type.boolean?
 
         # The answer does not need to be given if there is a default or if
         # it is optional
-        if !(default || optional)
-          highline_question.validate = ensure_answer_given
-        end
+        return if default || optional
+        highline_question.validate = ensure_answer_given
       end
 
       def use_readline?

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -1,24 +1,22 @@
 
 # frozen_string_literal: true
+require 'active_support/core_ext/module/delegation'
 
 module Metalware
   class Configurator
     class Question
       def initialize(
+        question_node,
         default:,
         old_answer: nil,
-        progress_indicator:,
-        identifier:,
-        properties:
+        progress_indicator:
       )
-        @choices = properties.choices
+        @question_node = question_node
         @default = default
-        @identifier = identifier
         @old_answer = old_answer
         @progress_indicator = progress_indicator
-        @question = properties.question
-        @required = !properties.optional
-        @type = type_for(properties[:type])
+        @required = !optional
+        @type = type_for(question_node.type)
       end
 
       def ask(highline)
@@ -29,14 +27,15 @@ module Metalware
       private
 
       attr_reader \
-        :choices,
+        :question_node,
         :default,
-        :identifier,
         :old_answer,
         :progress_indicator,
-        :question,
         :required,
         :type
+
+      delegate :identifier, :choices, :optional, :question,
+               to: :question_node
 
       def configure_question(highline_question)
         highline_question.readline = use_readline?

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -1,5 +1,6 @@
 
 # frozen_string_literal: true
+
 require 'active_support/core_ext/module/delegation'
 require 'highline'
 require 'patches/highline'

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -19,7 +19,7 @@ module Metalware
 
       def ask
         ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'
-        answer = send(ask_method, highline) { |q| configure_question(q) }
+        answer = send(ask_method) { |q| configure_question(q) }
         answer.tap { |a| question_node.answer = a }
       end
 
@@ -76,22 +76,22 @@ module Metalware
         old_answer.nil? ? default : old_answer
       end
 
-      def ask_boolean_question(highline)
+      def ask_boolean_question
         highline.agree(question_text + ' [yes/no]') { |q| yield q }
       end
 
-      def ask_choice_question(highline)
+      def ask_choice_question
         highline.choose(*choices) do |menu|
           menu.prompt = question_text
           yield menu
         end
       end
 
-      def ask_integer_question(highline)
+      def ask_integer_question
         highline.ask(question_text, Integer) { |q| yield q }
       end
 
-      def ask_string_question(highline)
+      def ask_string_question
         highline.ask(question_text) { |q| yield q }
       end
 

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -15,7 +15,6 @@ module Metalware
         @default = default
         @old_answer = old_answer
         @progress_indicator = progress_indicator
-        @required = !optional
         @type = type_for(question_node.type)
       end
 
@@ -31,7 +30,6 @@ module Metalware
         :default,
         :old_answer,
         :progress_indicator,
-        :required,
         :type
 
       delegate :identifier, :choices, :optional, :question,
@@ -60,7 +58,7 @@ module Metalware
       # default or a higher level answer file (the `default`), or if the
       # question is not `required`.
       def answer_required?
-        !default && required
+        !(default || optional)
       end
 
       def use_readline?

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -18,11 +18,12 @@ module Metalware
         default:,
         old_answer: nil,
         progress_indicator:,
+        identifier:,
         properties:
       )
         @choices = properties.choices
         @default = default
-        @identifier = properties.identifier
+        @identifier = identifier
         @old_answer = old_answer
         @progress_indicator = progress_indicator
         @question = properties.question

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -30,7 +30,7 @@ module Metalware
         :old_answer,
         :progress_indicator
 
-      delegate :identifier, :choices, :optional, :question,
+      delegate :identifier, :choices, :optional, :text,
                to: :question_node
 
       def configure_question(highline_question)
@@ -99,7 +99,7 @@ module Metalware
       end
 
       def question_text
-        "#{question.strip} #{progress_indicator}"
+        "#{text.strip} #{progress_indicator}"
       end
 
       def type

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -1,17 +1,23 @@
 
 # frozen_string_literal: true
 require 'active_support/core_ext/module/delegation'
+require 'highline'
+require 'patches/highline'
+
+HighLine::Question.prepend Metalware::Patches::HighLine::Question
+HighLine::Menu.prepend Metalware::Patches::HighLine::Menu
 
 module Metalware
   class Configurator
     class Question
       def initialize(question_node)
         @question_node = question_node
+        @highline = HighLine.new
       end
 
       attr_accessor :default, :old_answer, :progress_indicator
 
-      def ask(highline)
+      def ask
         ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'
         answer = send(ask_method, highline) { |q| configure_question(q) }
         answer.tap { |a| question_node.answer = a }
@@ -19,7 +25,7 @@ module Metalware
 
       private
 
-      attr_reader :question_node
+      attr_reader :question_node, :highline
 
       delegate :identifier, :choices, :optional, :text,
                to: :question_node

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -4,16 +4,6 @@
 module Metalware
   class Configurator
     class Question
-      attr_reader \
-        :choices,
-        :default,
-        :identifier,
-        :old_answer,
-        :progress_indicator,
-        :question,
-        :required,
-        :type
-
       def initialize(
         default:,
         old_answer: nil,
@@ -37,6 +27,16 @@ module Metalware
       end
 
       private
+
+      attr_reader \
+        :choices,
+        :default,
+        :identifier,
+        :old_answer,
+        :progress_indicator,
+        :question,
+        :required,
+        :type
 
       def configure_question(highline_question)
         highline_question.readline = use_readline?

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -19,7 +19,8 @@ module Metalware
 
       def ask(highline)
         ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'
-        send(ask_method, highline) { |q| configure_question(q) }
+        answer = send(ask_method, highline) { |q| configure_question(q) }
+        answer.tap { |a| question_node.answer = a }
       end
 
       private

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -8,6 +8,8 @@ module Metalware
   class QuestionTree < Tree::TreeNode
     delegate :choices, :optional, :type, to: :os_content
 
+    attr_accessor :answer
+
     BASE_TRAVERSALS = [
       :each,
       :breadth_each,

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -34,7 +34,19 @@ module Metalware
     end
 
     def identifier
-      content[:identifier]
+      content[:identifier]&.to_sym
+    end
+
+    # TODO: Eventually change this to a `question` method once the index's
+    # and defaults are rationalised
+    def create_question(default, progress_indicator, old_answer)
+      Configurator::Question.new(
+        default: default,
+        properties: content,
+        old_answer: old_answer,
+        progress_indicator: progress_indicator,
+        identifier: identifier
+      )
     end
   end
 end

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -50,13 +50,8 @@ module Metalware
 
     # TODO: Eventually change this to a `question` method once the index's
     # and defaults are rationalised
-    def create_question(default, progress_indicator, old_answer)
-      Configurator::Question.new(
-        self,
-        default: default,
-        old_answer: old_answer,
-        progress_indicator: progress_indicator
-      )
+    def create_question
+      Configurator::Question.new(self)
     end
 
     private

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -6,9 +6,7 @@ require 'ostruct'
 
 module Metalware
   class QuestionTree < Tree::TreeNode
-    # TODO: `question` isn't super descriptive as the is a QuestionTree
-    # object. Maybe `text` would be better?
-    delegate :question, :choices, :optional, :type, to: :os_content
+    delegate :choices, :optional, :type, to: :os_content
 
     BASE_TRAVERSALS = [
       :each,
@@ -40,6 +38,12 @@ module Metalware
 
     def identifier
       os_content.identifier&.to_sym
+    end
+
+    # In `configure.yaml` the text is stored under the `question` key
+    # However "question" isn't super meaningful in this class
+    def text
+      os_content.question
     end
 
     # TODO: Eventually change this to a `question` method once the index's

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -2,9 +2,14 @@
 # frozen_string_literal: true
 
 require 'rubytree'
+require 'ostruct'
 
 module Metalware
   class QuestionTree < Tree::TreeNode
+    # TODO: `question` isn't super descriptive as the is a QuestionTree
+    # object. Maybe `text` would be better?
+    delegate :question, :choices, :optional, :type, to: :os_content
+
     BASE_TRAVERSALS = [
       :each,
       :breadth_each,
@@ -34,19 +39,27 @@ module Metalware
     end
 
     def identifier
-      content[:identifier]&.to_sym
+      os_content.identifier&.to_sym
     end
 
     # TODO: Eventually change this to a `question` method once the index's
     # and defaults are rationalised
     def create_question(default, progress_indicator, old_answer)
       Configurator::Question.new(
+        self,
         default: default,
-        properties: content,
         old_answer: old_answer,
-        progress_indicator: progress_indicator,
-        identifier: identifier
+        progress_indicator: progress_indicator
       )
+    end
+
+    private
+
+    # TODO: Stop wrapping the content in the validator, that should really
+    # be done within the QuestionTree object. It doesn't hurt, as you can't
+    # double wrap and OpenStruct, it just isn't required
+    def os_content
+      OpenStruct.new(content)
     end
   end
 end

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -6,7 +6,7 @@ require 'ostruct'
 
 module Metalware
   class QuestionTree < Tree::TreeNode
-    delegate :choices, :optional, :type, to: :os_content
+    delegate :default, :choices, :optional, :type, to: :os_content
 
     attr_accessor :answer
 

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -24,10 +24,10 @@ module Metalware
       end
     end
 
-    def ask_questions(&block)
-      self.filtered_each.with_index do |question, index|
+    def ask_questions
+      filtered_each.with_index do |question, index|
         next unless ask_conditional_question?(question)
-        block.call(question, index + 1)
+        yield(question, index + 1)
       end
     end
 

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -24,6 +24,13 @@ module Metalware
       end
     end
 
+    def ask_questions(&block)
+      self.filtered_each.with_index do |question, index|
+        next unless ask_conditional_question?(question)
+        block.call(question, index + 1)
+      end
+    end
+
     def questions_length
       num = 0
       filtered_each { |_q| num += 1 }
@@ -61,6 +68,21 @@ module Metalware
     # double wrap and OpenStruct, it just isn't required
     def os_content
       OpenStruct.new(content)
+    end
+
+    # NOTE: This method is used by the iterator and thus DOES NOT reference
+    # the "self" object. Instead it should use the question passed to it
+    def ask_conditional_question?(question)
+      # Ask the question if the parent has a truthy answer
+      if question.parent.answer
+        true
+      # Ask the question if the parent isn't a question (e.g. a section)
+      elsif !question.parent.question?
+        true
+      # Otherwise don't ask the question
+      else
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
Based on #335, please merge it first.

This PR does not add/ remove/ alter any functionality (hopefully). Instead it focuses reorganising the configuration process. This can be broadly defined between the three classes:

1. `Configurator`: Is responsible for the high level "which section to configure?" type details. It also acts as a cache to prevent certain file from being reloaded as well as interacting with the `alces` object (also a cache)
1. `QuestionTree`: Is a "node" centric implementation of the question structure. Each node (mostly*) represents a question and thus contains its data. Contained within the node is a `content` hash which is set by the validator. A lot of work went into abstracting this detail away. The only object that should access it is `QuestionTree`. Every other object should not talk to strangers children. The other purpose of the `QuestionTree` is to provide the different iteration methods.
1. `Configurator::Question`: Is responsible for anything to do with `highline`. It is still closely coupled with `QuestionTree` as it needs the data contained within it. However the number of inputs it uses has been greatly reduces. The remaining coupling has also been streamlined with the use of delegates. It has also been broken out into its own file.

`Configurator` is still a work in progress which will be updated some more in the next PR.

* The top level of the `QuestionTree` is the root tree_node and thus is not a question. The second level contains the section tree_nodes which correspond to the `:domain`, `:group`, `:node`, and `:local` question structures and are thus not questions either. Everything below this are questions. At some point it might be good to split these off as a separate object.