### PR TITLE
Prompt the user when asset file is invalid

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -128,7 +128,7 @@ module AlcesUtils
   end
 
   # The following methods have to be initialized with a individual test
-  # Example, when using: 'before :each { AlcesUtils::Mock.new(self) }'
+  # Example, when using: 'before { AlcesUtils::Mock.new(self) }'
   class Mock
     def initialize(individual_spec_test)
       @test = individual_spec_test

--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Metalware::Cache::Asset do
   describe '#unassign_asset' do
     let(:asset_name) { 'asset_test' }
     let(:expected_content) { { node: {} } }
-    before :each do
+    before do
       cache.assign_asset_to_node(asset_name, node)
       cache.save
     end
@@ -91,7 +91,7 @@ RSpec.describe Metalware::Cache::Asset do
         }
       end
 
-      before :each do
+      before do
         Metalware::Data.dump(cache_path, initial_content)
       end
 

--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Metalware::Cache::Asset do
   let(:initial_content) do
     { node: { node_name.to_sym => 'asset_test' } }
   end
-  let(:node_name) { 'test_node' } 
+  let(:node_name) { 'test_node' }
   let(:node) { alces.nodes.find_by_name(node_name) }
 
   AlcesUtils.mock(self, :each) do
@@ -75,19 +75,19 @@ RSpec.describe Metalware::Cache::Asset do
 
     context 'with multiple assets in cache' do
       let(:initial_content) do
-        node_data = expected_content[:node].merge( 
+        node_data = expected_content[:node].merge(
           node_name.to_sym => asset_name,
-          node02: asset_name,
+          node02: asset_name
         )
-        { node: node_data } 
+        { node: node_data }
       end
 
       let(:expected_content) do
         {
           node: {
             node01: 'test-asset-01',
-            node03: 'test-asset-03'
-          }
+            node03: 'test-asset-03',
+          },
         }
       end
 
@@ -114,7 +114,7 @@ RSpec.describe Metalware::Cache::Asset do
     it 'attempts to unassign a missing asset' do
       cache.unassign_asset('missing_asset')
       new_cache = Metalware::Cache::Asset.new
-      expect(new_cache.data).to eq(initial_content) 
+      expect(new_cache.data).to eq(initial_content)
     end
   end
 end

--- a/spec/commands/asset/link_spec.rb
+++ b/spec/commands/asset/link_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Metalware::Commands::Asset::Link do
     let(:asset_path) { Metalware::FilePath.asset(asset_name) }
     let(:asset_content) { { key: 'value' } }
 
-    before :each { Metalware::Data.dump(asset_path, asset_content) } 
+    before { Metalware::Data.dump(asset_path, asset_content) } 
 
     it 'links the asset to a node' do
       run_command

--- a/spec/commands/asset/link_spec.rb
+++ b/spec/commands/asset/link_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Metalware::Commands::Asset::Link do
     let(:asset_path) { Metalware::FilePath.asset(asset_name) }
     let(:asset_content) { { key: 'value' } }
 
-    before { Metalware::Data.dump(asset_path, asset_content) } 
+    before { Metalware::Data.dump(asset_path, asset_content) }
 
     it 'links the asset to a node' do
       run_command

--- a/spec/commands/asset/unlink_spec.rb
+++ b/spec/commands/asset/unlink_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Metalware::Commands::Asset::Unlink do
     let(:asset_content) { { key: 'value' } }
     let(:cache_content) { { node: { node_name.to_sym => asset_name } } }
 
-    before :each do 
+    before do
       Metalware::Data.dump(asset_path, asset_content)
       Metalware::Data.dump(Metalware::FilePath.asset_cache, cache_content)
     end

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -4,6 +4,7 @@ require 'utils/editor'
 
 RSpec.describe Metalware::Utils::Editor do
   let(:default_editor) { described_class::DEFAULT_EDITOR }
+  before { allow_any_instance_of(HighLine).to receive(:agree) }
 
   context 'with the environment variables unset' do
     before do |_example|

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -43,13 +43,16 @@ module Metalware
         def raise_if_validation_fails(path, &validator)
           return if yield path
           cli = HighLine.new
-          if cli.agree('The file is invalid, would you like to reopen? (y/n)' \
-          "\nNote: Invalids files will be discarded")
+          if cli.agree(<<-EOF.squish
+                The file is invalid and will be discarded,
+                would you like to reopen? (y/n)
+              EOF
+            )
             open(path)
             raise_if_validation_fails(path, &validator) if validator
           else
             raise ValidationFailure, <<-EOF.squish
-              The edited file is invalid
+              Failed to edit file, changes have been discarded  
             EOF
           end
         end

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -42,17 +42,21 @@ module Metalware
 
         def raise_if_validation_fails(path, &validator)
           return if yield path
+          prompt_user
+          open(path)
+          raise_if_validation_fails(path, &validator) if validator
+        end
+
+        def prompt_user
           cli = HighLine.new
           if cli.agree(<<-EOF.squish
                 The file is invalid and will be discarded,
                 would you like to reopen? (y/n)
               EOF
-            )
-            open(path)
-            raise_if_validation_fails(path, &validator) if validator
+                      )
           else
             raise ValidationFailure, <<-EOF.squish
-              Failed to edit file, changes have been discarded  
+              Failed to edit file, changes have been discarded
             EOF
           end
         end

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -24,7 +24,7 @@ module Metalware
           create_temp_file(name, File.read(source)) do |path|
             open(path)
             raise_if_validation_fails(path, &validator) if validator
-            FileUtils.cp(path, destination) if File.exist?(path)
+            FileUtils.cp(path, destination)
           end
         end
 


### PR DESCRIPTION
This PR implements the ability to reopen a temporary `asset` file if it is invalid. When an invalid file is found the user is prompted with a question asking if they wish to reopen the file.
Answering no will discard any changes made to the file and answering yes will allow the user to make changes to the document. However if the file is still invalid after re-editing then they will be prompted again, repeating the process until either the file is valid or they discard the changes.