### PR TITLE
Add ipmi command flags back to the cli

### DIFF
--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -80,4 +80,34 @@ RSpec.describe Metalware::Commands::Ipmi do
       include_examples 'runs on each node'
     end
   end
+
+  describe Metalware::Commands::Ipmi::Command do
+    subject { Metalware::Commands::Ipmi::Command }
+    let :regular_command { 'regular_command' }
+    let :options_command { 'options_command' }
+    let :args { [nil, regular_command] }
+    let :options { OpenStruct.new(command: options_command) }
+
+    describe '::parse' do
+      it 'errors if both command inputs are used' do
+        expect do
+          subject.parse(args, options)
+        end.to raise_error Metalware::InvalidInput
+      end
+
+      it 'uses the regular COMMAND input' do
+        expect(subject.parse(args, OpenStruct.new)).to eq(regular_command)
+      end
+
+      it 'uses the options LEGACY_COMMAND input' do
+        expect(subject.parse([nil], options)).to eq(options_command)
+      end
+
+      it 'errors without a command input' do
+        expect do
+          subject.parse([], OpenStruct.new)
+        end.to raise_error Metalware::InvalidInput
+      end
+    end
+  end
 end

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -291,6 +291,10 @@ commands:
     action: Commands::Ipmi
     options:
       - *gender_option
+      - tags: [-c, -k, --command]
+        description: >
+          Legacy tags used to specify the input. Their use has been
+          deprecated by the COMMAND input.
 
   orchestrate:
     syntax: metal orchestrate [SUB_COMMAND] [options]

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -284,14 +284,15 @@ commands:
           node name in the hunter cache
 
   ipmi:
-    syntax: metal ipmi NODE_IDENTIFIER COMMAND [options]
+    syntax: metal ipmi NODE_IDENTIFIER [COMMAND] [options]
     summary: Perform ipmi commands on single or multiple machines
     description: >
        Perform ipmi commands on single or multiple machines
     action: Commands::Ipmi
     options:
       - *gender_option
-      - tags: [-c, -k, --command]
+      - tags: [-k, -c, --command LEGACY_COMMAND]
+        type: String
         description: >
           Legacy tags used to specify the input. Their use has been
           deprecated by the COMMAND input.

--- a/src/commands/console.rb
+++ b/src/commands/console.rb
@@ -29,6 +29,11 @@ module Metalware
     class Console < Ipmi
       private
 
+      # Empty `setup` as we want to skip behaviour of `ipmi`'s `setup` method,
+      # which is not relevant for the custom behaviour of `console` (ideally we
+      # wouldn't inherit from it at all, but that's what we do for now).
+      def setup; end
+
       def run
         raise MetalwareError, 'Console not supported on virtual machines' if vm?(node)
         raise MetalwareError, "Unable to connect to #{node.name}" unless valid_connection?

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -43,9 +43,9 @@ module Metalware
           regular_command = (args.length > 1 ? args[1] : nil)
           two_commands = regular_command && options.command
           raise InvalidInput, TWO_COMMANDS_ERROR if two_commands
-          (regular_command || options.command).tap do |command|
-            raise InvalidInput, NO_COMMAND_ERROR unless command
-          end
+          command = (regular_command || options.command)
+          raise InvalidInput, NO_COMMAND_ERROR unless command
+          command
         end
       end
 

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -31,13 +31,13 @@ module Metalware
   module Commands
     class Ipmi < CommandHelpers::BaseCommand
       class Command
-        TWO_COMMANDS_ERROR = <<~EOF.squish
+        TWO_COMMANDS_ERROR = <<~ERROR.squish
           The COMMAND input can not be used with a LEGACY_COMMAND flag
-        EOF
+        ERROR
 
-        NO_COMMAND_ERROR = <<~EOF.squish
+        NO_COMMAND_ERROR = <<~ERROR.squish
           No command given. Use --help for more information
-        EOF
+        ERROR
 
         def self.parse(args, options)
           regular_command = (args.length > 1 ? args[1] : nil)

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -71,7 +71,13 @@ module Metalware
 
       private
 
+      attr_reader :command_argument
+
       prepend CommandHelpers::NodeIdentifier
+
+      def setup
+        @command_argument = Command.parse(args, options)
+      end
 
       def run
         nodes.each do |node|
@@ -105,10 +111,6 @@ module Metalware
           ipmitool -H #{node.name}.bmc -I lanplus #{render_credentials(node)}
           #{arguments}
         COMMAND
-      end
-
-      def command_argument
-        Command.parse(args, options)
       end
 
       # By default the arguments passed to `ipmitool` are the same as the

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -31,12 +31,15 @@ module Metalware
   module Commands
     class Ipmi < CommandHelpers::BaseCommand
       Command = Struct.new(:args, :options) do
-        TWO_COMMANDS_ERROR = <<~ERROR.squish
-          The COMMAND input can not be used with a LEGACY_COMMAND flag
+        SEE_HELP = 'Use --help for more information'
+
+        MULTIPLE_COMMANDS_ERROR = <<~ERROR.squish
+          Both command option and argument given but only one may be provided.
+          #{SEE_HELP}
         ERROR
 
         NO_COMMAND_ERROR = <<~ERROR.squish
-          No command given. Use --help for more information
+          No command given. #{SEE_HELP}
         ERROR
 
         def self.parse(args, options)
@@ -44,7 +47,7 @@ module Metalware
         end
 
         def parse
-          raise InvalidInput, TWO_COMMANDS_ERROR if multiple_commands_given?
+          raise InvalidInput, MULTIPLE_COMMANDS_ERROR if multiple_commands_given?
           raise InvalidInput, NO_COMMAND_ERROR if no_command_given?
           provided_commands.first
         end

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -32,12 +32,11 @@ module Metalware
     class Ipmi < CommandHelpers::BaseCommand
       class Command
         TWO_COMMANDS_ERROR = <<~EOF.squish
-          The regular COMMAND input can not be used with a LEGACY_COMMAND
-          flag
+          The COMMAND input can not be used with a LEGACY_COMMAND flag
         EOF
 
         NO_COMMAND_ERROR = <<~EOF.squish
-          No command given. Refer to 'metal ipmi -h' for assistance
+          No command given. Use --help for more information
         EOF
 
         def self.parse(args, options)
@@ -89,7 +88,7 @@ module Metalware
       end
 
       def command_argument
-        args[1]
+        Command.parse(args, options)
       end
 
       # By default the arguments passed to `ipmitool` are the same as the

--- a/src/commands/ipmi.rb
+++ b/src/commands/ipmi.rb
@@ -30,6 +30,26 @@ require 'vm'
 module Metalware
   module Commands
     class Ipmi < CommandHelpers::BaseCommand
+      class Command
+        TWO_COMMANDS_ERROR = <<~EOF.squish
+          The regular COMMAND input can not be used with a LEGACY_COMMAND
+          flag
+        EOF
+
+        NO_COMMAND_ERROR = <<~EOF.squish
+          No command given. Refer to 'metal ipmi -h' for assistance
+        EOF
+
+        def self.parse(args, options)
+          regular_command = (args.length > 1 ? args[1] : nil)
+          two_commands = regular_command && options.command
+          raise InvalidInput, TWO_COMMANDS_ERROR if two_commands
+          (regular_command || options.command).tap do |command|
+            raise InvalidInput, NO_COMMAND_ERROR unless command
+          end
+        end
+      end
+
       private
 
       prepend CommandHelpers::NodeIdentifier


### PR DESCRIPTION
Based on #346, please merge it first.

This fixes #348 which raise a very good point that the command input to `ipmi` has been highly volatile. This has been the case for various reasons, without going into depth. However to keep the current `UI` consistent with passed versions, the `-k`, `-c` and `--command` flags have been added back into the `cli`.

They serve no purpose internally within metalware as the command can be inferred by commander automatically. However including them in the command will no longer raise an error.

It does mean however the following command will still error:
```
metal ipmi -c COMMAND -g GROUP_NAME
```
Because the `-c` flag is ignored, metalware will interpret `COMMAND` as the group input and `GROUP_NAME` as the command input. Whilst this might be unexpected, the first input is consistently used as the node/group input into the other `metal` commands (where applicable).

It would be possible to fix this, however it would require adding additional logic to metalware internally rather than updating the `cli`.