### PR TITLE
Correctly display integer values during the configure process

### DIFF
--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -60,7 +60,7 @@ module Metalware
 
       def default_input
         return human_readable_boolean_default if type.boolean?
-        default.to_s
+        default.nil? ? default : default.to_s
       end
 
       # Default for a boolean question which has a previous answer should be

--- a/src/configurator/question.rb
+++ b/src/configurator/question.rb
@@ -60,7 +60,7 @@ module Metalware
 
       def default_input
         return human_readable_boolean_default if type.boolean?
-        default
+        default.to_s
       end
 
       # Default for a boolean question which has a previous answer should be


### PR DESCRIPTION
This pr implements a fix for #275 by simply converting the default to a string  