### PR TITLE
Adding paths to asset files

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -83,6 +83,7 @@ mkdir -p /var/lib/metalware/events
 mkdir -p /var/lib/metalware/repo
 mkdir -p /var/lib/metalware/plugins
 mkdir -p /var/lib/metalware/answers/{groups,nodes}
+mkdir -p /var/lib/metalware/assets
 mkdir -p /etc/named
 touch /etc/named/metalware.conf
 chmod a+rw /var/lib/metalware/events

--- a/spec/asset_path_spec.rb
+++ b/spec/asset_path_spec.rb
@@ -1,0 +1,15 @@
+require 'file_path'
+
+RSpec.describe Metalware::FilePath do
+  describe 'asset files' do
+    let :file_path { Metalware::FilePath }
+
+    it 'defines an asset template' do
+      expect(file_path.asset_template('rack')).to eq('/var/lib/metalware/repo/assets/rack.yaml')
+    end
+
+    it 'defines an asset final save path' do
+      expect(file_path.asset_final('rack01')).to eq('/var/lib/metalware/assets/rack01.yaml')
+    end
+  end
+end

--- a/spec/asset_path_spec.rb
+++ b/spec/asset_path_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe Metalware::FilePath do
     let :file_path { Metalware::FilePath }
 
     it 'defines an asset template' do
-      expect(file_path.asset_template('rack')).to eq('/var/lib/metalware/repo/assets/rack.yaml')
+      path = File.join(file_path.repo, 'assets', 'rack.yaml')
+      expect(file_path.asset_template('rack')).to eq(path)
     end
 
     it 'defines an asset final save path' do
-      expect(file_path.asset_final('rack01')).to eq('/var/lib/metalware/assets/rack01.yaml')
+      path = File.join(file_path.metalware_data, 'assets', 'rack01.yaml')
+      expect(file_path.asset('rack01')).to eq(path)
     end
   end
 end

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -200,6 +200,7 @@ class FileSystem
       '/var/lib/metalware/repo',
       '/var/lib/metalware/answers/groups',
       '/var/lib/metalware/answers/nodes',
+      '/var/lib/metalware/assets',
       '/var/named',
       '/var/log/metalware',
       File.join(Metalware::Constants::METALWARE_INSTALL_PATH, 'templates'),

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -148,8 +148,12 @@ module Metalware
         '/var/log/metalware'
       end
 
+      def asset_template(type) 
+        File.join('/var/lib/metalware/repo/assets', "#{type}.yaml")
+      end
+    
       def asset_final(name)
-        File.join('/var/lib/metalware/assets/', "#{name}.yaml")
+        File.join('/var/lib/metalware/assets', "#{name}.yaml")
       end
 
       private

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -57,7 +57,7 @@ module Metalware
       end
 
       def answer_files
-	      File.join(metalware_data, 'answers')	
+        File.join(metalware_data, 'answers')
       end
 
       def server_config
@@ -148,10 +148,10 @@ module Metalware
         '/var/log/metalware'
       end
 
-      def asset_template(type) 
+      def asset_template(type)
         File.join('/var/lib/metalware/repo/assets', "#{type}.yaml")
       end
-    
+
       def asset_final(name)
         File.join('/var/lib/metalware/assets', "#{name}.yaml")
       end

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -149,11 +149,11 @@ module Metalware
       end
 
       def asset_template(type)
-        File.join('/var/lib/metalware/repo/assets', "#{type}.yaml")
+        File.join(repo, 'assets', type + 'yaml')
       end
 
       def asset(name)
-        File.join('/var/lib/metalware/assets', "#{name}.yaml")
+        File.join(metalware_data, 'assets', name + 'yaml')
       end
 
       private

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -117,7 +117,7 @@ module Metalware
       end
 
       def rendered_files
-        Constants::RENDERED_DIR_PATH
+        rendered_dir
       end
 
       def staging(path)

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -152,7 +152,7 @@ module Metalware
         File.join('/var/lib/metalware/repo/assets', "#{type}.yaml")
       end
 
-      def asset_final(name)
+      def asset(name)
         File.join('/var/lib/metalware/assets', "#{name}.yaml")
       end
 

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -149,11 +149,11 @@ module Metalware
       end
 
       def asset_template(type)
-        File.join(repo, 'assets', type + 'yaml')
+        File.join(repo, 'assets', type + '.yaml')
       end
 
       def asset(name)
-        File.join(metalware_data, 'assets', name + 'yaml')
+        File.join(metalware_data, 'assets', name + '.yaml')
       end
 
       private

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -57,7 +57,7 @@ module Metalware
       end
 
       def answer_files
-        '/var/lib/metalware/answers'
+	      File.join(metalware_data, 'answers')	
       end
 
       def server_config
@@ -65,7 +65,7 @@ module Metalware
       end
 
       def repo
-        '/var/lib/metalware/repo'
+        File.join(metalware_data, 'repo')
       end
 
       def overview
@@ -73,7 +73,7 @@ module Metalware
       end
 
       def plugins_dir
-        File.join(Constants::METALWARE_DATA_PATH, 'plugins')
+        File.join(metalware_data, 'plugins')
       end
 
       def repo_relative_path_to(path)
@@ -117,7 +117,7 @@ module Metalware
       end
 
       def rendered_files
-        '/var/lib/metalware/rendered'
+        Constants::RENDERED_DIR_PATH
       end
 
       def staging(path)
@@ -146,6 +146,10 @@ module Metalware
 
       def log
         '/var/log/metalware'
+      end
+
+      def asset_final(name)
+        File.join('/var/lib/metalware/assets/', "#{name}.yaml")
       end
 
       private


### PR DESCRIPTION
* Implements the two methods that define the paths for asset templates and save locations; `asset_template` and `asset_final` respectively.
* Adds a `spec` for testing these methods return correct paths
* Replaces any hard coded paths within `FilePath` that simply replicate other method calls with the appropriate method
* Edits the `install` script and `FileSystem` class to include the `/v/l/m/assets` dir in their processes