### PR TITLE
Fix merging of `configure.yaml` defaults

### DIFF
--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -87,10 +87,10 @@ RSpec.describe Metalware::Commands::Power do
           lines = output.lines.map(&:strip)
 
           expect(lines).to eq([
-            'node01: error123',
-            'node02: output123',
-            'node03: output123',
-          ])
+                                'node01: error123',
+                                'node02: output123',
+                                'node03: output123',
+                              ])
         end.not_to raise_error
       end
     end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe Metalware::Configurator do
     let :group_default { 'I am the group level yaml default' }
     let :node_default { 'I am the node level yaml default' }
     let :local_default { 'I am the local level yaml default' }
-    let :domain_answer { 'I am the domain answer' }
+    let :domain_answer { 'Domain answer with ERB, <%= node.name %>' }
     let :identifier { :question_identifier }
     let :question do
       {
@@ -520,7 +520,7 @@ RSpec.describe Metalware::Configurator do
 
     context 'when configuring a group' do
       subject do
-        alces.groups.find_by_name(group_name).answer.send(identifier)
+        alces.groups.find_by_name(group_name).answer.to_h[identifier]
       end
       before :each { configure_group }
 
@@ -561,7 +561,7 @@ RSpec.describe Metalware::Configurator do
       let :node_name { 'my_super_awesome_node' }
       let :group_answer { 'I am the group level answer' }
       subject do
-        alces.nodes.find_by_name(node_name).answer[identifier]
+        alces.nodes.find_by_name(node_name).answer.to_h[identifier]
       end
       let :load_answer do
         path = Metalware::FilePath.node_answers(node_name)
@@ -595,7 +595,7 @@ RSpec.describe Metalware::Configurator do
 
     context 'when configuring the local node' do
       subject do
-        alces.local.answer[identifier]
+        alces.local.answer.to_h[identifier]
       end
       let :load_answer do
         path = Metalware::FilePath.local_answers

--- a/spec/group_cache_spec.rb
+++ b/spec/group_cache_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Metalware::GroupCache do
           raise 'something has gone wrong'
         end
       end.to raise_error(RuntimeError)
-      expect(Metalware::GroupCache.new.group? group).to eq false
+      expect(Metalware::GroupCache.new.group?(group)).to eq false
     end
   end
 end

--- a/spec/question_tree_spec.rb
+++ b/spec/question_tree_spec.rb
@@ -137,6 +137,15 @@ RSpec.describe Metalware::QuestionTree do
       { identifier: 'local_question' }
     end
 
+    let :correct_defaults do
+      {
+        domain_question[:identifier].to_sym => 'domain_default',
+        group_question[:identifier].to_sym => 'group_default',
+        node_question[:identifier].to_sym => 'node_default',
+        local_question[:identifier].to_sym => 'local_default',
+      }
+    end
+
     let :question_hash do
       {
         domain: make('domain_default', domain_question),
@@ -166,8 +175,7 @@ RSpec.describe Metalware::QuestionTree do
         subject { tree.section_tree(section) }
 
         it "only uses the domain question's default" do
-          defaults = { domain_question: 'domain_default' }
-          expect(subject.root_defaults).to eq(defaults)
+          expect(subject.root_defaults).to eq(correct_defaults)
         end
       end
     end

--- a/spec/question_tree_spec.rb
+++ b/spec/question_tree_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Metalware::QuestionTree do
       context "when called on the '#{section}' section" do
         subject { tree.section_tree(section) }
 
-        it "only uses the domain question's default" do
+        it 'uses the merged default hash' do
           expect(subject.root_defaults).to eq(correct_defaults)
         end
       end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -137,7 +137,7 @@ module Metalware
         when Namespaces::Node
           group_for_node(configure_object).answer
         end
-      end.to_h # Ensure the un-rendered answer is used
+      end.to_h # Ensure the un-rendered answer are used
     end
 
     # Orphan nodes will not appear in the genders file at this point

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -137,7 +137,7 @@ module Metalware
         when Namespaces::Node
           group_for_node(configure_object).answer
         end
-      end
+      end.to_h # Ensure the un-rendered answer is used
     end
 
     # Orphan nodes will not appear in the genders file at this point

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -63,7 +63,6 @@ module Metalware
         default
       end
 
-
       # Default for a boolean question which has a previous answer should be
       # set to the input HighLine's `agree` expects, i.e. 'yes' or 'no'.
       def human_readable_boolean_default

--- a/src/hash_mergers/answer.rb
+++ b/src/hash_mergers/answer.rb
@@ -16,9 +16,7 @@ module Metalware
       attr_reader :alces
 
       def defaults
-        alces.questions
-             .root_defaults
-             .reject { |_k, value| value.nil? }
+        alces.questions.root_defaults
       end
 
       def load_yaml(section, section_name)

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -69,7 +69,7 @@ module Metalware
     def root_defaults
       @root_defaults ||= begin
         [:local, :node, :group, :domain].reduce({}) do |memo, section|
-          memo.merge(section_default_hash section)
+          memo.merge(section_default_hash(section))
         end
       end
     end

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -68,7 +68,9 @@ module Metalware
 
     def root_defaults
       @root_defaults ||= begin
-        section_default_hash :domain
+        [:local, :node, :group, :domain].reduce({}) do |memo, section|
+          memo.merge(section_default_hash section)
+        end
       end
     end
 

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -68,9 +68,7 @@ module Metalware
 
     def root_defaults
       @root_defaults ||= begin
-        section_tree(:domain).filtered_each.reduce({}) do |memo, question|
-          memo.merge(question.identifier => question.yaml_default)
-        end
+        section_default_hash :domain
       end
     end
 
@@ -81,6 +79,12 @@ module Metalware
     end
 
     private
+
+    def section_default_hash(section)
+      section_tree(section).filtered_each.reduce({}) do |memo, question|
+        memo.merge(question.identifier => question.yaml_default)
+      end
+    end
 
     # TODO: Stop wrapping the content in the validator, that should really
     # be done within the QuestionTree object. It doesn't hurt, as you can't

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -68,8 +68,8 @@ module Metalware
 
     def root_defaults
       @root_defaults ||= begin
-        [:local, :node, :group, :domain].reduce({}) do |memo, section|
-          memo.merge(section_default_hash(section))
+        Constants::CONFIGURE_SECTIONS.reverse.reduce({}) do |memo, section|
+          memo.merge(section_default_hash section)
         end
       end
     end

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -69,7 +69,7 @@ module Metalware
     def root_defaults
       @root_defaults ||= begin
         Constants::CONFIGURE_SECTIONS.reverse.reduce({}) do |memo, section|
-          memo.merge(section_default_hash section)
+          memo.merge(section_default_hash(section))
         end
       end
     end


### PR DESCRIPTION
Based on #343, please merge it first. This PR fixes #345.

In an attempt to ensure all questions use the same yaml defaults regardless in level, the defaults from non-domain levels where being ignored. This meant that questions that do not get asked at the domain level can not have a default at all.

Instead the yaml defaults at each level are merged in reverse priority order to form the root defaults for all questions. This ensures each question can have a default BUT which default is used is independent of section level.

Also fixes #347 which in the end being an easy fix (see https://github.com/alces-software/metalware/pull/346/commits/6736efdfcf03a58242af3d4d983cb29b67fae7d4). The error was caused by the rendering of the answers during the save process. However the save process should be using the un-rendered answers anyway. So before the comparison, the existing answers are converted to a regular hash that causes the render to be skipped.