### PR TITLE
Implement edit asset command

### DIFF
--- a/spec/commands/asset/edit_spec.rb
+++ b/spec/commands/asset/edit_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe Metalware::Commands::Asset::Edit do
 
     let :saved_asset { 'saved-asset' }
     let :asset_path { Metalware::FilePath.asset(saved_asset) }
+    let :test_content { { key: 'value' } }
+
+    before :each { Metalware::Data.dump(asset_path, test_content) }
 
     def run_command
       Metalware::Utils.run_command(described_class,
@@ -37,7 +40,5 @@ RSpec.describe Metalware::Commands::Asset::Edit do
                                       .with(asset_path, asset_path)
       run_command
     end
-    
-    i
   end
 end

--- a/spec/commands/asset/edit_spec.rb
+++ b/spec/commands/asset/edit_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'commands'
+require 'utils'
+require 'filesystem'
+
+RSpec.describe Metalware::Commands::Asset::Edit do
+  before :each { allow(Metalware::Utils::Editor).to receive(:open) }
+
+  it 'errors if the asset doesnt exist' do
+    expect do
+      Metalware::Utils.run_command(described_class,
+                                    'missing-type',
+                                    'name',
+                                    stderr: StringIO.new)
+    end.to raise_error(Metalware::InvalidInput)
+  end
+  
+  context 'when using a saved asset' do
+    before do
+      FileSystem.root_setup do |fs|
+        fs.with_minimal_repo
+      end
+    end
+
+    let :saved_asset { 'saved-asset' }
+    let :asset_path { Metalware::FilePath.asset(saved_asset) }
+
+    def run_command
+      Metalware::Utils.run_command(described_class,
+                                    saved_asset,
+                                    stderr: StringIO.new)
+    end
+
+    it 'calls for the saved asset to be opened and copied into a temp file' do
+      expect(Metalware::Utils::Editor).to receive(:open_copy)
+                                      .with(asset_path, asset_path)
+      run_command
+    end
+    
+    i
+  end
+end

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -1,9 +1,32 @@
 # frozen_string_literal: true
 
+require 'utils/editor'
+
 module Metalware
   module Commands
     module Asset
       class Edit < Metalware::CommandHelpers::BaseCommand
+        private
+
+        attr_reader :asset_name, :asset_path
+
+        def setup
+          @asset_name = args[0]
+          @asset_path = FilePath.asset(asset_name)
+        end
+
+        def run
+          error_if_asset_doesnt_exist
+          Utils::Editor.open_copy(asset_path, asset_path)
+        end
+
+        def error_if_asset_doesnt_exist
+          return if File.exist?(asset_path)
+          raise InvalidInput, <<-EOF.squish
+            The "#{asset_name}" asset does not yet exist. Use 'metal
+            asset add' to create the asset
+          EOF
+        end
       end
     end
   end


### PR DESCRIPTION
`metal asset edit` allows the user to edit an already saved asset using their default editor, just like with `metal asset add`. This will only work on assets that exist so if the user attempts to edit an asset that is non-existent then it will throw back an error message to inform them that the requested asset doesn't exist yet.