### PR TITLE
Load the assets into the namespace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,14 @@ Style/ClassAndModuleChildren:
 # to get this.
 Style/DoubleNegation:
   Enabled: false
+
+# Allow the following parameter names. The additional "s, a, b" are used commonly
+# with method missing
+Naming/UncommunicativeMethodParamName:
+  AllowedNames: [io, id, to, by, on, in, at, s, a, b, _a, _b, e, _e]
+
+# Turn off Heredoc delimiter check. EOF is used extensively and will continue
+# to be used
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,9 @@ Style/WordArray:
 # Do not preder trailing commas in multi-line hash/array literals - better as
 # when something is added to a literal the previous last line does not also
 # need to be changed, which also makes diffs smaller
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 # Do not require documentation for top-level classes or modules - seems

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,14 +15,6 @@ Style/SymbolArray:
 Style/WordArray:
   Enabled: false
 
-# Do not preder trailing commas in multi-line hash/array literals - better as
-# when something is added to a literal the previous last line does not also
-# need to be changed, which also makes diffs smaller
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
-
 # Do not require documentation for top-level classes or modules - seems
 # unnecessary for the project at the moment.
 Style/Documentation:

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
 
           expect(new_cache.primary_groups).to eq [
             'testnodes',
-            'orphan',
+            'orphan'
           ]
         end
       end
@@ -88,7 +88,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
           expect(new_cache.primary_groups).to eq [
             'first_group',
             'second_group',
-            'orphan',
+            'orphan'
           ]
         end
       end
@@ -104,7 +104,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
           expect(new_cache.primary_groups).to eq [
             'first_group',
             'second_group',
-            'orphan',
+            'orphan'
           ]
         end
       end

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -203,7 +203,7 @@ class FileSystem
       '/var/lib/metalware/assets',
       '/var/named',
       '/var/log/metalware',
-      File.join(Metalware::Constants::METALWARE_INSTALL_PATH, 'templates'),
+      File.join(Metalware::Constants::METALWARE_INSTALL_PATH, 'templates')
     ].each do |path|
       FileUtils.mkdir_p(path)
     end

--- a/spec/minimal_repo.rb
+++ b/spec/minimal_repo.rb
@@ -48,11 +48,11 @@ module MinimalRepo
                                   local: []),
       # Define the build interface to be whatever the first interface is; this
       # should always be sufficient for testing purposes.
-      'server.yaml': YAML.dump(build_interface: NetworkInterface.interfaces.first),
+      'server.yaml': YAML.dump(build_interface: NetworkInterface.interfaces.first)
     }.freeze
 
     ABSOLUTE_FILES = {
-      '/var/lib/tftpboot/pxelinux.cfg/': nil,
+      '/var/lib/tftpboot/pxelinux.cfg/': nil
     }.freeze
 
     def create_at(path)

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
 
     describe '#[]' do
       it 'loads the date' do
-        expect(subject[index]).to eq(asset[:data])
+        expect(subject[index].to_h).to eq(asset[:data])
       end
 
       it 'only loads the asset file once' do
@@ -63,11 +63,15 @@ RSpec.describe Metalware::Namespaces::AssetArray do
         subject[index]
         subject[index]
       end
+
+      it 'returns a RecursiveOpenStruct' do
+        expect(subject[index]).to be_a(RecursiveOpenStruct)
+      end
     end
 
     describe '#find_by_name' do
       it 'returns the asset' do
-        expect(subject.find_by_name(asset[:name])).to eq(asset[:data])
+        expect(subject.find_by_name(asset[:name]).to_h).to eq(asset[:data])
       end
 
       it 'only loads the asset data once' do
@@ -81,7 +85,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
   describe 'each' do
     it 'loops through all the asset data' do
       asset_data = assets.map { |a| a[:data] }
-      expect(subject.each.to_a).to eq(asset_data)
+      expect(subject.each.to_a.map(&:to_h)).to eq(asset_data)
     end
   end
 end

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -26,12 +26,22 @@ RSpec.describe Metalware::Namespaces::AssetArray do
   end 
 
   describe '#new' do
+    context 'when there is an asset called "each"' do
+      before :each do
+        each_path = Metalware::FilePath.asset('each')
+        Metalware::Data.dump(each_path, { data: 'some-data' })
+      end
+
+      it 'errors due to the existing method' do
+        expect do
+          Metalware::Namespaces::AssetArray.new
+        end.to raise_error(Metalware::DataError)
+      end
+    end
+
     it 'does not load the files when initially called' do
       expect(Metalware::Data).not_to receive(:load)
       Metalware::Namespaces::AssetArray.new
-    end
-
-    it 'it only loads the file when required' do
     end
   end
 

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -40,8 +40,9 @@ RSpec.describe Metalware::Namespaces::AssetArray do
       expect(subject[1]).to eq(assets[1][:data])
     end
 
-    it 'does not load all the other asset records' do
-      expect(Metalware::Data).to receive(:load).once
+    it 'only loads the asset file once' do
+      expect(Metalware::Data).to receive(:load).once.and_call_original
+      subject[1]
       subject[1]
     end
   end

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -46,5 +46,12 @@ RSpec.describe Metalware::Namespaces::AssetArray do
       subject[1]
     end
   end
+
+  describe 'asset name method' do
+    it 'can load the asset by name' do
+      asset = assets[1]
+      expect(subject.send(asset[:name])).to eq(asset[:data])
+    end
+  end
 end
 

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -53,5 +53,12 @@ RSpec.describe Metalware::Namespaces::AssetArray do
       expect(subject.send(asset[:name])).to eq(asset[:data])
     end
   end
+
+  describe 'each' do
+    it 'loops through all the asset data' do
+      asset_data = assets.map { |a| a[:data] }
+      expect(subject.each.to_a).to eq(asset_data)
+    end
+  end
 end
 

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'namespaces/alces'
+
+RSpec.describe Metalware::Namespaces::AssetArray do
+  subject { Metalware::Namespaces::AssetArray.new }
+
+  let :assets do
+    [
+      {
+        name: 'asset1',
+        data: { key: 'value1' },
+      },
+      {
+        name: 'asset2',
+        data: { key: 'value2' },
+      },
+    ]
+  end
+
+  before :each do
+    assets.each do |asset|
+      path = Metalware::FilePath.asset(asset[:name])
+      Metalware::Data.dump(path, asset[:data])
+    end
+  end 
+
+  describe '#new' do
+    it 'does not load the files when initially called' do
+      expect(Metalware::Data).not_to receive(:load)
+      Metalware::Namespaces::AssetArray.new
+    end
+
+    it 'it only loads the file when required' do
+    end
+  end
+
+  describe '#[]' do
+    it 'loads the date' do
+      expect(subject[1]).to eq(assets[1][:data])
+    end
+
+    it 'does not load all the other asset records' do
+      expect(Metalware::Data).to receive(:load).once
+      subject[1]
+    end
+  end
+end
+

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -49,21 +49,31 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     let :index { 1 }
     let :asset { assets[index] }
 
+    def expect_to_only_load_asset_data_once
+      expect(Metalware::Data).to receive(:load).once.and_call_original
+    end
+
     describe '#[]' do
       it 'loads the date' do
         expect(subject[index]).to eq(asset[:data])
       end
 
       it 'only loads the asset file once' do
-        expect(Metalware::Data).to receive(:load).once.and_call_original
+        expect_to_only_load_asset_data_once
         subject[index]
         subject[index]
       end
     end
 
-    describe 'asset name method' do
-      it 'can load the asset by name' do
-        expect(subject.send(asset[:name])).to eq(asset[:data])
+    describe '#find_by_name' do
+      it 'returns the asset' do
+        expect(subject.find_by_name(asset[:name])).to eq(asset[:data])
+      end
+
+      it 'only loads the asset data once' do
+        expect_to_only_load_asset_data_once
+        subject.find_by_name(asset[:name])
+        subject.find_by_name(asset[:name])
       end
     end
   end

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -45,22 +45,26 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     end
   end
 
-  describe '#[]' do
-    it 'loads the date' do
-      expect(subject[1]).to eq(assets[1][:data])
+  context 'when loading the second asset' do
+    let :index { 1 }
+    let :asset { assets[index] }
+
+    describe '#[]' do
+      it 'loads the date' do
+        expect(subject[index]).to eq(asset[:data])
+      end
+
+      it 'only loads the asset file once' do
+        expect(Metalware::Data).to receive(:load).once.and_call_original
+        subject[index]
+        subject[index]
+      end
     end
 
-    it 'only loads the asset file once' do
-      expect(Metalware::Data).to receive(:load).once.and_call_original
-      subject[1]
-      subject[1]
-    end
-  end
-
-  describe 'asset name method' do
-    it 'can load the asset by name' do
-      asset = assets[1]
-      expect(subject.send(asset[:name])).to eq(asset[:data])
+    describe 'asset name method' do
+      it 'can load the asset by name' do
+        expect(subject.send(asset[:name])).to eq(asset[:data])
+      end
     end
   end
 

--- a/spec/slow/status/job_spec.rb
+++ b/spec/slow/status/job_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Metalware::Status::Job do
 
       results = Metalware::Status::Job.results
       expect(results).to eq(@node => {
-                              @cmd => 'timeout',
+                              @cmd => 'timeout'
                             })
     end
 
@@ -110,7 +110,7 @@ RSpec.describe Metalware::Status::Job do
 
       expect(Metalware::Status::Job.results).to eq(@node => {
                                                      ping: 'PING_NODE',
-                                                     power: 'POWER_STATUS',
+                                                     power: 'POWER_STATUS'
                                                    })
     end
   end

--- a/spec/validation/answer_spec.rb
+++ b/spec/validation/answer_spec.rb
@@ -33,23 +33,23 @@ RSpec.describe Metalware::Validation::Answer do
       domain: [
         {
           identifier: 'string_question',
-          question: 'Am I a string?',
+          question: 'Am I a string?'
         },
         {
           identifier: 'integer_question',
           question: 'Am I a integer',
-          type: 'integer',
+          type: 'integer'
         },
         {
           identifier: 'bool_question',
           question: 'Am I a boolean',
-          type: 'boolean',
-        },
+          type: 'boolean'
+        }
       ],
 
       group: [],
       node: [],
-      local: [],
+      local: []
     }
   end
 
@@ -57,7 +57,7 @@ RSpec.describe Metalware::Validation::Answer do
     {
       string_question: 'string',
       integer_question: 100,
-      bool_question: true,
+      bool_question: true
     }
   end
 
@@ -88,7 +88,7 @@ RSpec.describe Metalware::Validation::Answer do
   context 'with an invalid answer hash' do
     it 'contains an answer to a missing question' do
       answers = {
-        a_missing_question: 'I do not appear in configure.yaml',
+        a_missing_question: 'I do not appear in configure.yaml'
       }
       results, validator = run_answer_validation(answers)
       expect(results.errors.keys).to include(:missing_questions)

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Metalware::Validation::Loader do
         [
           section, [{
             identifier: "#{section}_identifier",
-            question: "#{section}_question",
+            question: "#{section}_question"
           }]
         ]
       end.to_h
@@ -45,12 +45,12 @@ RSpec.describe Metalware::Validation::Loader do
       configure_sections.map do |section|
         dependent_question = {
           identifier: "example_plugin_#{section}_dependent_identifier",
-          question: "example_plugin_#{section}_dependent_question",
+          question: "example_plugin_#{section}_dependent_question"
         }
         top_level_question = {
           identifier: "example_plugin_#{section}_identifier",
           question: "example_plugin_#{section}_question",
-          dependent: [dependent_question],
+          dependent: [dependent_question]
         }
         [section, [top_level_question]]
       end.to_h

--- a/src/answers_table_creator.rb
+++ b/src/answers_table_creator.rb
@@ -39,7 +39,7 @@ module Metalware
         'Question',
         'Domain',
         group_name ? "Group: #{group_name}" : nil,
-        node_name ?  "Node: #{node_name}" : nil,
+        node_name ?  "Node: #{node_name}" : nil
       ].reject(&:nil?)
     end
 
@@ -49,7 +49,7 @@ module Metalware
           identifier,
           domain_answer(question: identifier),
           group_answer(question: identifier, group_name: group_name),
-          node_answer(question: identifier, node_name: node_name),
+          node_answer(question: identifier, node_name: node_name)
         ].reject(&:nil?)
       end
     end

--- a/src/build_files_retriever.rb
+++ b/src/build_files_retriever.rb
@@ -142,7 +142,7 @@ module Metalware
         name = File.basename(identifier)
         {
           raw: identifier,
-          name: name,
+          name: name
         }
       end
 

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -75,8 +75,8 @@ module Metalware
         {
           repo: ['configure.yaml'],
           optional: {
-            configure: [relative_answer_file],
-          },
+            configure: [relative_answer_file]
+          }
         }
       end
 

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -84,7 +84,7 @@ module Metalware
       def dependency_hash
         {
           repo: repo_dependencies,
-          configure: ['domain.yaml'],
+          configure: ['domain.yaml']
         }
       end
 

--- a/src/commands/each.rb
+++ b/src/commands/each.rb
@@ -44,7 +44,7 @@ module Metalware
           rendered_cmd = node.render_erb_template(command)
           opt = {
             out: $stdout.fileno ? $stdout.fileno : 1,
-            err: $stderr.fileno ? $stderr.fileno : 2,
+            err: $stderr.fileno ? $stderr.fileno : 2
           }
           system(rendered_cmd, opt)
         end

--- a/src/commands/remove/group.rb
+++ b/src/commands/remove/group.rb
@@ -51,7 +51,7 @@ module Metalware
 
         def dependency_hash
           {
-            configure: ["groups/#{primary_group}.yaml"],
+            configure: ["groups/#{primary_group}.yaml"]
           }
         end
 

--- a/src/commands/repo/update.rb
+++ b/src/commands/repo/update.rb
@@ -82,7 +82,7 @@ module Metalware
 
         def dependency_hash
           {
-            repo: [],
+            repo: []
           }
         end
       end

--- a/src/commands/view_answers/domain.rb
+++ b/src/commands/view_answers/domain.rb
@@ -16,7 +16,7 @@ module Metalware
         def dependency_hash
           {
             repo: ['configure.yaml'],
-            configure: ['domain.yaml'],
+            configure: ['domain.yaml']
           }
         end
       end

--- a/src/commands/view_answers/group.rb
+++ b/src/commands/view_answers/group.rb
@@ -23,7 +23,7 @@ module Metalware
         def dependency_hash
           {
             repo: ['configure.yaml'],
-            configure: ['domain.yaml', "groups/#{group_name}.yaml"],
+            configure: ['domain.yaml', "groups/#{group_name}.yaml"]
           }
         end
       end

--- a/src/dependency_specifications.rb
+++ b/src/dependency_specifications.rb
@@ -16,8 +16,8 @@ module Metalware
         repo: ['configure.yaml'],
         configure: ['domain.yaml', "groups/#{group.name}.yaml"],
         optional: {
-          configure: ["nodes/#{name}.yaml"],
-        },
+          configure: ["nodes/#{name}.yaml"]
+        }
       }
     end
 

--- a/src/dns/hosts.rb
+++ b/src/dns/hosts.rb
@@ -58,7 +58,7 @@ module Metalware
 
       def staging_options
         {
-          service: self.class.name,
+          service: self.class.name
         }
       end
     end

--- a/src/dns/named.rb
+++ b/src/dns/named.rb
@@ -71,8 +71,8 @@ module Metalware
         {
           named: {
             zone: zone,
-            net: net,
-          },
+            net: net
+          }
         }
       end
 
@@ -97,7 +97,7 @@ module Metalware
       def staging_options
         {
           mkdir: true,
-          service: self.class.name,
+          service: self.class.name
         }
       end
     end

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -91,7 +91,7 @@ module Metalware
       payload = {
         next_index: next_available_index,
         primary_groups: groups_hash,
-        orphans: orphans,
+        orphans: orphans
       }
       Data.dump(file_path.group_cache, payload)
       @data = nil # Reloads the cached file

--- a/src/gui/bin/bundle
+++ b/src/gui/bin/bundle
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/src/gui/bin/setup
+++ b/src/gui/bin/setup
@@ -6,7 +6,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/src/gui/bin/update
+++ b/src/gui/bin/update
@@ -6,7 +6,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/src/gui/config/environments/development.rb
+++ b/src/gui/config/environments/development.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}",
+      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/src/gui/config/environments/test.rb
+++ b/src/gui/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}",
+    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/src/managed_file.rb
+++ b/src/managed_file.rb
@@ -45,7 +45,7 @@ module Metalware
           MANAGED_START,
           MANAGED_COMMENT,
           rendered_template,
-          MANAGED_END,
+          MANAGED_END
         ].join("\n") + "\n"
       end
     end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -26,6 +26,7 @@ module Metalware
       def initialize
         @asset_loaders = Dir.glob(FilePath.asset('*')).map do |path|
           AssetLoader.new(path).tap do |loader|
+            raise_error_if_method_is_defined(loader.name)
             define_singleton_method(loader.name) { loader.data }
           end
         end
@@ -42,6 +43,14 @@ module Metalware
       private
 
       attr_reader :asset_loaders
+
+      def raise_error_if_method_is_defined(method)
+        return unless respond_to?(method)
+        raise DataError, <<-EOF.strip_heredoc
+          Asset can not be called key word: #{method}
+        EOF
+      end
     end
   end
 end
+

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -9,7 +9,7 @@ module Metalware
         end
 
         def data
-          load
+          @data ||= load
         end
 
         private

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -40,6 +40,12 @@ module Metalware
         asset_loaders.map(&:data).each
       end
 
+      def find_by_name(name)
+        asset_loaders.find do |asset|
+          asset.name == name
+        end.data
+      end
+
       private
 
       attr_reader :asset_loaders

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -3,19 +3,39 @@
 module Metalware
   module Namespaces
     class AssetArray
+      class AssetLoader
+        def initialize(path)
+          @path = path
+        end
+
+        def data
+          load
+        end
+
+        private
+
+        attr_reader :path
+
+        def load
+          Data.load(path)
+        end
+      end
+
       include Enumerable
 
       def initialize
-        @files = Dir.glob(FilePath.asset('*'))
+        @asset_loaders = Dir.glob(FilePath.asset('*')).map do |path|
+          AssetLoader.new(path)
+        end
       end
 
       def [](index)
-        Data.load(files[index])
+        asset_loaders[index].data
       end
 
       private
 
-      attr_reader :files
+      attr_reader :asset_loaders
     end
   end
 end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -9,16 +9,12 @@ module Metalware
         end
 
         def data
-          @data ||= load
+          @data ||= Data.load(path)
         end
 
         private
 
         attr_reader :path
-
-        def load
-          Data.load(path)
-        end
       end
 
       include Enumerable

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -35,6 +35,10 @@ module Metalware
         asset_loaders[index].data
       end
 
+      def each
+        asset_loaders.map(&:data).each
+      end
+
       private
 
       attr_reader :asset_loaders

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -8,6 +8,10 @@ module Metalware
           @path = path
         end
 
+        def name
+          @name ||= File.basename(path, '.yaml')
+        end
+
         def data
           @data ||= Data.load(path)
         end
@@ -21,7 +25,9 @@ module Metalware
 
       def initialize
         @asset_loaders = Dir.glob(FilePath.asset('*')).map do |path|
-          AssetLoader.new(path)
+          AssetLoader.new(path).tap do |loader|
+            define_singleton_method(loader.name) { loader.data }
+          end
         end
       end
 

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -59,4 +59,3 @@ module Metalware
     end
   end
 end
-

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -13,7 +13,7 @@ module Metalware
         end
 
         def data
-          @data ||= Data.load(path)
+          @data ||= RecursiveOpenStruct.new(Data.load(path))
         end
 
         private

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Metalware
+  module Namespaces
+    class AssetArray
+      include Enumerable
+
+      def initialize
+        @files = Dir.glob(FilePath.asset('*'))
+      end
+
+      def [](index)
+        Data.load(files[index])
+      end
+
+      private
+
+      attr_reader :files
+    end
+  end
+end

--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -76,6 +76,10 @@ module Metalware
           @questions ||= loader.question_tree
         end
 
+        def asset
+          @asset ||= AssetArray.new
+        end
+
         private
 
         def group_cache

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -112,7 +112,7 @@ module Metalware
         # a group work fine as they appear in the genders file BUT local and
         # orphan nodes DO NOT appear in the genders file and cause the above
         # error.
-        return { groups: ['orphan'], node: name }
+        { groups: ['orphan'], node: name }
       end
 
       def additional_dynamic_namespace

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -93,7 +93,7 @@ module Metalware
                        :build_complete_url,
                        :build_complete_path,
                        :hexadecimal_ip,
-                       :build_method,
+                       :build_method
                      ])
       end
 

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -63,7 +63,7 @@ module Metalware
         [
           Constants::CONFIGURE_INTERNAL_QUESTION_PREFIX,
           'plugin_enabled',
-          plugin_name,
+          plugin_name
         ].join('--')
       end
 

--- a/src/plugins/configure_questions_builder.rb
+++ b/src/plugins/configure_questions_builder.rb
@@ -44,7 +44,7 @@ module Metalware
           identifier: plugin.enabled_question_identifier,
           question: "Should '#{plugin.name}' plugin be enabled for #{section}?",
           type: 'boolean',
-          dependent: questions_for_section(section),
+          dependent: questions_for_section(section)
         }
       end
 

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -14,7 +14,7 @@ module Metalware
       :each,
       :breadth_each,
       :postordered_each,
-      :preordered_each,
+      :preordered_each
     ].freeze
 
     BASE_TRAVERSALS.each do |base_method|

--- a/src/render_methods/dhcp.rb
+++ b/src/render_methods/dhcp.rb
@@ -31,7 +31,7 @@ module Metalware
           {
             managed: managed?,
             validator: name,
-            service: name,
+            service: name
           }
         end
 

--- a/src/render_methods/render_method.rb
+++ b/src/render_methods/render_method.rb
@@ -35,7 +35,7 @@ module Metalware
         def staging_opts
           {
             managed: managed?,
-            validator: name,
+            validator: name
           }
         end
 

--- a/src/staging.rb
+++ b/src/staging.rb
@@ -83,7 +83,7 @@ module Metalware
     def default_push_options
       {
         managed: false,
-        validator: nil,
+        validator: nil
       }
     end
 

--- a/src/status/job.rb
+++ b/src/status/job.rb
@@ -62,7 +62,7 @@ module Metalware
       # ----- THREAD METHODS BELOW THIS LINE ------
       CMD_LIBRARY = {
         power: :job_power_status,
-        ping: :job_ping_node,
+        ping: :job_ping_node
       }.freeze
 
       def run_command

--- a/src/system_command.rb
+++ b/src/system_command.rb
@@ -49,7 +49,7 @@ module Metalware
         {
           stdout: stdout,
           stderr: stderr,
-          status: status,
+          status: status
         }
       end
 

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -143,7 +143,7 @@ module Metalware
           MANAGED_START,
           MANAGED_COMMENT,
           rendered_template,
-          MANAGED_END,
+          MANAGED_END
         ].join("\n") + "\n"
       end
 

--- a/src/validation/answer.rb
+++ b/src/validation/answer.rb
@@ -43,7 +43,7 @@ module Metalware
           end],
           [:AnswerTypeSchema, proc do
             AnswerTypeSchema.call(validation_hash)
-          end],
+          end]
         ]
         tests.each do |(test_name, test_proc)|
           @validation_result = test_proc.call
@@ -95,7 +95,7 @@ module Metalware
         @validation_hash ||= begin
           payload = {
             answers: [],
-            missing_questions: [],
+            missing_questions: []
           }
           answers.each_with_object(payload) do |(question, answer), pay|
             if questions_in_section&.key?(question)
@@ -103,7 +103,7 @@ module Metalware
                 {
                   question: question,
                   answer: answer,
-                  type: questions_in_section[question].type,
+                  type: questions_in_section[question].type
                 }.tap { |h| h[:type] = 'string' if h[:type].nil? }
               )
             else

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -59,7 +59,7 @@ module Metalware
         @tree ||= begin
           root_hash = {
             pass: true,
-            result: TopLevelSchema.call(data: questions_hash),
+            result: TopLevelSchema.call(data: questions_hash)
           }
           QuestionTree.new('ROOT', root_hash).tap do |root|
             add_children(root, root) do
@@ -104,7 +104,7 @@ module Metalware
         question_data = questions_hash[section] || []
         data = {
           section: section,
-          result: DependantSchema.call(dependent: question_data),
+          result: DependantSchema.call(dependent: question_data)
         }
         node_s = QuestionTree.new(section, data)
         add_children(root, node_s) do

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -70,7 +70,7 @@ module Metalware
       def all_questions_for_section(section)
         [
           repo_configure_questions,
-          *plugin_configure_questions,
+          *plugin_configure_questions
         ].flat_map do |question_group|
           question_group[section]
         end


### PR DESCRIPTION
This PR loads all the `YAML` files into the `Alces` namespace. The assets are loading under the `asset` key using a new `AssetArray` class.

Due to the large number of files, it isn't feasible to load the all the assets up front each time the namespace is created. This means the `AssetArray` does not inherit from `Array`. Instead it contains a list of file loader objects (`AssetLoader`) which are created from the contents of the `assets` directory.

The asset file is only loaded when it is accessed through the `AssetLoader`. The loader objects also act as a cache to prevent additional file loads.

The assets can be accessed in a few different methods:
1. `[]()`: The standard array indexing method if supported,
1. Name: The assets can be accessed by name similarly to the `nodes`,
1. `find_by_name`: The `find_by_name` method is support as a safer alternative to `send`,
1. `each`: The standard enumerable methods such as `each` (NOTE: These will trigger all the assets to be loaded)