### PR TITLE
Do not save orphan until the end of the configure process

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -184,7 +184,7 @@ module AlcesUtils
 
     def mock_group(name)
       AlcesUtils.check_and_raise_fakefs_error
-      group_cache.add(name)
+      group_cache { |c| c.add(name) }
       alces.instance_variable_set(:@groups, nil)
       alces.instance_variable_set(:@group_cache, nil)
       group = alces.groups.find_by_name(name)
@@ -217,7 +217,7 @@ module AlcesUtils
     end
 
     def group_cache
-      @group_cache ||= Metalware::GroupCache.new
+      Metalware::GroupCache.update { |c| yield c }
     end
 
     def hash_object(h = {})

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Metalware::Commands::Configure::Group do
     )
   end
 
+  def update_cache
+    Metalware::GroupCache.update { |c| yield c }
+  end
+
   def new_cache
     Metalware::GroupCache.new
   end
@@ -77,7 +81,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
     context 'when `cache/groups.yaml` exists' do
       it 'inserts primary group if new' do
         filesystem.test do
-          new_cache.add('first_group')
+          update_cache { |c| c.add('first_group') }
 
           run_configure_group 'second_group'
 
@@ -91,7 +95,9 @@ RSpec.describe Metalware::Commands::Configure::Group do
 
       it 'does nothing if primary group already presnt' do
         filesystem.test do
-          ['first_group', 'second_group'].each { |g| new_cache.add(g) }
+          ['first_group', 'second_group'].each do |group|
+            update_cache { |c| c.add(group) }
+          end
 
           run_configure_group 'second_group'
 

--- a/spec/group_cache_spec.rb
+++ b/spec/group_cache_spec.rb
@@ -133,4 +133,12 @@ RSpec.describe Metalware::GroupCache do
       expect(new_cache.orphans).to eq([orphan])
     end
   end
+
+  describe '#update' do
+    it 'yields the group cache' do
+      Metalware::GroupCache.update do |cache|
+        expect(cache).to be_a(Metalware::GroupCache)
+      end
+    end
+  end
 end

--- a/spec/group_cache_spec.rb
+++ b/spec/group_cache_spec.rb
@@ -123,13 +123,15 @@ RSpec.describe Metalware::GroupCache do
       orphans.each do |orphan|
         cache.push_orphan(orphan)
       end
+      cache.save
       expect(new_cache.orphans).to eq(orphans)
     end
 
-    it 'siliently refuses to double add orphans' do
+    it 'silently refuses to double add orphans' do
       orphan = 'node1'
-      new_cache.push_orphan(orphan)
-      new_cache.push_orphan(orphan)
+      cache.push_orphan(orphan)
+      cache.push_orphan(orphan)
+      cache.save
       expect(new_cache.orphans).to eq([orphan])
     end
   end

--- a/spec/group_cache_spec.rb
+++ b/spec/group_cache_spec.rb
@@ -142,5 +142,16 @@ RSpec.describe Metalware::GroupCache do
         expect(cache).to be_a(Metalware::GroupCache)
       end
     end
+
+    it 'does not save if there is an error' do
+      group = 'my-new-group'
+      expect do
+        Metalware::GroupCache.update do |cache|
+          cache.add group
+          raise 'something has gone wrong'
+        end
+      end.to raise_error(RuntimeError)
+      expect(Metalware::GroupCache.new.group? group).to eq false
+    end
   end
 end

--- a/src/commands/configure/group.rb
+++ b/src/commands/configure/group.rb
@@ -36,7 +36,6 @@ module Metalware
 
         def setup
           @group_name = args.first
-          @cache = GroupCache.new
         end
 
         def configurator
@@ -49,7 +48,7 @@ module Metalware
         end
 
         def custom_configuration
-          cache.add(group_name)
+          GroupCache.update { |c| c.add group_name }
         end
       end
     end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -84,15 +84,19 @@ module Metalware
     end
 
     def configure(answers = nil)
-      answers ||= ask_questions
-      save_answers(answers)
+      GroupCache.update do |cache|
+        @group_cache = cache
+        answers ||= ask_questions
+        save_answers(answers)
+      end
     end
 
     private
 
     attr_reader :alces,
                 :questions_section,
-                :name
+                :name,
+                :group_cache
 
     def loader
       @loader ||= Validation::Loader.new
@@ -100,10 +104,6 @@ module Metalware
 
     def saver
       @saver ||= Validation::Saver.new
-    end
-
-    def group_cache
-      @group_cache ||= GroupCache.new
     end
 
     def ask_questions
@@ -191,7 +191,7 @@ module Metalware
     end
 
     def create_new_group
-      idx = GroupCache.new.next_available_index
+      idx = group_cache.next_available_index
       Namespaces::Group.new(alces, name, index: idx)
     end
 

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -29,6 +29,10 @@ module Metalware
   class GroupCache
     include Enumerable
 
+    def self.update
+      yield new
+    end
+
     def initialize(force_reload_file: false)
       @force_reload = force_reload_file
     end

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -30,7 +30,9 @@ module Metalware
     include Enumerable
 
     def self.update
-      yield new
+      cache = new
+      yield cache
+      cache.save
     end
 
     def initialize(force_reload_file: false)
@@ -45,13 +47,11 @@ module Metalware
       return if group?(group)
       primary_groups_hash[group.to_sym] = next_available_index
       bump_next_index
-      save
     end
 
     def remove(group)
       pgh = primary_groups_hash
       pgh.delete(group.to_sym)
-      save
     end
 
     def each
@@ -84,7 +84,6 @@ module Metalware
     def push_orphan(name)
       return if orphans.include?(name)
       orphans.push(name)
-      save
     end
 
     def save

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -87,6 +87,18 @@ module Metalware
       save
     end
 
+    def save
+      groups_hash = primary_groups_hash.dup.tap { |x| x.delete(:orphan) }
+      payload = {
+        next_index: next_available_index,
+        primary_groups: groups_hash,
+        orphans: orphans,
+      }
+      Data.dump(file_path.group_cache, payload)
+      @data = nil # Reloads the cached file
+      data
+    end
+
     private
 
     attr_reader :force_reload
@@ -122,18 +134,6 @@ module Metalware
 
     def bump_next_index
       data[:next_index] += 1
-    end
-
-    def save
-      groups_hash = primary_groups_hash.dup.tap { |x| x.delete(:orphan) }
-      payload = {
-        next_index: next_available_index,
-        primary_groups: groups_hash,
-        orphans: orphans,
-      }
-      Data.dump(file_path.group_cache, payload)
-      @data = nil # Reloads the cached file
-      data
     end
   end
 end


### PR DESCRIPTION
Based on #340 , please merge it first.

Previously the orphan nodes where being saved to the `group_cache` right at the beginning of the configure process. This meant exiting it early still resulted in the orphan being added.

The fix is not to implicitly save the `GroupCache` after a node is added. Instead a new `GroupCache.update` method has been created, which can be used instead of `new`. It will yield an instance of the cache and save it at then end. This means if the process exits early, the cache is not saved.

Fixes #341 