### PR TITLE
Access asset records from the node namespace

### DIFF
--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -59,4 +59,12 @@ RSpec.describe Metalware::Cache::Asset do
       expect(new_cache.asset_for_node(node)).to eq(asset_name)
     end
   end
+
+  describe '#unassign_asset' do
+    it 'unassigns the asset from the node' do
+      cache.unassign_asset('asset_test')
+      new_cache = Metalware::Cache::Asset.new
+      expect(new_cache.data).not_to eq(content)
+    end
+  end
 end

--- a/spec/commands/asset/delete_spec.rb
+++ b/spec/commands/asset/delete_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'cache/asset'
+require 'filesystem'
+require 'commands'
+require 'utils'
+
+RSpec.describe Metalware::Commands::Asset::Delete do
+
+  it 'errors if the asset doesnt exist' do
+    expect do
+      Metalware::Utils.run_command(described_class,
+                                    'missing-type',
+                                    'name',
+                                    stderr: StringIO.new)
+    end.to raise_error(Metalware::InvalidInput)
+  end
+
+  context 'when using a saved asset' do
+    before do
+      FileSystem.root_setup do |fs|
+        fs.with_minimal_repo
+      end
+    end
+
+    let :asset { 'saved-asset' }
+    let :asset_path { Metalware::FilePath.asset(asset) }
+    let :asset_content { { key: 'value' } }
+
+    before :each { Metalware::Data.dump(asset_path, asset_content) }
+
+    def run_command
+      Metalware::Utils.run_command(described_class,
+                                    asset,
+                                    stderr: StringIO.new)
+    end
+    
+    it 'deletes the asset file' do
+      run_command
+    end
+  end
+end

--- a/spec/commands/asset/delete_spec.rb
+++ b/spec/commands/asset/delete_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Metalware::Commands::Asset::Delete do
   it 'errors if the asset doesnt exist' do
     expect do
       Metalware::Utils.run_command(described_class,
-                                    'missing-type',
-                                    'name',
-                                    stderr: StringIO.new)
+                                   'missing-type',
+                                   'name',
+                                   stderr: StringIO.new)
     end.to raise_error(Metalware::InvalidInput)
   end
 
@@ -31,12 +31,13 @@ RSpec.describe Metalware::Commands::Asset::Delete do
 
     def run_command
       Metalware::Utils.run_command(described_class,
-                                    asset,
-                                    stderr: StringIO.new)
+                                   asset,
+                                   stderr: StringIO.new)
     end
     
     it 'deletes the asset file' do
       run_command
+      expect(File.exist?(asset_path)).to eq(false)
     end
   end
 end

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -8,6 +8,7 @@ require 'constants'
 require 'hash_mergers'
 require 'recursive_open_struct'
 require 'spec_utils'
+require 'file_path'
 
 RSpec.describe Metalware::Namespaces::Node do
   context 'with AlcesUtils' do
@@ -187,6 +188,27 @@ RSpec.describe Metalware::Namespaces::Node do
         # Instead, always force the local node to use the local build
         it 'it ignores incorrect config values' do
           local_node_uses_local_build?(:pxelinux)
+        end
+      end
+    end
+
+    describe '#asset' do
+      let :content { { node: { node_name.to_sym => 'asset_test' } } }
+      let :cache { Metalware::Cache::Asset.new }
+      
+      context 'with an assigned asset' do
+        before :each { Metalware::Data.dump(Metalware::FilePath.asset('asset_test'), content) }
+
+        it 'can access the nodes asset' do
+          cache.assign_asset_to_node('asset_test', node)
+          cache.save
+          expect(node.asset.to_h).to eq(content)
+        end
+      end
+
+      context 'without an assigned asset' do
+        it 'returns nil' do
+          expect(node.asset).to eq(nil)
         end
       end
     end

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -193,10 +193,11 @@ RSpec.describe Metalware::Namespaces::Node do
 
     describe '#asset' do
       let :content { { node: { node_name.to_sym => 'asset_test' } } }
+      let :asset_path { Metalware::FilePath.asset('asset_test') }
       let :cache { Metalware::Cache::Asset.new }
       
       context 'with an assigned asset' do
-        before :each { Metalware::Data.dump(Metalware::FilePath.asset('asset_test'), content) }
+        before :each { Metalware::Data.dump(asset_path, content) }
 
         it 'can access the nodes asset' do
           cache.assign_asset_to_node('asset_test', node)

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -8,7 +8,6 @@ require 'constants'
 require 'hash_mergers'
 require 'recursive_open_struct'
 require 'spec_utils'
-require 'file_path'
 
 RSpec.describe Metalware::Namespaces::Node do
   context 'with AlcesUtils' do

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -25,6 +25,10 @@ module Metalware
         data[:node][node.name.to_sym]
       end
 
+      def unassign_asset(asset_name)
+        data.delete_if { |key, value| value == asset_name }
+      end
+
       private
 
       def blank_cache

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -26,7 +26,7 @@ module Metalware
       end
 
       def unassign_asset(asset_name)
-        data.delete_if { |key, value| value == asset_name }
+        data.delete_if { |_key, value| value == asset_name }
       end
 
       private

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -40,6 +40,11 @@ subcommands:
     options:
       - *asset_node_option
 
+  asset_delete: &asset_delete
+    syntax: metal asset delete ASSET_NAME [options]
+    summary: Delete an existing asset record
+    action: Commands::Asset::Delete
+
   configure_domain: &configure_domain
     syntax: metal configure domain [options]
     summary: Configure Metalware domain
@@ -187,6 +192,7 @@ commands:
     subcommands:
       add: *asset_add
       edit: *asset_edit
+      delete: *asset_delete
 
   build:
     syntax: metal build NODE_IDENTIFIER [options]

--- a/src/command_helpers/asset_helper.rb
+++ b/src/command_helpers/asset_helper.rb
@@ -46,6 +46,13 @@ module Metalware
           Can not find node: #{options.node}
         EOF
       end
+
+      def error_if_asset_file_doesnt_exist(asset_name, asset_path)
+        return if File.exist?(asset_path)
+        raise InvalidInput, <<-EOF.squish
+          The "#{asset_name}" asset does not yet exist
+        EOF
+      end
     end
   end
 end

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -9,28 +9,29 @@ module Metalware
       class Delete < Metalware::CommandHelpers::BaseCommand
         private
       
-        attr_reader :asset_name, :asset_path
+        attr_reader :name, :path, :cache
 
         def setup
-          @asset_name = args[0]
-          @asset_path = FilePath.asset(asset_name)
+          @name = args[0]
+          @path = FilePath.asset(name)
+          @cache = Metalware::Cache::Asset.new
         end
 
         def run
           error_if_asset_doesnt_exist
-          unassign_asset(asset_name)
+          cache.unassign_asset(name)
           delete_asset
         end
 
         def error_if_asset_doesnt_exist
-          return if File.exist?(asset_path)
+          return if File.exist?(path)
           raise InvalidInput, <<-EOF.squish
-            The "#{asset_name}" asset does not yet exist to delete.
+            The "#{name}" asset does not yet exist to delete.
           EOF
         end
         
         def delete_asset
-          FileUtils.rm asset_path
+          FileUtils.rm path
         end
       end
     end

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -20,6 +20,7 @@ module Metalware
         def run
           error_if_asset_doesnt_exist
           cache.unassign_asset(name)
+          cache.save
           delete_asset
         end
 

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'cache/asset'
+require 'fileutils'
+
+module Metalware
+  module Commands
+    module Asset
+      class Delete < Metalware::CommandHelpers::BaseCommand
+        private
+      
+        attr_reader :asset_name, :asset_path
+
+        def setup
+          @asset_name = args[0]
+          @asset_path = FilePath.asset(asset_name)
+        end
+
+        def run
+          error_if_asset_doesnt_exist
+          unassign_asset(asset_name)
+          delete_asset
+        end
+
+        def error_if_asset_doesnt_exist
+          return if File.exist?(asset_path)
+          raise InvalidInput, <<-EOF.squish
+            The "#{asset_name}" asset does not yet exist to delete.
+          EOF
+        end
+        
+        def delete_asset
+          FileUtils.rm asset_path
+        end
+      end
+    end
+  end
+end

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -8,7 +8,7 @@ module Metalware
     module Asset
       class Delete < Metalware::CommandHelpers::BaseCommand
         private
-      
+
         attr_reader :name, :path, :cache
 
         def setup
@@ -29,7 +29,7 @@ module Metalware
             The "#{name}" asset does not yet exist to delete.
           EOF
         end
-        
+
         def delete_asset
           FileUtils.rm path
         end

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -7,6 +7,7 @@ module Metalware
   module Commands
     module Asset
       class Delete < Metalware::CommandHelpers::BaseCommand
+        include CommandHelpers::AssetHelper
         private
 
         attr_reader :name, :path, :cache
@@ -18,17 +19,10 @@ module Metalware
         end
 
         def run
-          error_if_asset_doesnt_exist
+          error_if_asset_file_doesnt_exist(name, path)
           cache.unassign_asset(name)
           cache.save
           delete_asset
-        end
-
-        def error_if_asset_doesnt_exist
-          return if File.exist?(path)
-          raise InvalidInput, <<-EOF.squish
-            The "#{name}" asset does not yet exist to delete.
-          EOF
         end
 
         def delete_asset

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -8,6 +8,7 @@ module Metalware
     module Asset
       class Delete < Metalware::CommandHelpers::BaseCommand
         include CommandHelpers::AssetHelper
+
         private
 
         attr_reader :name, :path, :cache

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -17,17 +17,9 @@ module Metalware
         end
 
         def run
-          error_if_asset_doesnt_exist
+          error_if_asset_file_doesnt_exist(asset_name, asset_path)
           edit_asset_file(asset_path)
           assign_asset_to_node_if_given(asset_name)
-        end
-
-        def error_if_asset_doesnt_exist
-          return if File.exist?(asset_path)
-          raise InvalidInput, <<-EOF.squish
-            The "#{asset_name}" asset does not yet exist. Use 'metal
-            asset add' to create the asset
-          EOF
         end
       end
     end

--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -5,6 +5,7 @@ require 'nodeattr_interface'
 require 'group_cache'
 require 'hashie'
 require 'validation/loader'
+require 'cache/asset'
 
 module Metalware
   module Namespaces
@@ -78,6 +79,10 @@ module Metalware
 
         def asset
           @asset ||= AssetArray.new
+        end
+
+        def asset_cache
+          @asset_cache ||= Metalware::Cache::Asset.new
         end
 
         private

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -88,7 +88,7 @@ module Metalware
 
       def asset
         @asset ||= begin
-          asset_name = alces.asset_cache.asset_for_node(name)
+          asset_name = alces.asset_cache.asset_for_node(self)
           return unless asset_name
           alces.asset.find_by_name(asset_name)
         end

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -90,7 +90,7 @@ module Metalware
         @asset ||= begin
           asset_name = alces.asset_cache.asset_for_node(name)
           return unless asset_name
-          alces.asset.find_by_name(asset_name)  
+          alces.asset.find_by_name(asset_name)
         end
       end
 

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -86,6 +86,14 @@ module Metalware
         @plugins ||= MetalArray.new(enabled_plugin_namespaces)
       end
 
+      def asset
+        @asset ||= begin
+          asset_name = alces.asset_cache.asset_for_node(name)
+          return unless asset_name
+          alces.asset.find_by_name(asset_name)  
+        end
+      end
+
       private
 
       def white_list_for_hasher


### PR DESCRIPTION
This PR implements methods to the `alces_static` and `node` namespaces to allow for the loading of the asset cache and node's asset respectively.