### PR TITLE
Rename `alces.asset` to `alces.assets`

### DIFF
--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -77,7 +77,7 @@ module Metalware
           @questions ||= loader.question_tree
         end
 
-        def asset
+        def assets
           @asset ||= AssetArray.new
         end
 

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -92,7 +92,7 @@ module Metalware
           return unless asset_name
           OpenStruct.new(
             name: asset_name,
-            data: alces.asset.find_by_name(asset_name)
+            data: alces.assets.find_by_name(asset_name)
           )
         end
       end


### PR DESCRIPTION
It should be plural