### PR TITLE
Add the ability to validate files after they have been edited

### DIFF
--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -56,14 +56,18 @@ RSpec.describe Metalware::Utils::Editor do
 
       before :each { Metalware::Data.dump(source, initial_content) }
 
+      def run_open_copy
+        described_class.open_copy(source, destination)
+      end
+
       it 'creates and opens the temp file' do
         expect(described_class).to receive(:open).once.with(/\A\/tmp\//)
-        described_class.open_copy(source, destination)
+        run_open_copy
       end
 
       it 'saves the content to the destination' do
         expect(described_class).to receive(:open)
-        described_class.open_copy(source, destination)
+        run_open_copy
         expect(Metalware::Data.load(destination)).to eq(initial_content)
       end
     end

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -3,8 +3,7 @@
 require 'utils/editor'
 
 RSpec.describe Metalware::Utils::Editor do
-  subject { Metalware::Utils::Editor }
-  let :default_editor { subject::DEFAULT_EDITOR }
+  let :default_editor { described_class::DEFAULT_EDITOR }
 
   context 'with the environment variables unset' do
     before :each do |example|
@@ -14,7 +13,7 @@ RSpec.describe Metalware::Utils::Editor do
 
     describe '#editor' do
       it 'uses the default editor' do
-        expect(subject.editor).to eq(default_editor)
+        expect(described_class.editor).to eq(default_editor)
       end
 
       context 'when $EDITOR is set' do
@@ -22,7 +21,7 @@ RSpec.describe Metalware::Utils::Editor do
         before :each { ENV['EDITOR'] = editor }
 
         it 'uses the $EDITOR env var' do
-          expect(subject.editor).to eq(editor)
+          expect(described_class.editor).to eq(editor)
         end
 
         context 'when $VISUAL is set' do
@@ -30,7 +29,7 @@ RSpec.describe Metalware::Utils::Editor do
           before :each { ENV['VISUAL'] = visual }
 
           it 'uses the $VISUAL env var' do
-            expect(subject.editor).to eq(visual)
+            expect(described_class.editor).to eq(visual)
           end
         end
       end
@@ -42,7 +41,7 @@ RSpec.describe Metalware::Utils::Editor do
       it 'opens the file in the default editor' do
         cmd = "#{default_editor} #{file}"
         expect(Metalware::SystemCommand).to receive(:no_capture).with(cmd)
-        thr = Thread.new { subject.open(file) }
+        thr = Thread.new { described_class.open(file) }
         sleep 0.1
         thr.kill
         sleep 0.001 while thr.alive?
@@ -58,13 +57,13 @@ RSpec.describe Metalware::Utils::Editor do
       before :each { Metalware::Data.dump(source, initial_content) }
 
       it 'creates and opens the temp file' do
-        expect(subject).to receive(:open).once.with(/\A\/tmp\//)
-        subject.open_copy(source, destination)
+        expect(described_class).to receive(:open).once.with(/\A\/tmp\//)
+        described_class.open_copy(source, destination)
       end
 
-      it 'destination contains content' do
-        expect(subject).to receive(:open)
-        subject.open_copy(source, destination)
+      it 'saves the content to the destination' do
+        expect(described_class).to receive(:open)
+        described_class.open_copy(source, destination)
         expect(Metalware::Data.load(destination)).to eq(initial_content)
       end
     end

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -18,12 +18,12 @@ module Metalware
           ENV['VISUAL'] || ENV['EDITOR'] || DEFAULT_EDITOR
         end
 
-        def open_copy(source, destination, &b)
+        def open_copy(source, destination, &validator)
           name = File.basename(source, '.*')
           file = Tempfile.new(name)
           FileUtils.cp(source, file.path)
           open(file.path)
-          raise_error_if_validation_fails(file.path, &b) if b
+          raise_if_validation_fails(file.path, &validator) if validator
           FileUtils.cp(file.path, destination)
         ensure
           file.close
@@ -32,7 +32,7 @@ module Metalware
 
         private
 
-        def raise_error_if_validation_fails(path)
+        def raise_if_validation_fails(path)
           return if yield path
           raise ValidationFailure, <<-EOF.squish
             The edited file is invalid

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -32,8 +32,8 @@ module Metalware
 
         private
 
-        def raise_error_if_validation_fails(path, &validation)
-          return if validation.call(path)
+        def raise_error_if_validation_fails(path)
+          return if yield path
           raise ValidationFailure, <<-EOF.squish
             The edited file is invalid
           EOF

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -18,11 +18,12 @@ module Metalware
           ENV['VISUAL'] || ENV['EDITOR'] || DEFAULT_EDITOR
         end
 
-        def open_copy(source, destination)
+        def open_copy(source, destination, &validation)
           name = File.basename(source, '.*')
           file = Tempfile.new(name)
           FileUtils.cp(source, file.path)
           open(file.path)
+          validation.call(file) if validation
           FileUtils.cp(file.path, destination)
         ensure
           file.close

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -21,9 +21,9 @@ module Metalware
         def open_copy(source, destination)
           name = File.basename(source, '.*')
           file = Tempfile.new(name)
-          FileUtils.cp source, file.path
+          FileUtils.cp(source, file.path)
           open(file.path)
-          FileUtils.cp file.path, destination
+          FileUtils.cp(file.path, destination)
         ensure
           file.close
           file.unlink

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -18,16 +18,25 @@ module Metalware
           ENV['VISUAL'] || ENV['EDITOR'] || DEFAULT_EDITOR
         end
 
-        def open_copy(source, destination, &validation)
+        def open_copy(source, destination, &b)
           name = File.basename(source, '.*')
           file = Tempfile.new(name)
           FileUtils.cp(source, file.path)
           open(file.path)
-          validation.call(file) if validation
+          raise_error_if_validation_fails(file.path, &b) if b
           FileUtils.cp(file.path, destination)
         ensure
           file.close
           file.unlink
+        end
+
+        private
+
+        def raise_error_if_validation_fails(path, &validation)
+          return if validation.call(path)
+          raise ValidationFailure, <<-EOF.squish
+            The edited file is invalid
+          EOF
         end
       end
     end

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -32,6 +32,7 @@ module Metalware
         def create_temp_file(name, content)
           file = Tempfile.new(name)
           file.write(content)
+          file.flush
           yield file.path
         ensure
           file.close


### PR DESCRIPTION
An optional validation block can be provided to the `open_copy` method that will check if the edited file is valid. If the validation passes or if no validation is provided, than the file is moved into place in the same manner as before.

However if the validation fails, than an error is raised. Currently this will trigger the invalid file to be deleted (like it would have been anyway). As this is a `temp` file, the source file remains unchanged. At some point in the future, the invalid files may get cached, however there is issues with scalability if the files are never deleted.  