### PR TITLE
Create an utility for opening files in an editor

### DIFF
--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -4,6 +4,7 @@ require 'utils/editor'
 
 RSpec.describe Metalware::Utils::Editor do
   subject { Metalware::Utils::Editor }
+  let :default_editor { subject::DEFAULT_EDITOR }
 
   context 'with the environment variables unset' do
     before :each do |example|
@@ -12,8 +13,8 @@ RSpec.describe Metalware::Utils::Editor do
     end
 
     describe '#editor' do
-      it 'defaults to vi' do
-        expect(subject.editor).to eq('vi')
+      it 'uses the default editor' do
+        expect(subject.editor).to eq(default_editor)
       end
 
       context 'when $EDITOR is set' do
@@ -42,14 +43,14 @@ RSpec.describe Metalware::Utils::Editor do
 
       let :file { '/tmp/some-random-file' }
 
-      it 'opens the file in vi' do
-        vi_cmd = "vi #{file}"
+      it 'opens the file in the default editor' do
+        cmd = "#{default_editor} #{file}"
         expect(Metalware::SystemCommand).to \
-          receive(:run).with(vi_cmd).and_call_original
+          receive(:run).with(cmd).and_call_original
         thr = Thread.new { subject.open(file) }
         sleep 0.1
         expect(thr).to be_alive
-        expect(`ps | grep vi`).to include('vi')
+        expect(`ps | grep #{default_editor}`).to include(default_editor)
         thr.kill
         sleep 0.001 while thr.alive?
       end
@@ -57,7 +58,7 @@ RSpec.describe Metalware::Utils::Editor do
       it 'detects when the editor has ended' do
         thr = Thread.new { subject.open(file) }
         sleep 0.1
-        pid = `ps | grep vi`.split[0]
+        pid = `ps | grep #{default_editor}`.split[0]
         expect(pid).to match(/\d+/)
         expect do
           Process.kill(9, pid.to_i)

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Metalware::Utils::Editor do
         it 'uses the $EDITOR env var' do
           expect(subject.editor).to eq(editor)
         end
+
+        context 'when $VISUAL is set' do
+          let :visual { 'VISUAL-ENV-VAR' }
+          before :each { ENV['VISUAL'] = visual }
+
+          it 'uses the $VISUAL env var' do
+            expect(subject.editor).to eq(visual)
+          end
+        end
       end
     end
   end

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe Metalware::Utils::Editor do
       it 'defaults to vi' do
         expect(subject.editor).to eq('vi')
       end
+
+      context 'when $EDITOR is set' do
+        let :editor { 'EDITOR-ENV-VAR' }
+        before :each { ENV['EDITOR'] = editor }
+
+        it 'uses the $EDITOR env var' do
+          expect(subject.editor).to eq(editor)
+        end
+      end
     end
   end
 end

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'utils/editor'
+
+RSpec.describe Metalware::Utils::Editor do
+  subject { Metalware::Utils::Editor }
+
+  context 'with the environment variables unset' do
+    before :each do |example|
+      ENV['VISUAL'] = nil
+      ENV['EDITOR'] = nil
+    end
+
+    describe '#editor' do
+      it 'defaults to vi' do
+        expect(subject.editor).to eq('vi')
+      end
+    end
+  end
+end

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Metalware::Utils::Editor do
 
   context 'with the environment variables unset' do
     before :each do |example|
-      ENV['VISUAL'] = nil
-      ENV['EDITOR'] = nil
+      ENV.delete('VISUAL')
+      ENV.delete('EDITOR')
     end
 
     describe '#editor' do

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -37,33 +37,15 @@ RSpec.describe Metalware::Utils::Editor do
     end
 
     describe '#open' do
-      after :each do
-        Thread.list.each { |t| t.kill unless t == Thread.current }
-      end
-
       let :file { '/tmp/some-random-file' }
 
       it 'opens the file in the default editor' do
         cmd = "#{default_editor} #{file}"
-        expect(Metalware::SystemCommand).to \
-          receive(:run).with(cmd).and_call_original
+        expect(Metalware::SystemCommand).to receive(:no_capture).with(cmd)
         thr = Thread.new { subject.open(file) }
         sleep 0.1
-        expect(thr).to be_alive
-        expect(`ps | grep #{default_editor}`).to include(default_editor)
         thr.kill
         sleep 0.001 while thr.alive?
-      end
-
-      it 'detects when the editor has ended' do
-        thr = Thread.new { subject.open(file) }
-        sleep 0.1
-        pid = `ps | grep #{default_editor}`.split[0]
-        expect(pid).to match(/\d+/)
-        expect do
-          Process.kill(9, pid.to_i)
-          Timeout::timeout(2) { sleep 0.001 while thr.alive? }
-        end.not_to raise_error
       end
     end
   end

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -34,5 +34,22 @@ RSpec.describe Metalware::Utils::Editor do
         end
       end
     end
+
+    describe '#open' do
+      let :file { '/tmp/some-random-file' }
+
+      it 'opens the file in vi' do
+        vi_cmd = "vi #{file}"
+        expect(Metalware::SystemCommand).to \
+          receive(:run).with(vi_cmd).and_call_original
+        thr = Thread.new { subject.open(file) }
+        sleep 0.1
+        expect(thr).to be_alive
+        expect(`ps | grep vi`).to include('vi')
+        thr.kill
+        sleep 0.001 while thr.alive?
+      end
+    end
   end
 end
+

--- a/src/system_command.rb
+++ b/src/system_command.rb
@@ -53,6 +53,11 @@ module Metalware
         }
       end
 
+      def no_capture(command)
+        MetalLog.info("SystemCommand: #{command}")
+        system(command)
+      end
+
       private
 
       def capture3(command)

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -6,8 +6,8 @@ module Metalware
   module Utils
     class Editor
       class << self
-        def open
-          
+        def open(file)
+          SystemCommand.run("#{editor} #{file}")
         end
 
         def editor

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -9,7 +9,7 @@ module Metalware
 
       class << self
         def open(file)
-          SystemCommand.run("#{editor} #{file}")
+          SystemCommand.no_capture("#{editor} #{file}")
         end
 
         def editor

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -11,7 +11,9 @@ module Metalware
         end
 
         def editor
-          if ENV['EDITOR'].present?
+          if ENV['VISUAL'].present?
+            ENV['VISUAL']
+          elsif ENV['EDITOR'].present?
             ENV['EDITOR']
           else
             'vi'

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -11,7 +11,11 @@ module Metalware
         end
 
         def editor
-          'vi'
+          if ENV['EDITOR'].present?
+            ENV['EDITOR']
+          else
+            'vi'
+          end
         end
       end
     end

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -11,13 +11,7 @@ module Metalware
         end
 
         def editor
-          if ENV['VISUAL'].present?
-            ENV['VISUAL']
-          elsif ENV['EDITOR'].present?
-            ENV['EDITOR']
-          else
-            'vi'
-          end
+          ENV['VISUAL'] || ENV['EDITOR'] || 'vi'
         end
       end
     end

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'utils'
+
+module Metalware
+  module Utils
+    class Editor
+      class << self
+        def open
+          
+        end
+
+        def editor
+          'vi'
+        end
+      end
+    end
+  end
+end

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -5,13 +5,15 @@ require 'utils'
 module Metalware
   module Utils
     class Editor
+      DEFAULT_EDITOR = 'vi'
+
       class << self
         def open(file)
           SystemCommand.run("#{editor} #{file}")
         end
 
         def editor
-          ENV['VISUAL'] || ENV['EDITOR'] || 'vi'
+          ENV['VISUAL'] || ENV['EDITOR'] || DEFAULT_EDITOR
         end
       end
     end


### PR DESCRIPTION
Opening files in an editor will become a key component of #356.

This utility takes a file path and opens it in the system editor according to `$VISUAL` or `$EDITOR`. If neither are set, then `vi` is used instead.

Most of the commits are concerning the tests. Note that the editor command is not ran during the spec to prevent it opening. Opening the editor during the spec does not play well with `rspec` and creates issues with swap files.

Instead the command is expected to be called with the correct arguments. The ability to open and close the editor has been tested manually. As this action is blocking, as long as the correct command is called the outcome shouldn't change.