### PR TITLE
Implement the add asset command

### DIFF
--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'commands'
+require 'utils'
+
+RSpec.describe Metalware::Commands::Asset::Add do
+  it 'errors if the template does not exist' do
+    expect do
+      Metalware::Utils.run_command(described_class,
+                                   'missing-type',
+                                   'name',
+                                   stderr: StringIO.new)
+    end.to raise_error(Metalware::InvalidInput)
+  end
+end
+

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe Metalware::Commands::Asset::Add do
                                       .with(template_path, save_path)
       run_command
     end
+
+    it 'errors if the asset already exists' do
+      run_command
+      expect do
+        run_command
+      end.to raise_error(Metalware::InvalidInput)
+    end
   end
 end
 

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -2,8 +2,12 @@
 
 require 'commands'
 require 'utils'
+require 'filesystem'
 
 RSpec.describe Metalware::Commands::Asset::Add do
+  # Stops the editor from running the bash command
+  before :each { allow(Metalware::Utils::Editor).to receive(:open) }
+
   it 'errors if the template does not exist' do
     expect do
       Metalware::Utils.run_command(described_class,
@@ -11,6 +15,33 @@ RSpec.describe Metalware::Commands::Asset::Add do
                                    'name',
                                    stderr: StringIO.new)
     end.to raise_error(Metalware::InvalidInput)
+  end
+
+  context 'when using the default template' do
+    before do
+      FileSystem.root_setup do |fs|
+        fs.with_minimal_repo
+      end
+    end
+
+    let :template { 'default' }
+    let :save { 'saved-asset' }
+
+    let :template_path { Metalware::FilePath.asset_template(template) }
+    let :save_path { Metalware::FilePath.asset(save) }
+
+    def run_command
+      Metalware::Utils.run_command(described_class,
+                                   template,
+                                   save,
+                                   stderr: StringIO.new)
+    end
+
+    it 'calls for the template to be opened and copyed' do
+      expect(Metalware::Utils::Editor).to receive(:open_copy)
+                                      .with(template_path, save_path)
+      run_command
+    end
   end
 end
 

--- a/spec/minimal_repo.rb
+++ b/spec/minimal_repo.rb
@@ -41,6 +41,7 @@ module MinimalRepo
       'genders/default': '',
       'dhcp/default': '',
       'config/domain.yaml': '',
+      'assets/default.yaml': '',
       'configure.yaml': YAML.dump(questions: [],
                                   domain: [],
                                   group: [],

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -51,22 +51,11 @@ RSpec.describe Metalware::Namespaces::Node do
     let :node_name { 'node02' }
     let :node_array { ['some_other_node', node_name] }
 
-    ##
-    # Mocking the HashMerger to return a specified hash as the original
-    # block should still be used. It has been mocked by specifying a new
-    # block that references the original render_node_template block contained
-    # within Namespaces::Node
-    #
     let :config_hash do
       Metalware::Constants::HASH_MERGER_DATA_STRUCTURE.new(
         key: test_value,
         erb_value1: '<%= alces.node.config.key  %>'
-      ) { |template_string| render_node_template(template_string) }
-    end
-
-    def render_node_template(template)
-      template_lambda = node.send(:template_block)
-      template_lambda.call(template)
+      ) { |template_string| node.render_erb_template(template_string) }
     end
 
     let :node { Metalware::Namespaces::Node.create(alces, node_name) }

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -23,12 +23,12 @@ global_options:
 
 subcommands:
   asset_add: &asset_add
-    syntax: metal asset add [options]
+    syntax: metal asset add ASSET_TYPE ASSET_NAME [options]
     summary: Add a new asset record
     action: Commands::Asset::Add
 
   asset_edit: &asset_edit
-    syntax: metal asset edit [options]
+    syntax: metal asset edit ASSET_NAME [options]
     summary: Edit an existing asset record
     action: Commands::Asset::Edit
 

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -22,6 +22,16 @@ global_options:
       Suppress any warnings from being displayed
 
 subcommands:
+  asset_add: &asset_add
+    syntax: metal asset add [options]
+    summary: Add a new asset record
+    action: Commands::Asset::Add
+
+  asset_edit: &asset_edit
+    syntax: metal asset edit [options]
+    summary: Edit an existing asset record
+    action: Commands::Asset::Edit
+
   configure_domain: &configure_domain
     syntax: metal configure domain [options]
     summary: Configure Metalware domain
@@ -163,6 +173,13 @@ subcommands:
       Commands::ViewAnswers::Node
 
 commands:
+  asset:
+    syntax: metal asset [SUB_COMMAND] [options]
+    summary: Manage the asset record files
+    subcommands:
+      add: *asset_add
+      edit: *asset_edit
+
   build:
     syntax: metal build NODE_IDENTIFIER [options]
     summary: Renders the templates used to build the nodes

--- a/src/commands.rb
+++ b/src/commands.rb
@@ -23,5 +23,6 @@
 #==============================================================================
 
 require 'utils/dynamic_require'
+require 'command_helpers/base_command'
 
 Metalware::Utils::DynamicRequire.relative('commands')

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -41,4 +41,3 @@ module Metalware
     end
   end
 end
-

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Metalware
+  module Commands
+    module Asset
+      class Add < Metalware::CommandHelpers::BaseCommand
+      end
+    end
+  end
+end
+

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -1,9 +1,32 @@
 # frozen_string_literal: true
 
+require 'utils/editor'
+
 module Metalware
   module Commands
     module Asset
       class Add < Metalware::CommandHelpers::BaseCommand
+        private
+
+        attr_reader :template_name, :template_path, :asset_path
+
+        def setup
+          @template_name = args[0]
+          @template_path = FilePath.asset_template(template_name)
+          @asset_path = FilePath.asset(args[1])
+        end
+
+        def run
+          error_if_template_is_missing
+          Utils::Editor.open_copy(template_path, asset_path)
+        end
+
+        def error_if_template_is_missing
+          return if File.exist?(template_path)
+          raise InvalidInput, <<-EOF.squish
+            Can not find asset template: "#{template_name}"
+          EOF
+        end
       end
     end
   end

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -8,23 +8,33 @@ module Metalware
       class Add < Metalware::CommandHelpers::BaseCommand
         private
 
-        attr_reader :template_name, :template_path, :asset_path
+        attr_reader :template_name, :template_path, :asset_path, :asset_name
 
         def setup
           @template_name = args[0]
           @template_path = FilePath.asset_template(template_name)
-          @asset_path = FilePath.asset(args[1])
+          @asset_name = args[1]
+          @asset_path = FilePath.asset(asset_name)
         end
 
         def run
           error_if_template_is_missing
+          error_if_asset_exists
           Utils::Editor.open_copy(template_path, asset_path)
         end
 
         def error_if_template_is_missing
           return if File.exist?(template_path)
           raise InvalidInput, <<-EOF.squish
-            Can not find asset template: "#{template_name}"
+            Cannot find asset template: "#{template_name}"
+          EOF
+        end
+
+        def error_if_asset_exists
+          return unless File.exist?(asset_path)
+          raise InvalidInput, <<-EOF.squish
+            The "#{asset_name}" asset already exists. Please use `metal
+            asset edit` instead
           EOF
         end
       end

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -8,4 +8,3 @@ module Metalware
     end
   end
 end
-

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Metalware
+  module Commands
+    module Asset
+      class Edit < Metalware::CommandHelpers::BaseCommand
+      end
+    end
+  end
+end
+

--- a/src/namespaces/hash_merger_namespace.rb
+++ b/src/namespaces/hash_merger_namespace.rb
@@ -25,7 +25,11 @@ module Metalware
       end
 
       def render_erb_template(template, **user_dynamic_namespace)
-        template_block(user_dynamic_namespace).call(template)
+        alces.render_erb_template(
+          template,
+          **additional_dynamic_namespace,
+          **user_dynamic_namespace
+        )
       end
 
       private
@@ -45,21 +49,13 @@ module Metalware
       end
 
       def run_hash_merger(hash_obj)
-        hash_obj.merge(**hash_merger_input, &template_block)
+        hash_obj.merge(**hash_merger_input) do |template|
+          render_erb_template(template)
+        end
       end
 
       def hash_merger_input
         raise NotImplementedError
-      end
-
-      def template_block(user_dynamic_namespace = {})
-        lambda do |template|
-          alces.render_erb_template(
-            template,
-            **additional_dynamic_namespace,
-            **user_dynamic_namespace
-          )
-        end
       end
 
       def additional_dynamic_namespace

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -71,7 +71,11 @@ module Metalware
       end
 
       def finalize_build_files(build_file_hashes)
-        Constants::HASH_MERGER_DATA_STRUCTURE.new(build_file_hashes, &template_block)
+        Constants::HASH_MERGER_DATA_STRUCTURE.new(
+          build_file_hashes
+        ) do |template|
+          render_erb_template(template)
+        end
       end
 
       def events_dir

--- a/src/utils.rb
+++ b/src/utils.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module Metalware


### PR DESCRIPTION
The `metal asset add` command takes template files from the repo and allows the user to edit them before saving. It is mostly a wrapper around `Editor.open_copy` with a few file checks to ensure the template exists and the asset doesn't.

The `metal asset edit` command has also been added into the `cli` and the file has been create. It otherwise has not been implemented.

The `render_erb_template` method in the `HashMergerNamespace` has also been simplified. This is otherwise unrelated but needed to be done at some point.