### PR TITLE
Asset Cache

### DIFF
--- a/spec/asset_cache_spec.rb
+++ b/spec/asset_cache_spec.rb
@@ -1,0 +1,53 @@
+require 'alces_utils'
+require 'cache/asset'
+
+RSpec.describe Metalware::Cache::Asset do
+  include AlcesUtils
+  
+  let :cache { Metalware::Cache::Asset.new }
+  let :content { { node: { node_name.to_sym => 'asset_test' } } }
+  let :node_name { 'test_node' } 
+  let :node { alces.nodes.find_by_name(node_name) }
+
+  AlcesUtils.mock(self, :each) do
+    mock_node(node_name) 
+  end
+  
+  describe '#data' do
+    it 'handles empty cache' do
+      expect do
+        cache.data
+      end.not_to raise_error
+    end
+
+    it 'returns populated cache' do
+      Metalware::Data.dump(Metalware::FilePath.asset_cache, content)
+      expect(cache.data).to eq(content)
+    end
+  end
+
+  describe '#save' do
+    it 'saves the cache to yaml' do
+      cache.assign_asset_to_node('asset_test', node)
+      cache.save
+      new_cache = Metalware::Cache::Asset.new
+      expect(new_cache.data).to eq(content)
+    end
+  end
+
+  describe '#assign_asset_to_node' do
+    it 'assigns an asset to a node' do
+      expect do
+        cache.assign_asset_to_node('asset_test', node)
+      end.not_to raise_error
+    end 
+  end
+
+  describe '#asset_for_node' do
+    it 'returns the corresponding nodes asset' do
+      cache.assign_asset_to_node('asset_test', node)
+      cache.save
+      expect(cache.asset_for_node(node)).to eq('asset_test')
+    end
+  end
+end

--- a/spec/asset_cache_spec.rb
+++ b/spec/asset_cache_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe Metalware::Cache::Asset do
   describe '#asset_for_node' do
     it 'returns the corresponding nodes asset' do
       cache.assign_asset_to_node('asset_test', node)
-      cache.save
       expect(cache.asset_for_node(node)).to eq('asset_test')
     end
   end

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -6,12 +6,12 @@ require 'data'
 module Metalware
   module Cache
     class Asset
-      def initialize
-        data
-      end
-
       def data
-        @assets ||= Data.load(FilePath.asset_cache)
+        @assets ||= begin
+          Data.load(FilePath.asset_cache).tap do |a|
+            a.merge! blank_cache if a.empty?
+          end
+        end
       end
       
       def save
@@ -19,11 +19,17 @@ module Metalware
       end
 
       def assign_asset_to_node(asset_name, node)
-        @assets["node"][node.name] = asset_name  
+        data[:node][node.name] = asset_name  
       end
 
       def asset_for_node(node)
-        @assets["node"][node.name]
+        data[:node][node.name]
+      end
+
+      private
+
+      def blank_cache
+        { node: {} }  
       end
     end
   end

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -8,9 +8,8 @@ module Metalware
     class Asset
       def data
         @data ||= begin
-          Data.load(FilePath.asset_cache).tap do |a|
-            a.merge! blank_cache if a.empty?
-          end
+          raw_load = Data.load(FilePath.asset_cache)
+          raw_load.empty? ? blank_cache : raw_load
         end
       end
 

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -16,7 +16,7 @@ module Metalware
 
       def save
         Data.dump(FilePath.asset_cache, data)
-     end
+      end
 
       def assign_asset_to_node(asset_name, node)
         data[:node][node.name] = asset_name

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -13,13 +13,13 @@ module Metalware
           end
         end
       end
-      
+
       def save
-        Data.dump(FilePath.asset_cache, data) 
-      end
+        Data.dump(FilePath.asset_cache, data)
+     end
 
       def assign_asset_to_node(asset_name, node)
-        data[:node][node.name] = asset_name  
+        data[:node][node.name] = asset_name
       end
 
       def asset_for_node(node)
@@ -29,7 +29,7 @@ module Metalware
       private
 
       def blank_cache
-        { node: {} }  
+        { node: {} }
       end
     end
   end

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'file_path'
+require 'data'
+
+module Metalware
+  module Cache
+    class Asset
+      def initialize
+        data
+      end
+
+      def data
+        @assets ||= Data.load(FilePath.asset_cache)
+      end
+      
+      def save
+        Data.dump(FilePath.asset_cache, data) 
+      end
+
+      def assign_asset_to_node(asset_name, node)
+        @assets["node"][node.name] = asset_name  
+      end
+
+      def asset_for_node(node)
+        @assets["node"][node.name]
+      end
+    end
+  end
+end

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -7,7 +7,7 @@ module Metalware
   module Cache
     class Asset
       def data
-        @assets ||= begin
+        @data ||= begin
           Data.load(FilePath.asset_cache).tap do |a|
             a.merge! blank_cache if a.empty?
           end

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -156,6 +156,10 @@ module Metalware
         File.join(metalware_data, 'assets', name + '.yaml')
       end
 
+      def asset_cache
+        File.join(cache, 'assets.yaml')
+      end
+
       private
 
       def template_file_name(template_type, node:)


### PR DESCRIPTION
This PR implements functionality and tests for assigning assets to nodes using an asset cache file. It currently stores the relationship in the following format:
```
node:
  node001: asset001
  node002: asset004
  ...
```
## Methods
`data`
* Loads the data and caches it internally
* Initially the file is empty so it creates the necessary structure

`save`
* Saves the data back to `YAML`

`assign_asset_to_node(asset_name, node)`
* Taking a `String` and `Namespaces::Node` as inputs respectively
* Updates the `node` key within the cache file `assets.yaml` using the `asset_name` given as it's value

`asset_for_node(node)`
* Takes `Namespaces::Node` as input
* Returns the value of the key given by `node`