### PR TITLE
Dev/more cleaning of configurator

### DIFF
--- a/spec/hash_mergers/hash_merger_spec.rb
+++ b/spec/hash_mergers/hash_merger_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Metalware::HashMergers::HashMerger do
 
   def build_merged_hash(**hash_input)
     hm = Metalware::HashMergers
-    b = Proc.new { |t| t }
+    b = proc { |t| t }
     OpenStruct.new(
       config: hm::Config.new.merge(**hash_input, &b),
       answer: hm::Answer.new(alces).merge(**hash_input, &b)

--- a/spec/hash_mergers/hash_merger_spec.rb
+++ b/spec/hash_mergers/hash_merger_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Metalware::HashMergers::HashMerger do
     b = Proc.new { |t| t }
     OpenStruct.new(
       config: hm::Config.new.merge(**hash_input, &b),
-      answer: hm::Answer.new.merge(**hash_input, &b)
+      answer: hm::Answer.new(alces).merge(**hash_input, &b)
     )
   end
 

--- a/spec/hash_mergers/hash_merger_spec.rb
+++ b/spec/hash_mergers/hash_merger_spec.rb
@@ -24,9 +24,12 @@ RSpec.describe Metalware::HashMergers::HashMerger do
   end
 
   def build_merged_hash(**hash_input)
-    Metalware::HashMergers.merge(**hash_input) do |template_string|
-      template_string
-    end
+    hm = Metalware::HashMergers
+    b = Proc.new { |t| t }
+    OpenStruct.new(
+      config: hm::Config.new.merge(**hash_input, &b),
+      answer: hm::Answer.new.merge(**hash_input, &b)
+    )
   end
 
   def expect_config_value(my_hash)

--- a/spec/question_tree_spec.rb
+++ b/spec/question_tree_spec.rb
@@ -4,117 +4,122 @@
 require 'validation/configure'
 
 RSpec.describe Metalware::QuestionTree do
-  let :identifier_hash do
-    {
-      domain: 'domain_identifier',
-      domain2: 'second_domain_identifier',
-      group: 'group_identifier',
-      node: 'node_identifier',
-      local: 'local_identifier',
-      dependent: 'dependent_identifier',
-      dependent2: 'second_dependent_identifier',
-    }
-  end
+  context 'with the first question setup' do
+    let :identifier_hash do
+      {
+        domain: 'domain_identifier',
+        domain2: 'second_domain_identifier',
+        group: 'group_identifier',
+        node: 'node_identifier',
+        local: 'local_identifier',
+        dependent: 'dependent_identifier',
+        dependent2: 'second_dependent_identifier',
+      }
+    end
 
-  let :identifiers { identifier_hash.values.map(&:to_sym) }
+    let :identifiers { identifier_hash.values.map(&:to_sym) }
 
-  let :question_hash do
-    {
-      domain: [
-        {
-          identifier: identifier_hash[:domain],
-          question: 'Am I a question for the domain?',
-        },
-        {
-          identifier: identifier_hash[:domain2],
-          question: 'Can I have two questions in a section?',
-        },
-      ],
-      group: [
-        identifier: identifier_hash[:group],
-        question: 'Am I a question for the group?',
-        dependent: [
+    let :question_hash do
+      {
+        domain: [
           {
-            identifier: identifier_hash[:dependent],
-            question: 'Can I have a dependent question?',
+            identifier: identifier_hash[:domain],
+            question: 'Am I a question for the domain?',
           },
           {
-            identifier: identifier_hash[:dependent2],
-            question: 'Can I have a second dependent question?',
+            identifier: identifier_hash[:domain2],
+            question: 'Can I have two questions in a section?',
           },
         ],
-      ],
-      node: [
-        identifier: identifier_hash[:node],
-        question: 'Am I a question for the node?',
-      ],
-      local: [
-        identifier: identifier_hash[:local],
-        question: 'Am I a question for the local node?',
-      ],
-    }
-  end
-
-  subject { Metalware::Validation::Configure.new(question_hash).tree }
-
-  shared_examples 'a filtered traversal' do |base_method|
-    let :filtered_method { :"filtered_#{base_method}" }
-    let :enum { subject.public_send(filtered_method) }
-
-    it 'is defined' do
-      expect(subject).to respond_to(filtered_method)
+        group: [
+          identifier: identifier_hash[:group],
+          question: 'Am I a question for the group?',
+          dependent: [
+            {
+              identifier: identifier_hash[:dependent],
+              question: 'Can I have a dependent question?',
+            },
+            {
+              identifier: identifier_hash[:dependent2],
+              question: 'Can I have a second dependent question?',
+            },
+          ],
+        ],
+        node: [
+          identifier: identifier_hash[:node],
+          question: 'Am I a question for the node?',
+        ],
+        local: [
+          identifier: identifier_hash[:local],
+          question: 'Am I a question for the local node?',
+        ],
+      }
     end
 
-    it 'only includes questions' do
-      enum.each { |q| expect(q).to be_question }
-    end
+    subject { Metalware::Validation::Configure.new(question_hash).tree }
 
-    it 'returns an enumerator when called without a block' do
-      expect(enum).to be_a Enumerator
-    end
+    shared_examples 'a filtered traversal' do |base_method|
+      let :filtered_method { :"filtered_#{base_method}" }
+      let :enum { subject.public_send(filtered_method) }
 
-    it 'runs the block for each valid question' do
-      num = 0
-      subject.send filtered_method do |_q|
-        num += 1
+      it 'is defined' do
+        expect(subject).to respond_to(filtered_method)
       end
-      expect(num).to eq(identifiers.length)
-    end
-  end
 
-  Metalware::QuestionTree::BASE_TRAVERSALS.each do |base_method|
-    describe "#filtered_#{base_method}" do
-      it_behaves_like 'a filtered traversal', base_method
-    end
-  end
+      it 'only includes questions' do
+        enum.each { |q| expect(q).to be_question }
+      end
 
-  describe '#identifiers' do
-    it 'returns all the identifiers' do
-      expect(subject.identifiers).to contain_exactly(*identifiers)
-    end
-  end
+      it 'returns an enumerator when called without a block' do
+        expect(enum).to be_a Enumerator
+      end
 
-  describe '#question?' do
-    # The root is not a question, it stores references to the sections
-    it "is false for the Tree's root" do
-      expect(subject).not_to be_question
-    end
-
-    it 'is false for all section nodes' do
-      subject.children.each do |section_node|
-        expect(section_node).not_to be_question
+      it 'runs the block for each valid question' do
+        num = 0
+        subject.send filtered_method do |_q|
+          num += 1
+        end
+        expect(num).to eq(identifiers.length)
       end
     end
 
-    it 'returns true if the identifier is defined' do
-      question = Metalware::QuestionTree.new('', identifier: 'some string')
-      expect(question).to be_question
+    Metalware::QuestionTree::BASE_TRAVERSALS.each do |base_method|
+      describe "#filtered_#{base_method}" do
+        it_behaves_like 'a filtered traversal', base_method
+      end
+    end
+
+    describe '#identifiers' do
+      it 'returns all the identifiers' do
+        expect(subject.identifiers).to contain_exactly(*identifiers)
+      end
+    end
+
+    describe '#question?' do
+      # The root is not a question, it stores references to the sections
+      it "is false for the Tree's root" do
+        expect(subject).not_to be_question
+      end
+
+      it 'is false for all section nodes' do
+        subject.children.each do |section_node|
+          expect(section_node).not_to be_question
+        end
+      end
+
+      it 'returns true if the identifier is defined' do
+        question = Metalware::QuestionTree.new('', identifier: 'some string')
+        expect(question).to be_question
+      end
+    end
+
+    describe '#questions_length' do
+      it 'does not include the non questions in the length' do
+        expect(subject.questions_length).to eq(identifiers.length)
+      end
     end
   end
 
-  describe '#questions_length' do
-    it 'does not include the non questions in the length' do
-      expect(subject.questions_length).to eq(identifiers.length)
-    end
+  context 'with the second question setup' do
   end
 end

--- a/spec/question_tree_spec.rb
+++ b/spec/question_tree_spec.rb
@@ -142,14 +142,14 @@ RSpec.describe Metalware::QuestionTree do
         domain: make('domain_default', domain_question),
         group: make('group_default', domain_question, group_question),
         node: make('node_default',
-                          domain_question,
-                          group_question,
-                          node_question),
+                   domain_question,
+                   group_question,
+                   node_question),
         local: make('local_default',
-                           domain_question,
-                           group_question,
-                           node_question,
-                           local_question)
+                    domain_question,
+                    group_question,
+                    node_question,
+                    local_question),
       }
     end
 

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -108,10 +108,8 @@ module Metalware
 
     def ask_questions
       memo = {}
-      section_question_tree.ask_questions do |node_q, progress_indicator|
-        identifier = node_q.identifier
-        question = node_q.create_question(progress_indicator)
-
+      section_question_tree.ask_questions do |question|
+        identifier = question.identifier
         question.default = default_hash[identifier]
 
         answer = question.ask

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -174,9 +174,5 @@ module Metalware
     def save_answers(answers)
       saver.section_answers(answers, questions_section, name)
     end
-
-    def total_questions
-      section_question_tree.questions_length
-    end
   end
 end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -108,12 +108,12 @@ module Metalware
 
     def ask_questions
       memo = {}
-      section_question_tree.ask_questions do |node_q, idx|
+      section_question_tree.ask_questions do |node_q, progress_indicator|
         identifier = node_q.identifier
         question = node_q.create_question
 
         question.default = default_hash[identifier]
-        question.progress_indicator = progress_indicator(idx)
+        question.progress_indicator = progress_indicator
 
         answer = question.ask
         memo[identifier] = answer unless answer == root_defaults(identifier)
@@ -140,6 +140,8 @@ module Metalware
       end
     end
 
+    # TODO: This isn't being used currently, if this doesn't change in the
+    # near future - remove it!
     def old_answers
       @old_answers ||= loader.section_answers(questions_section, name)
     end
@@ -174,10 +176,6 @@ module Metalware
 
     def save_answers(answers)
       saver.section_answers(answers, questions_section, name)
-    end
-
-    def progress_indicator(index)
-      "(#{index}/#{total_questions})"
     end
 
     def total_questions

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -110,10 +110,9 @@ module Metalware
       memo = {}
       section_question_tree.ask_questions do |node_q, progress_indicator|
         identifier = node_q.identifier
-        question = node_q.create_question
+        question = node_q.create_question(progress_indicator)
 
         question.default = default_hash[identifier]
-        question.progress_indicator = progress_indicator
 
         answer = question.ask
         memo[identifier] = answer unless answer == root_defaults(identifier)

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -106,11 +106,6 @@ module Metalware
       @group_cache ||= GroupCache.new
     end
 
-    # Whether the answer is saved depends if it matches the default AND
-    # if it was previously saved. If there is no old_answer, then the
-    # default must be set at a higher level. In this case it shouldn't be
-    # saved. If there is an old_answer then it is the default. In this case
-    # it needs to be saved again so it is not lost.
     def ask_questions
       memo = {}
       section_question_tree.ask_questions do |node_q, idx|
@@ -120,13 +115,8 @@ module Metalware
         question.default = default_hash[identifier]
         question.progress_indicator = progress_indicator(idx)
 
-        raw_answer = question.ask
-        answer = if raw_answer == node_q.yaml_default
-                   nil # TODO: workout whats going on here
-                 else
-                   raw_answer
-                 end
-        memo[identifier] = answer unless answer.nil?
+        answer = question.ask
+        memo[identifier] = answer unless answer == node_q.yaml_default
       end
       memo
     end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -133,7 +133,7 @@ module Metalware
     end
 
     def section_question_tree
-      @section_question_tree ||= loader.configure_section(questions_section)
+      alces.questions.section_tree(questions_section)
     end
 
     def default_hash

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -119,7 +119,6 @@ module Metalware
 
         question.default = default_hash[identifier]
         question.progress_indicator = progress_indicator(idx)
-        question.old_answer = old_answers[identifier]
 
         raw_answer = question.ask
         answer = if raw_answer == node_q.yaml_default

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -116,7 +116,7 @@ module Metalware
         question.progress_indicator = progress_indicator(idx)
 
         answer = question.ask
-        memo[identifier] = answer unless answer == node_q.yaml_default
+        memo[identifier] = answer unless answer == root_defaults(identifier)
       end
       memo
     end
@@ -138,6 +138,14 @@ module Metalware
           raise InternalError, "Unrecognised question section: #{questions_section}"
         end.answer.to_h
       end
+    end
+
+    def old_answers
+      @old_answers ||= loader.section_answers(questions_section, name)
+    end
+
+    def root_defaults(identifier)
+      alces.questions.root_defaults[identifier]
     end
 
     def orphan_warning
@@ -162,10 +170,6 @@ module Metalware
       MetalLog.warn orphan_warning unless questions_section == :local
       group_cache.push_orphan(name)
       Namespaces::Node.create(alces, name)
-    end
-
-    def old_answers
-      @old_answers ||= loader.section_answers(questions_section, name)
     end
 
     def save_answers(answers)

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -122,7 +122,7 @@ module Metalware
         question.old_answer = old_answers[identifier]
 
         raw_answer = question.ask
-        answer = if raw_answer == node_q.default
+        answer = if raw_answer == node_q.yaml_default
                    nil # TODO: workout whats going on here
                  else
                    raw_answer

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -60,20 +60,15 @@ module Metalware
       end
 
       def default_input
-        type.boolean? ? boolean_default_input : current_answer_value
+        type.boolean? ? boolean_default_input : default
       end
 
       def boolean_default_input
-        return nil if current_answer_value.nil?
+        return nil if default.nil?
 
         # Default for a boolean question which has a previous answer should be
         # set to the input HighLine's `agree` expects, i.e. 'yes' or 'no'.
-        current_answer_value ? 'yes' : 'no'
-      end
-
-      # The answer value this question at this level would currently take.
-      def current_answer_value
-        default
+        default ? 'yes' : 'no'
       end
 
       def ask_boolean_question

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -18,7 +18,7 @@ module Metalware
       end
 
       attr_accessor :default
-      attr_reader :progress_indicator
+      delegate :identifier, to: :question_node
 
       def ask
         ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'
@@ -28,10 +28,8 @@ module Metalware
 
       private
 
-      attr_reader :question_node, :highline
-
-      delegate :identifier, :choices, :optional, :text,
-               to: :question_node
+      attr_reader :question_node, :highline, :progress_indicator
+      delegate :choices, :optional, :text, to: :question_node
 
       def configure_question(highline_question)
         highline_question.readline = use_readline?

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -73,7 +73,7 @@ module Metalware
 
       # The answer value this question at this level would currently take.
       def current_answer_value
-        old_answer.nil? ? default : old_answer
+        default
       end
 
       def ask_boolean_question

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -59,15 +59,12 @@ module Metalware
         Metalware::Configurator.use_readline
       end
 
+      # Default for a boolean question which has a previous answer should be
+      # set to the input HighLine's `agree` expects, i.e. 'yes' or 'no'.
       def default_input
         return nil if default.nil?
-        type.boolean? ? boolean_default_input : default
-      end
-
-      def boolean_default_input
-        # Default for a boolean question which has a previous answer should be
-        # set to the input HighLine's `agree` expects, i.e. 'yes' or 'no'.
-        default ? 'yes' : 'no'
+        return (default ? 'yes' : 'no') if type.boolean?
+        default
       end
 
       def ask_boolean_question

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -11,12 +11,14 @@ HighLine::Menu.prepend Metalware::Patches::HighLine::Menu
 module Metalware
   class Configurator
     class Question
-      def initialize(question_node)
+      def initialize(question_node, progress_indicator)
         @question_node = question_node
         @highline = HighLine.new
+        @progress_indicator = progress_indicator
       end
 
-      attr_accessor :default, :progress_indicator
+      attr_accessor :default
+      attr_reader :progress_indicator
 
       def ask
         ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -16,7 +16,7 @@ module Metalware
         @highline = HighLine.new
       end
 
-      attr_accessor :default, :old_answer, :progress_indicator
+      attr_accessor :default, :progress_indicator
 
       def ask
         ask_method = choices.nil? ? "ask_#{type}_question" : 'ask_choice_question'

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -60,12 +60,11 @@ module Metalware
       end
 
       def default_input
+        return nil if default.nil?
         type.boolean? ? boolean_default_input : default
       end
 
       def boolean_default_input
-        return nil if default.nil?
-
         # Default for a boolean question which has a previous answer should be
         # set to the input HighLine's `agree` expects, i.e. 'yes' or 'no'.
         default ? 'yes' : 'no'

--- a/src/hash_mergers.rb
+++ b/src/hash_mergers.rb
@@ -7,13 +7,3 @@ require 'ostruct'
 
 Metalware::Utils::DynamicRequire.relative('hash_mergers')
 
-module Metalware
-  module HashMergers
-    class << self
-      def merge(**inputs, &templater_block)
-        OpenStruct.new(config: Config.new.merge(**inputs, &templater_block),
-                       answer: Answer.new.merge(**inputs, &templater_block))
-      end
-    end
-  end
-end

--- a/src/hash_mergers.rb
+++ b/src/hash_mergers.rb
@@ -6,4 +6,3 @@ require 'hash_mergers/hash_merger'
 require 'ostruct'
 
 Metalware::Utils::DynamicRequire.relative('hash_mergers')
-

--- a/src/hash_mergers/answer.rb
+++ b/src/hash_mergers/answer.rb
@@ -6,17 +6,26 @@ require 'hash_mergers/hash_merger'
 module Metalware
   module HashMergers
     class Answer < HashMerger
+      def initialize(alces)
+        @alces = alces
+        super
+      end
+
       private
+
+      attr_reader :alces
 
       def hash_array(*a)
         super.unshift(domain_answers)
       end
 
       def domain_answers
-        loader.flattened_configure_section(:domain)
-              .reject { |_k, value| value.default.nil? }
-              .map { |key, value| [key, value.default] }
-              .to_h
+        alces.questions
+             .section_tree(:domain)
+             .flatten
+             .reject { |_k, value| value.default.nil? }
+             .map { |key, value| [key, value.default] }
+             .to_h
       end
 
       def load_yaml(section, section_name)

--- a/src/hash_mergers/answer.rb
+++ b/src/hash_mergers/answer.rb
@@ -23,8 +23,8 @@ module Metalware
         alces.questions
              .section_tree(:domain)
              .flatten
-             .reject { |_k, value| value.default.nil? }
-             .map { |key, value| [key, value.default] }
+             .reject { |_k, value| value.yaml_default.nil? }
+             .map { |key, value| [key, value.yaml_default] }
              .to_h
       end
 

--- a/src/hash_mergers/answer.rb
+++ b/src/hash_mergers/answer.rb
@@ -21,11 +21,8 @@ module Metalware
 
       def domain_answers
         alces.questions
-             .section_tree(:domain)
-             .flatten
-             .reject { |_k, value| value.yaml_default.nil? }
-             .map { |key, value| [key, value.yaml_default] }
-             .to_h
+             .root_defaults
+             .reject { |_k, value| value.nil? }
       end
 
       def load_yaml(section, section_name)

--- a/src/namespaces/alces.rb
+++ b/src/namespaces/alces.rb
@@ -80,7 +80,7 @@ module Metalware
       def hash_mergers
         @hash_mergers ||= begin
           OpenStruct.new(config: HashMergers::Config.new,
-                         answer: HashMergers::Answer.new)
+                         answer: HashMergers::Answer.new(alces))
         end
       end
 

--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/string/strip'
 require 'nodeattr_interface'
 require 'group_cache'
 require 'hashie'
+require 'validation/loader'
 
 module Metalware
   module Namespaces
@@ -71,10 +72,18 @@ module Metalware
           @orphan_list ||= group_cache.orphans
         end
 
+        def questions
+          @questions ||= loader.question_tree
+        end
+
         private
 
         def group_cache
           @group_cache ||= GroupCache.new
+        end
+
+        def loader
+          @loader ||= Validation::Loader.new
         end
       end
     end

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -25,14 +25,16 @@ module Metalware
     def ask_questions
       filtered_each.with_index do |question, index|
         next unless ask_conditional_question?(question)
-        yield(question, index + 1)
+        yield question, "(#{index + 1}/#{questions_length})"
       end
     end
 
     def questions_length
-      num = 0
-      filtered_each { |_q| num += 1 }
-      num
+      questions_length ||= begin
+        num = 0
+        filtered_each { |_q| num += 1 }
+        num
+      end
     end
 
     def question?

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -65,6 +65,14 @@ module Metalware
       root.children.find { |c| c.name == section }
     end
 
+    # TODO: Should this be using node.name or node.identifier?
+    # TODO: Should this return the `content` OR a hashed version of self?
+    def flatten
+      filtered_each.reduce({}) do |memo, node|
+        memo.merge(node.name.to_sym => node.content)
+      end
+    end
+
     private
 
     # TODO: Stop wrapping the content in the validator, that should really

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -70,8 +70,10 @@ module Metalware
     end
 
     def root_defaults
-      section_tree(:domain).filtered_each.reduce({}) do |memo, question|
-        memo.merge(question.identifier => question.yaml_default)
+      @root_defaults ||= begin
+        section_tree(:domain).filtered_each.reduce({}) do |memo, question|
+          memo.merge(question.identifier => question.yaml_default)
+        end
       end
     end
 

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -71,7 +71,7 @@ module Metalware
 
     def flatten
       filtered_each.reduce({}) do |memo, node|
-        memo.merge(node.name.to_sym => node)
+        memo.merge(node.identifier => node)
       end
     end
 

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -69,6 +69,12 @@ module Metalware
       root.children.find { |c| c.name == section }
     end
 
+    def root_defaults
+      section_tree(:domain).filtered_each.reduce({}) do |memo, question|
+        memo.merge(question.identifier => question.yaml_default)
+      end
+    end
+
     def flatten
       filtered_each.reduce({}) do |memo, node|
         memo.merge(node.identifier => node)

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -6,8 +6,6 @@ require 'ostruct'
 
 module Metalware
   class QuestionTree < Tree::TreeNode
-    delegate :choices, :optional, :type, to: :os_content
-
     attr_accessor :answer
 
     BASE_TRAVERSALS = [
@@ -46,6 +44,8 @@ module Metalware
     end
 
     # START REMAPPING 'content' to variable names
+    delegate :choices, :optional, :type, to: :os_content
+
     def identifier
       os_content.identifier&.to_sym
     end
@@ -69,11 +69,9 @@ module Metalware
       root.children.find { |c| c.name == section }
     end
 
-    # TODO: Should this be using node.name or node.identifier?
-    # TODO: Should this return the `content` OR a hashed version of self?
     def flatten
       filtered_each.reduce({}) do |memo, node|
-        memo.merge(node.name.to_sym => node.content)
+        memo.merge(node.name.to_sym => node)
       end
     end
 

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -25,7 +25,8 @@ module Metalware
     def ask_questions
       filtered_each.with_index do |question, index|
         next unless ask_conditional_question?(question)
-        yield question, "(#{index + 1}/#{questions_length})"
+        progress = "(#{index + 1}/#{questions_length})"
+        yield create_question(question, progress)
       end
     end
 
@@ -61,12 +62,6 @@ module Metalware
     end
     # END REMAPPING CONTENT
 
-    # TODO: Eventually change this to a `question` method once the index's
-    # and defaults are rationalised
-    def create_question(progress_indicator)
-      Configurator::Question.new(self, progress_indicator)
-    end
-
     def section_tree(section)
       root.children.find { |c| c.name == section }
     end
@@ -94,8 +89,8 @@ module Metalware
       OpenStruct.new(content)
     end
 
-    # NOTE: This method is used by the iterator and thus DOES NOT reference
-    # the "self" object. Instead it should use the question passed to it
+    # NOTE: The following methods are used by the iterator and thus do not
+    # reference the self object
     def ask_conditional_question?(question)
       # Ask the question if the parent has a truthy answer
       if question.parent.answer
@@ -107,6 +102,10 @@ module Metalware
       else
         false
       end
+    end
+
+    def create_question(question, progress_indicator)
+      Configurator::Question.new(question, progress_indicator)
     end
   end
 end

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -63,8 +63,8 @@ module Metalware
 
     # TODO: Eventually change this to a `question` method once the index's
     # and defaults are rationalised
-    def create_question
-      Configurator::Question.new(self)
+    def create_question(progress_indicator)
+      Configurator::Question.new(self, progress_indicator)
     end
 
     def section_tree(section)

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -31,7 +31,7 @@ module Metalware
     end
 
     def questions_length
-      questions_length ||= begin
+      @questions_length ||= begin
         num = 0
         filtered_each { |_q| num += 1 }
         num

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -6,7 +6,7 @@ require 'ostruct'
 
 module Metalware
   class QuestionTree < Tree::TreeNode
-    delegate :default, :choices, :optional, :type, to: :os_content
+    delegate :choices, :optional, :type, to: :os_content
 
     attr_accessor :answer
 
@@ -45,15 +45,19 @@ module Metalware
       filtered_each.map(&:identifier)
     end
 
+    # START REMAPPING 'content' to variable names
     def identifier
       os_content.identifier&.to_sym
     end
 
-    # In `configure.yaml` the text is stored under the `question` key
-    # However "question" isn't super meaningful in this class
     def text
       os_content.question
     end
+
+    def yaml_default
+      os_content.default
+    end
+    # END REMAPPING CONTENT
 
     # TODO: Eventually change this to a `question` method once the index's
     # and defaults are rationalised

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -61,6 +61,10 @@ module Metalware
       Configurator::Question.new(self)
     end
 
+    def section_tree(section)
+      root.children.find { |c| c.name == section }
+    end
+
     private
 
     # TODO: Stop wrapping the content in the validator, that should really

--- a/src/validation/answer.rb
+++ b/src/validation/answer.rb
@@ -103,7 +103,7 @@ module Metalware
                 {
                   question: question,
                   answer: answer,
-                  type: questions_in_section[question][:type],
+                  type: questions_in_section[question].type,
                 }.tap { |h| h[:type] = 'string' if h[:type].nil? }
               )
             else

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -43,7 +43,7 @@ module Metalware
 
       # Returns a tree
       def configure_section(section)
-        question_tree.children.find { |c| c.name == section }
+        question_tree.section_tree(section)
       end
 
       # Returns a hash of identifiers and questions

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -41,18 +41,14 @@ module Metalware
           Validation::Configure.new(combined_configure_data).tree
       end
 
-      # Returns a tree
+      # TODO: Remove this method
       def configure_section(section)
         question_tree.section_tree(section)
       end
 
-      # Returns a hash of identifiers and questions
+      # TODO: Remove this method
       def flattened_configure_section(section)
-        section_root = configure_section(section)
-        section_root.each_with_object({}) do |node, memo|
-          next if section_root == node
-          memo[node.name.to_sym] = node.content
-        end
+        question_tree.section_tree(section).flatten
       end
 
       def group_cache


### PR DESCRIPTION
Based on #336, please merge it first.

This PR follows the same tack as the last. It mainly focuses on cleaning up the `Configurator` process to the point that `QuestionTree` is almost completely abstracted away. No when the `Configurator` loops through all the questions, the conditional questions are already skipped AND the progress bar has been set.

A bunch of the logic has also been cleaned up. This mostly entailed deleting logic and checking if tests still passed. Turns out basically none of the behaviour concerning how answers should be saved according to the defaults has been tested. This made refactoring it easy as it is already buggy so I wasn't concerned about more bugs. Primarily the focus was to reduce down all logic that hasn't been tested. See https://github.com/alces-software/metalware/pull/339/commits/d8ba4352673034fba263c6083048a10cec1f3979 and https://github.com/alces-software/metalware/pull/339/commits/192cd9e11070118254b0b4d1b61818a58946a554 and https://github.com/alces-software/metalware/pull/339/commits/b0afe6d0eae4810ef8c53ef405d04bb48ed5df3a

This meant that the `old_answers` do not get used by `highline` anymore. This partly makes sense as they should already been merged into the answers returned from the namespace.

The remained of this PR is focused at integrating the `QuestionTree` object into the namespace. The questions are required by `HashMergers::Answer` and the `Configurator`. So it made sense to define the questions on the namespace so they can be used in both locations. The defaults are now generated by a common method. See https://github.com/alces-software/metalware/commit/4756920110eaa32a38ffdcd8f83ddb0c2d659337

A few of the methods on the `loader` have also been moved onto `QuesionTree` as that is the more appropriate location.