### PR TITLE
Make a bunch of changes to stop rubocop complaining

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,12 @@ Style/Documentation:
 Metrics/BlockLength:
   Enabled: false
 
+# Ignore the number of methods in FilePath, the class is design to
+# collect all the file path methods.
+Metrics/ModuleLength:
+  Exclude:
+    - src/file_path.rb
+
 # We trust the YAML we're loading, so don't warn if we don't use
 # `YAML.safe_load` instead of `YAML.load`.
 Security/YAMLLoad:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,14 @@ Style/SymbolArray:
 Style/WordArray:
   Enabled: false
 
+# Do not prefer trailing commas in multi-line hash/array literals - better as
+# when something is added to a literal the previous last line does not also
+# need to be changed, which also makes diffs smaller
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
 # Do not require documentation for top-level classes or modules - seems
 # unnecessary for the project at the moment.
 Style/Documentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,3 +57,9 @@ Style/DoubleNegation:
 # continue to be used
 Naming/HeredocDelimiterNaming:
   Enabled: false
+
+# The status has a race condition when killing bash commands. Thus
+# it should ignore no process errors
+Lint/HandleExceptions:
+  Exclude:
+    - src/status/job.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   TargetRubyVersion: 2.4
+  Exclude:
+    - src/gui/**/*
 
 # Do not prefer various `%` ways of specifying things in Ruby - I
 # think these are less clear and unnecessary

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,8 @@ Style/ClassAndModuleChildren:
 # to get this.
 Style/DoubleNegation:
   Enabled: false
+
+# Turn off Heredoc delimiter check. EOF is used extensively and will
+# continue to be used
+Naming/HeredocDelimiterNaming:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,12 +15,10 @@ Style/SymbolArray:
 Style/WordArray:
   Enabled: false
 
-# Do not prefer trailing commas in multi-line hash/array literals - better as
+# Do not preder trailing commas in multi-line hash/array literals - better as
 # when something is added to a literal the previous last line does not also
 # need to be changed, which also makes diffs smaller
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInHashLiteral:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
 # Do not require documentation for top-level classes or modules - seems
@@ -46,14 +44,3 @@ Style/ClassAndModuleChildren:
 # to get this.
 Style/DoubleNegation:
   Enabled: false
-
-# Allow the following parameter names. The additional "s, a, b" are used commonly
-# with method missing
-Naming/UncommunicativeMethodParamName:
-  AllowedNames: [io, id, to, by, on, in, at, s, a, b, _a, _b, e, _e]
-
-# Turn off Heredoc delimiter check. EOF is used extensively and will continue
-# to be used
-Naming/HeredocDelimiterNaming:
-  Enabled: false
-

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,13 +5,6 @@
 # one by one as the offenses are removed from the code base.
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
-
-# Offense count: 2
-Lint/HandleExceptions:
-  Exclude:
-    - 'spec/configurator_spec.rb'
-    - 'src/status/job.rb'
-
 # Offense count: 8
 Metrics/AbcSize:
   Max: 60

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/EmptyLines:
-  Exclude:
-    - 'src/exceptions.rb'
-
 # Offense count: 2
 Lint/HandleExceptions:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 133
+  Max: 130
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,11 +29,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 36
 
-# Offense count: 1
-# Configuration parameters: CountKeywordArgs.
-Metrics/ParameterLists:
-  Max: 7
-
 # Offense count: 2
 Metrics/PerceivedComplexity:
   Max: 14

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ end
 
 group :development do
   gem 'pry'
-  gem 'rubocop', "~> 0.52.1", require: false
+  gem 'rubocop', '~> 0.52.1', require: false
 end
 
 # Gems added for GUI app.

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ end
 
 group :development do
   gem 'pry'
-  gem 'rubocop', require: false
+  gem 'rubocop', "~> 0.52.1", require: false
 end
 
 # Gems added for GUI app.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    parser (2.5.0.5)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     popper_js (1.12.9)
     powerpack (0.1.1)
@@ -196,9 +196,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.54.0)
+    rubocop (0.52.1)
       parallel (~> 1.10)
-      parser (>= 2.5)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
@@ -285,7 +285,7 @@ DEPENDENCIES
   rails (~> 5.1.3)
   recursive-open-struct
   rspec
-  rubocop
+  rubocop (~> 0.52.1)
   ruby-libvirt
   ruby-prof
   rubytree!

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -80,7 +80,7 @@ module AlcesUtils
       buffers = input.map { |k| [k, StringIO.new] }.to_h
       update_std_files buffers
       yield
-      buffers.each { |_k, v| v.rewind }
+      buffers.each_value { |v| v.rewind }
       buffers
     ensure
       update_std_files old

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -24,8 +24,8 @@ module AlcesUtils
         end
 
         # `alces` is defined as a method so it can be reset
-        define_method :alces { Metalware::Namespaces::Alces.new }
-        define_method :reset_alces do
+        define_method(:alces) { Metalware::Namespaces::Alces.new }
+        define_method(:reset_alces) do
           @spec_alces = nil
           alces
         end

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -80,7 +80,7 @@ module AlcesUtils
       buffers = input.map { |k| [k, StringIO.new] }.to_h
       update_std_files buffers
       yield
-      buffers.each_value { |v| v.rewind }
+      buffers.each_value(&:rewind)
       buffers
     ensure
       update_std_files old

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -16,7 +16,7 @@ module AlcesUtils
         # Cache the first version of alces to be created
         # This allows it to be mocked during the spec
         # It can also be reset in the test (see below)
-        before :each do
+        before(:each) do
           allow(Metalware::Namespaces::Alces).to \
             receive(:new).and_wrap_original do |m, *a|
               @spec_alces ||= m.call(*a)
@@ -30,7 +30,7 @@ module AlcesUtils
           alces
         end
 
-        before :each { AlcesUtils.spoof_nodeattr(self) }
+        before(:each) { AlcesUtils.spoof_nodeattr(self) }
       end
     end
 

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -59,7 +59,7 @@ module AlcesUtils
           AlcesUtils.check_and_raise_fakefs_error
           path = AlcesUtils.nodeattr_genders_file_path(args[0])
           cmd = AlcesUtils.nodeattr_cmd_trim_f(args[0])
-          genders_data = File.read(path).gsub('`', '"')
+          genders_data = File.read(path).tr('`', '"')
           tempfile = `mktemp /tmp/genders.XXXXX`.chomp
           begin
             `echo "#{genders_data}" > #{tempfile}`

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -16,7 +16,7 @@ module AlcesUtils
         # Cache the first version of alces to be created
         # This allows it to be mocked during the spec
         # It can also be reset in the test (see below)
-        before(:each) do
+        before do
           allow(Metalware::Namespaces::Alces).to \
             receive(:new).and_wrap_original do |m, *a|
               @spec_alces ||= m.call(*a)
@@ -30,7 +30,7 @@ module AlcesUtils
           alces
         end
 
-        before(:each) { AlcesUtils.spoof_nodeattr(self) }
+        before { AlcesUtils.spoof_nodeattr(self) }
       end
     end
 

--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -11,7 +11,7 @@ module AlcesUtils
   GENDERS_FILE_REGEX = /-f [[:graph:]]+/
   # Causes the testing version of alces (/config) to be used by metalware
   class << self
-    def start(example_group, config: nil)
+    def start(example_group)
       example_group.instance_exec do
         # Cache the first version of alces to be created
         # This allows it to be mocked during the spec

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AlcesUtils do
   end
 
   context 'with the AlceUtils.mock method' do
-    before(:each) do
+    before do
       AlcesUtils::Mock.new(self)
                       .define_method_testing {} # Intentionally blank
     end
@@ -204,7 +204,7 @@ RSpec.describe AlcesUtils do
     end
 
     describe '#reset_alces' do
-      before(:each) do
+      before do
         @old_alces = alces
         AlcesUtils.mock(self) do
           config(alces.domain, key: 'I should be deleted in the reset')

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -6,8 +6,8 @@ require 'alces_utils'
 RSpec.describe AlcesUtils do
   include AlcesUtils
 
-  let :file_path { Metalware::FilePath }
-  let :group_cache { Metalware::GroupCache.new }
+  let(:file_path) { Metalware::FilePath }
+  let(:group_cache) { Metalware::GroupCache.new }
 
   describe '#new' do
     it 'returns the mocked alces' do
@@ -51,7 +51,7 @@ RSpec.describe AlcesUtils do
     end
 
     context 'with the config mocked' do
-      let :domain_config do
+      let(:domain_config) do
         { key: 'domain' }
       end
 
@@ -97,8 +97,8 @@ RSpec.describe AlcesUtils do
     end
 
     describe '#mock_group' do
-      let :group { 'some random group' }
-      let :group2 { 'some other group' }
+      let(:group) { 'some random group' }
+      let(:group2) { 'some other group' }
 
       AlcesUtils.mock self, :each do
         expect(File.exist?(file_path.group_cache)).to eq(false)
@@ -136,7 +136,7 @@ RSpec.describe AlcesUtils do
     end
 
     describe '#mock_node' do
-      let :name { 'some_random_test_node3456734' }
+      let(:name) { 'some_random_test_node3456734' }
 
       AlcesUtils.mock self, :each do
         allow(alces).to receive(:node).and_return(mock_node(name))
@@ -162,8 +162,8 @@ RSpec.describe AlcesUtils do
       end
 
       context 'with a new node' do
-        let :new_node { 'some_random_new_node4362346' }
-        let :genders { ['_some_group_1', '_some_group_2'] }
+        let(:new_node) { 'some_random_new_node4362346' }
+        let(:genders) { ['_some_group_1', '_some_group_2'] }
 
         AlcesUtils.mock(self, :each) { mock_node(new_node, *genders) }
 
@@ -175,8 +175,8 @@ RSpec.describe AlcesUtils do
     end
 
     describe '#create_asset' do
-      let :asset_name { 'my-new-asset' }
-      let :asset_data { { key: "#{asset_name}-data" } }
+      let(:asset_name) { 'my-new-asset' }
+      let(:asset_data) { { key: "#{asset_name}-data" } }
 
       AlcesUtils.mock(self, :each) do
         create_asset(asset_name, asset_data)
@@ -233,7 +233,7 @@ RSpec.describe AlcesUtils do
   end
 
   describe '#redirect_std' do
-    let :test_str { 'Testing' }
+    let(:test_str) { 'Testing' }
 
     it 'can redirect stdout' do
       io = AlcesUtils.redirect_std(:stdout) do

--- a/spec/alces_utils_spec.rb
+++ b/spec/alces_utils_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AlcesUtils do
   end
 
   context 'with the AlceUtils.mock method' do
-    before :each do
+    before(:each) do
       AlcesUtils::Mock.new(self)
                       .define_method_testing {} # Intentionally blank
     end
@@ -204,7 +204,7 @@ RSpec.describe AlcesUtils do
     end
 
     describe '#reset_alces' do
-      before :each do
+      before(:each) do
         @old_alces = alces
         AlcesUtils.mock(self) do
           config(alces.domain, key: 'I should be deleted in the reset')

--- a/spec/answers_table_creator_spec.rb
+++ b/spec/answers_table_creator_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Metalware::AnswersTableCreator do
     Metalware::AnswersTableCreator.new(alces)
   end
 
-  let :raw_configure_data do
+  let(:raw_configure_data) do
     {
       domain: [{
         identifier: 'question_1',
@@ -72,26 +72,26 @@ RSpec.describe Metalware::AnswersTableCreator do
     }
   end
 
-  let :question_tree do
+  let(:question_tree) do
     Metalware::Validation::Configure.new(raw_configure_data).tree
   end
 
-  let! :loader do
+  let!(:loader) do
     l = Metalware::Validation::Loader.new
     allow(l).to receive(:question_tree).and_return(question_tree)
     allow(Metalware::Validation::Loader).to receive(:new).and_return(l)
     l
   end
 
-  let :domain_answers do
+  let(:domain_answers) do
     { question_1: 'domain question 1' }
   end
 
-  let :group_answers do
+  let(:group_answers) do
     { question_1: 'group question 1', question_2: 11 }
   end
 
-  let :node_answers do
+  let(:node_answers) do
     {
       question_1: 'node question 1',
       question_2: 13,
@@ -99,8 +99,8 @@ RSpec.describe Metalware::AnswersTableCreator do
     }
   end
 
-  let :group_name { 'testnodes' }
-  let :node_name { 'testnode01' }
+  let(:group_name) { 'testnodes' }
+  let(:node_name) { 'testnode01' }
 
   AlcesUtils.mock self, :each do
     answer(alces.domain, domain_answers)

--- a/spec/asset_path_spec.rb
+++ b/spec/asset_path_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'file_path'
 
 RSpec.describe Metalware::FilePath do

--- a/spec/asset_path_spec.rb
+++ b/spec/asset_path_spec.rb
@@ -2,7 +2,7 @@ require 'file_path'
 
 RSpec.describe Metalware::FilePath do
   describe 'asset files' do
-    let :file_path { Metalware::FilePath }
+    let(:file_path) { Metalware::FilePath }
 
     it 'defines an asset template' do
       path = File.join(file_path.repo, 'assets', 'rack.yaml')

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Metalware::BuildEvent do
 
     context 'with a single node built' do
       let(:built_node) { alces.nodes[2] }
-      before(:each) { build_node(built_node) }
+      before { build_node(built_node) }
 
       it 'runs the complete_hook for the node' do
         expect(built_node.build_method).to receive(:complete_hook)
@@ -95,7 +95,7 @@ RSpec.describe Metalware::BuildEvent do
     end
 
     context 'with all the nodes built' do
-      before(:each) { alces.nodes.each { |node| build_node(node) } }
+      before { alces.nodes.each { |node| build_node(node) } }
 
       it 'runs all the complete hooks' do
         alces.nodes.each do |node|
@@ -123,7 +123,7 @@ RSpec.describe Metalware::BuildEvent do
       let(:event_file) { Metalware::FilePath.event(node, event) }
 
       context 'with basic features only (no hooks nor messages)' do
-        before(:each) { touch_file event_file }
+        before { touch_file event_file }
 
         it 'reports the event and node names to stdout' do
           expect(process[:stdout].read).to include(node.name, event)
@@ -140,7 +140,7 @@ RSpec.describe Metalware::BuildEvent do
           ['I am a little message', 'With multiple lines', 'potato']
         end
 
-        before(:each) do
+        before do
           FileUtils.mkdir_p File.dirname(event_file)
           File.write(event_file, message_arr.join("\n"))
         end

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Metalware::BuildEvent do
 
     context 'with a single node built' do
       let(:built_node) { alces.nodes[2] }
-      before :each { build_node(built_node) }
+      before(:each) { build_node(built_node) }
 
       it 'runs the complete_hook for the node' do
         expect(built_node.build_method).to receive(:complete_hook)
@@ -95,7 +95,7 @@ RSpec.describe Metalware::BuildEvent do
     end
 
     context 'with all the nodes built' do
-      before :each { alces.nodes.each { |node| build_node(node) } }
+      before(:each) { alces.nodes.each { |node| build_node(node) } }
 
       it 'runs all the complete hooks' do
         alces.nodes.each do |node|
@@ -123,7 +123,7 @@ RSpec.describe Metalware::BuildEvent do
       let(:event_file) { Metalware::FilePath.event(node, event) }
 
       context 'with basic features only (no hooks nor messages)' do
-        before :each { touch_file event_file }
+        before(:each) { touch_file event_file }
 
         it 'reports the event and node names to stdout' do
           expect(process[:stdout].read).to include(node.name, event)
@@ -140,7 +140,7 @@ RSpec.describe Metalware::BuildEvent do
           ['I am a little message', 'With multiple lines', 'potato']
         end
 
-        before :each do
+        before(:each) do
           FileUtils.mkdir_p File.dirname(event_file)
           File.write(event_file, message_arr.join("\n"))
         end

--- a/spec/build_event_spec.rb
+++ b/spec/build_event_spec.rb
@@ -14,9 +14,9 @@ end
 RSpec.describe Metalware::BuildEvent do
   include AlcesUtils
 
-  let :nodes { ['node01', 'node02', 'node03', 'nodes4'] }
-  let :build_event { Metalware::BuildEvent.new(alces.nodes) }
-  let :empty_build_event { Metalware::BuildEvent.new([]) }
+  let(:nodes) { ['node01', 'node02', 'node03', 'nodes4'] }
+  let(:build_event) { Metalware::BuildEvent.new(alces.nodes) }
+  let(:empty_build_event) { Metalware::BuildEvent.new([]) }
 
   AlcesUtils.mock self, :each do
     nodes.each { |node| mock_node(node) }
@@ -68,7 +68,7 @@ RSpec.describe Metalware::BuildEvent do
     end
 
     context 'with a single node built' do
-      let :built_node { alces.nodes[2] }
+      let(:built_node) { alces.nodes[2] }
       before :each { build_node(built_node) }
 
       it 'runs the complete_hook for the node' do
@@ -118,9 +118,9 @@ RSpec.describe Metalware::BuildEvent do
     end
 
     context 'with an event trigger' do
-      let :node { alces.nodes[3] }
-      let :event { '__trigger_without_a_build_method_hook__' }
-      let :event_file { Metalware::FilePath.event(node, event) }
+      let(:node) { alces.nodes[3] }
+      let(:event) { '__trigger_without_a_build_method_hook__' }
+      let(:event_file) { Metalware::FilePath.event(node, event) }
 
       context 'with basic features only (no hooks nor messages)' do
         before :each { touch_file event_file }
@@ -136,7 +136,7 @@ RSpec.describe Metalware::BuildEvent do
       end
 
       context 'with a message' do
-        let :message_arr do
+        let(:message_arr) do
           ['I am a little message', 'With multiple lines', 'potato']
         end
 

--- a/spec/build_files_retriever_spec.rb
+++ b/spec/build_files_retriever_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
   end
 
   describe '#retrieve_for_node' do
-    before :each do
+    before(:each) do
       FileSystem.root_setup do |fs|
         fs.with_clone_fixture('configs/unit-test.yaml')
       end
@@ -112,7 +112,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
     end
 
     context 'when template file path not present' do
-      before :each do
+      before(:each) do
         allow(File).to receive(:exist?).and_return(false)
       end
 
@@ -146,7 +146,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
     end
 
     context 'when error retrieving URL file' do
-      before :each do
+      before(:each) do
         @http_error = SpecUtils.fake_download_error(self)
       end
 
@@ -173,7 +173,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
       Metalware::Plugins.all.find { |p| p.name == plugin_name }
     end
 
-    before :each do
+    before(:each) do
       FileSystem.root_setup do |fs|
         # This must exist so can attempt to get node groups.
         fs.touch Metalware::Constants::GENDERS_PATH

--- a/spec/build_files_retriever_spec.rb
+++ b/spec/build_files_retriever_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Metalware::BuildFilesRetriever do
     ],
   }.freeze
 
-  let :test_node_name { 'testnode01' }
-  let :test_node { alces.nodes.find_by_name(test_node_name) }
+  let(:test_node_name) { 'testnode01' }
+  let(:test_node) { alces.nodes.find_by_name(test_node_name) }
 
   AlcesUtils.mock self, :each do
     config(mock_node(test_node_name), files: TEST_FILES_HASH)
@@ -165,10 +165,10 @@ RSpec.describe Metalware::BuildFilesRetriever do
   end
 
   describe '#retrieve_for_plugin' do
-    let :plugin_name { 'some_plugin' }
-    let :plugin_path { File.join(Metalware::FilePath.plugins_dir, plugin_name) }
+    let(:plugin_name) { 'some_plugin' }
+    let(:plugin_path) { File.join(Metalware::FilePath.plugins_dir, plugin_name) }
 
-    let :plugin do
+    let(:plugin) do
       FileUtils.mkdir_p(plugin_path)
       Metalware::Plugins.all.find { |p| p.name == plugin_name }
     end

--- a/spec/build_files_retriever_spec.rb
+++ b/spec/build_files_retriever_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
   end
 
   describe '#retrieve_for_node' do
-    before(:each) do
+    before do
       FileSystem.root_setup do |fs|
         fs.with_clone_fixture('configs/unit-test.yaml')
       end
@@ -112,7 +112,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
     end
 
     context 'when template file path not present' do
-      before(:each) do
+      before do
         allow(File).to receive(:exist?).and_return(false)
       end
 
@@ -146,7 +146,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
     end
 
     context 'when error retrieving URL file' do
-      before(:each) do
+      before do
         @http_error = SpecUtils.fake_download_error(self)
       end
 
@@ -173,7 +173,7 @@ RSpec.describe Metalware::BuildFilesRetriever do
       Metalware::Plugins.all.find { |p| p.name == plugin_name }
     end
 
-    before(:each) do
+    before do
       FileSystem.root_setup do |fs|
         # This must exist so can attempt to get node groups.
         fs.touch Metalware::Constants::GENDERS_PATH

--- a/spec/build_methods/build_method_spec.rb
+++ b/spec/build_methods/build_method_spec.rb
@@ -29,16 +29,16 @@ RSpec.describe Metalware::BuildMethods::BuildMethod do
     end
   end
 
-  let :node { Metalware::Namespaces::Node.create(alces, 'node01') }
-  let :alces { Metalware::Namespaces::Alces.new }
-  let :templater do
+  let(:node) { Metalware::Namespaces::Node.create(alces, 'node01') }
+  let(:alces) { Metalware::Namespaces::Alces.new }
+  let(:templater) do
     Metalware::Staging.template
   end
 
-  let :template_path { '/path/to/template' }
-  let :rendered_path { '/path/to/rendered' }
+  let(:template_path) { '/path/to/template' }
+  let(:rendered_path) { '/path/to/rendered' }
 
-  let :mock_files do
+  let(:mock_files) do
     FileSystem.root_setup do |fs|
       fs.create template_path
       fs.create rendered_path
@@ -52,7 +52,7 @@ RSpec.describe Metalware::BuildMethods::BuildMethod do
     }
   end
 
-  let :mock_files_with_errors do
+  let(:mock_files_with_errors) do
     {
       some_section: [{
         error: 'error',

--- a/spec/build_methods/kickstarts/uefi_spec.rb
+++ b/spec/build_methods/kickstarts/uefi_spec.rb
@@ -30,7 +30,7 @@ require 'alces_utils'
 RSpec.describe Metalware::BuildMethods::Kickstarts::UEFI do
   include AlcesUtils
 
-  before :each do
+  before(:each) do
     FileSystem.root_setup(&:with_minimal_repo)
   end
 

--- a/spec/build_methods/kickstarts/uefi_spec.rb
+++ b/spec/build_methods/kickstarts/uefi_spec.rb
@@ -30,7 +30,7 @@ require 'alces_utils'
 RSpec.describe Metalware::BuildMethods::Kickstarts::UEFI do
   include AlcesUtils
 
-  before(:each) do
+  before do
     FileSystem.root_setup(&:with_minimal_repo)
   end
 

--- a/spec/build_methods/kickstarts/uefi_spec.rb
+++ b/spec/build_methods/kickstarts/uefi_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Metalware::BuildMethods::Kickstarts::UEFI do
     FileSystem.root_setup(&:with_minimal_repo)
   end
 
-  let :node_name { 'nodeA01' }
-  let :node { alces.nodes.find_by_name node_name }
+  let(:node_name) { 'nodeA01' }
+  let(:node) { alces.nodes.find_by_name node_name }
 
   AlcesUtils.mock self, :each do
     n = mock_node node_name

--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Metalware::Cache::Asset do
 
   describe '#asset_for_node' do
     let(:asset_name) { 'test-asset' }
-    before :each do
+    before(:each) do
       cache.assign_asset_to_node(asset_name, node)
       cache.save
     end

--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -4,11 +4,13 @@ require 'cache/asset'
 RSpec.describe Metalware::Cache::Asset do
   include AlcesUtils
   
-  let :cache { Metalware::Cache::Asset.new }
-  let :cache_path { Metalware::FilePath.asset_cache }
-  let :initial_content { { node: { node_name.to_sym => 'asset_test' } } }
-  let :node_name { 'test_node' } 
-  let :node { alces.nodes.find_by_name(node_name) }
+  let(:cache) { Metalware::Cache::Asset.new }
+  let(:cache_path) { Metalware::FilePath.asset_cache }
+  let(:initial_content) do
+    { node: { node_name.to_sym => 'asset_test' } }
+  end
+  let(:node_name) { 'test_node' } 
+  let(:node) { alces.nodes.find_by_name(node_name) }
 
   AlcesUtils.mock(self, :each) do
     mock_node(node_name) 
@@ -45,7 +47,7 @@ RSpec.describe Metalware::Cache::Asset do
   end
 
   describe '#asset_for_node' do
-    let :asset_name { 'test-asset' }
+    let(:asset_name) { 'test-asset' }
     before :each do
       cache.assign_asset_to_node(asset_name, node)
       cache.save
@@ -62,15 +64,15 @@ RSpec.describe Metalware::Cache::Asset do
   end
 
   describe '#unassign_asset' do
-    let :asset_name { 'asset_test' }
-    let :expected_content { { node: {} } }
+    let(:asset_name) { 'asset_test' }
+    let(:expected_content) { { node: {} } }
     before :each do
       cache.assign_asset_to_node(asset_name, node)
       cache.save
     end
 
     context 'with multiple assets in cache' do
-      let :initial_content do
+      let(:initial_content) do
         node_data = expected_content[:node].merge( 
           node_name.to_sym => asset_name,
           node02: asset_name,
@@ -78,7 +80,7 @@ RSpec.describe Metalware::Cache::Asset do
         { node: node_data } 
       end
 
-      let :expected_content do
+      let(:expected_content) do
         {
           node: {
             node01: 'test-asset-01',

--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Metalware::Cache::Asset do
 
   describe '#asset_for_node' do
     let(:asset_name) { 'test-asset' }
-    before(:each) do
+    before do
       cache.assign_asset_to_node(asset_name, node)
       cache.save
     end

--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'alces_utils'
 require 'cache/asset'
 
 RSpec.describe Metalware::Cache::Asset do
   include AlcesUtils
-  
+
   let(:cache) { Metalware::Cache::Asset.new }
   let(:cache_path) { Metalware::FilePath.asset_cache }
   let(:initial_content) do
@@ -13,9 +15,9 @@ RSpec.describe Metalware::Cache::Asset do
   let(:node) { alces.nodes.find_by_name(node_name) }
 
   AlcesUtils.mock(self, :each) do
-    mock_node(node_name) 
+    mock_node(node_name)
   end
-  
+
   describe '#data' do
     it 'handles empty cache' do
       expect do
@@ -43,7 +45,7 @@ RSpec.describe Metalware::Cache::Asset do
       expect do
         cache.assign_asset_to_node('asset_test', node)
       end.not_to raise_error
-    end 
+    end
   end
 
   describe '#asset_for_node' do

--- a/spec/cli_helper/parser_spec.rb
+++ b/spec/cli_helper/parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Metalware::CliHelper::Parser do
     stub_const('Metalware::CliHelper::CONFIG_PATH', test_config_path)
   end
 
-  let :test_config_path { '/tmp/config.yaml' }
+  let(:test_config_path) { '/tmp/config.yaml' }
 
   describe 'default parsing' do
     def define_config_with_default(default_value)

--- a/spec/command_helpers/alces_command_spec.rb
+++ b/spec/command_helpers/alces_command_spec.rb
@@ -7,10 +7,10 @@ require 'alces_utils'
 RSpec.describe Metalware::CommandHelpers::AlcesCommand do
   include AlcesUtils
 
-  let :domain_config { Hash.new(key: 'I am the domain config') }
+  let(:domain_config) { Hash.new(key: 'I am the domain config') }
 
-  let :node { 'node01' }
-  let :group { 'group1' }
+  let(:node) { 'node01' }
+  let(:group) { 'group1' }
 
   AlcesUtils.mock self, :each do
     config(alces.domain, domain_config)

--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
   end
 
   describe 'option handling' do
-    before(:each) do
+    before do
       SpecUtils.use_mock_genders(self)
       SpecUtils.mock_validate_genders_success(self)
     end

--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
   end
 
   describe 'option handling' do
-    before :each do
+    before(:each) do
       SpecUtils.use_mock_genders(self)
       SpecUtils.mock_validate_genders_success(self)
     end

--- a/spec/commander_extensions_spec.rb
+++ b/spec/commander_extensions_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CommanderExtensions do
     @command = command :'test do'
   end
 
-  before(:each) do
+  before do
     $stderr = StringIO.new
     mock_terminal
     create_test_command
@@ -139,7 +139,7 @@ RSpec.describe CommanderExtensions do
       end
 
       describe 'when multi-word command' do
-        before(:each) do
+        before do
           create_multi_word_test_command
         end
 

--- a/spec/commander_extensions_spec.rb
+++ b/spec/commander_extensions_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CommanderExtensions do
       c.example 'description', 'command'
       c.option '-o', '--some-option', 'Some option that does things'
       c.when_called do |args, _options|
-        format('test %s', args.join(' '))
+        format('test %<foo>s', foo: args.join(' '))
       end
     end
     @command = command :test
@@ -52,7 +52,7 @@ RSpec.describe CommanderExtensions do
     command :'test do' do |c|
       c.syntax = 'metal test do ARG1 ARG2 [options]'
       c.when_called do |args, _options|
-        format('test do %s', args.join(' '))
+        format('test do %<foo>s', foo: args.join(' '))
       end
     end
     @command = command :'test do'

--- a/spec/commander_extensions_spec.rb
+++ b/spec/commander_extensions_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CommanderExtensions do
     @command = command :'test do'
   end
 
-  before :each do
+  before(:each) do
     $stderr = StringIO.new
     mock_terminal
     create_test_command
@@ -139,7 +139,7 @@ RSpec.describe CommanderExtensions do
       end
 
       describe 'when multi-word command' do
-        before :each do
+        before(:each) do
           create_multi_word_test_command
         end
 

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe Metalware::Commands::Asset::Add do
       end
     end
 
-    let :template { 'default' }
-    let :save { 'saved-asset' }
+    let(:template) { 'default' }
+    let(:save) { 'saved-asset' }
 
-    let :template_path { Metalware::FilePath.asset_template(template) }
-    let :save_path { Metalware::FilePath.asset(save) }
+    let(:template_path) { Metalware::FilePath.asset_template(template) }
+    let(:save_path) { Metalware::FilePath.asset(save) }
 
     def run_command
       Metalware::Utils.run_command(described_class,
@@ -55,8 +55,8 @@ RSpec.describe Metalware::Commands::Asset::Add do
   context 'with a node argument' do
     before :each { FileSystem.root_setup(&:with_minimal_repo) }
 
-    let :asset_name { 'asset1' }
-    let :command_arguments { ['default', asset_name] }
+    let(:asset_name) { 'asset1' }
+    let(:command_arguments) { ['default', asset_name] }
 
     it_behaves_like 'asset command that assigns a node'
   end

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -7,7 +7,7 @@ require 'shared_examples/asset_command_that_assigns_a_node'
 
 RSpec.describe Metalware::Commands::Asset::Add do
   # Stops the editor from running the bash command
-  before :each { allow(Metalware::Utils::Editor).to receive(:open) }
+  before(:each) { allow(Metalware::Utils::Editor).to receive(:open) }
 
   it 'errors if the template does not exist' do
     expect do
@@ -53,7 +53,7 @@ RSpec.describe Metalware::Commands::Asset::Add do
   end
 
   context 'with a node argument' do
-    before :each { FileSystem.root_setup(&:with_minimal_repo) }
+    before(:each) { FileSystem.root_setup(&:with_minimal_repo) }
 
     let(:asset_name) { 'asset1' }
     let(:command_arguments) { ['default', asset_name] }

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -7,7 +7,7 @@ require 'shared_examples/asset_command_that_assigns_a_node'
 
 RSpec.describe Metalware::Commands::Asset::Add do
   # Stops the editor from running the bash command
-  before(:each) { allow(Metalware::Utils::Editor).to receive(:open) }
+  before { allow(Metalware::Utils::Editor).to receive(:open) }
 
   it 'errors if the template does not exist' do
     expect do
@@ -53,7 +53,7 @@ RSpec.describe Metalware::Commands::Asset::Add do
   end
 
   context 'with a node argument' do
-    before(:each) { FileSystem.root_setup(&:with_minimal_repo) }
+    before { FileSystem.root_setup(&:with_minimal_repo) }
 
     let(:asset_name) { 'asset1' }
     let(:command_arguments) { ['default', asset_name] }

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe Metalware::Commands::Asset::Add do
 
   context 'when using the default template' do
     before do
-      FileSystem.root_setup do |fs|
-        fs.with_minimal_repo
-      end
+      FileSystem.root_setup(&:with_minimal_repo)
     end
 
     let(:template) { 'default' }
@@ -40,7 +38,7 @@ RSpec.describe Metalware::Commands::Asset::Add do
 
     it 'calls for the template to be opened and copyed' do
       expect(Metalware::Utils::Editor).to receive(:open_copy)
-                                      .with(template_path, save_path)
+        .with(template_path, save_path)
       run_command
     end
 
@@ -61,4 +59,3 @@ RSpec.describe Metalware::Commands::Asset::Add do
     it_behaves_like 'asset command that assigns a node'
   end
 end
-

--- a/spec/commands/asset/delete_spec.rb
+++ b/spec/commands/asset/delete_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Metalware::Commands::Asset::Delete do
     let(:asset_path) { Metalware::FilePath.asset(asset) }
     let(:asset_content) { { key: 'value' } }
 
-    before :each { Metalware::Data.dump(asset_path, asset_content) }
+    before(:each) { Metalware::Data.dump(asset_path, asset_content) }
 
     it 'deletes the asset file' do
       run_command

--- a/spec/commands/asset/delete_spec.rb
+++ b/spec/commands/asset/delete_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Metalware::Commands::Asset::Delete do
                                  asset,
                                  stderr: StringIO.new)
   end
- 
+
   it 'errors if the asset does not exist' do
     expect do
       run_command

--- a/spec/commands/asset/delete_spec.rb
+++ b/spec/commands/asset/delete_spec.rb
@@ -6,7 +6,7 @@ require 'commands'
 require 'utils'
 
 RSpec.describe Metalware::Commands::Asset::Delete do
-  let :asset { 'saved-asset' }
+  let(:asset) { 'saved-asset' }
 
   def run_command
     Metalware::Utils.run_command(described_class,
@@ -25,8 +25,8 @@ RSpec.describe Metalware::Commands::Asset::Delete do
       FileSystem.root_setup(&:with_minimal_repo)
     end
 
-    let :asset_path { Metalware::FilePath.asset(asset) }
-    let :asset_content { { key: 'value' } }
+    let(:asset_path) { Metalware::FilePath.asset(asset) }
+    let(:asset_content) { { key: 'value' } }
 
     before :each { Metalware::Data.dump(asset_path, asset_content) }
 

--- a/spec/commands/asset/delete_spec.rb
+++ b/spec/commands/asset/delete_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Metalware::Commands::Asset::Delete do
     let(:asset_path) { Metalware::FilePath.asset(asset) }
     let(:asset_content) { { key: 'value' } }
 
-    before(:each) { Metalware::Data.dump(asset_path, asset_content) }
+    before { Metalware::Data.dump(asset_path, asset_content) }
 
     it 'deletes the asset file' do
       run_command

--- a/spec/commands/asset/edit_spec.rb
+++ b/spec/commands/asset/edit_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Metalware::Commands::Asset::Edit do
       end
     end
 
-    let :saved_asset { 'saved-asset' }
-    let :asset_path { Metalware::FilePath.asset(saved_asset) }
-    let :test_content { { key: 'value' } }
+    let(:saved_asset) { 'saved-asset' }
+    let(:asset_path) { Metalware::FilePath.asset(saved_asset) }
+    let(:test_content) { { key: 'value' } }
 
     before :each { Metalware::Data.dump(asset_path, test_content) }
 
@@ -44,8 +44,8 @@ RSpec.describe Metalware::Commands::Asset::Edit do
   end
 
   context 'with a node input' do
-    let :asset_name { 'asset1' }
-    let :command_arguments { [asset_name] }
+    let(:asset_name) { 'asset1' }
+    let(:command_arguments) { [asset_name] }
 
     before :each do
       Metalware::Data.dump(Metalware::FilePath.asset(asset_name), {})

--- a/spec/commands/asset/edit_spec.rb
+++ b/spec/commands/asset/edit_spec.rb
@@ -6,7 +6,7 @@ require 'filesystem'
 require 'shared_examples/asset_command_that_assigns_a_node'
 
 RSpec.describe Metalware::Commands::Asset::Edit do
-  before(:each) { allow(Metalware::Utils::Editor).to receive(:open) }
+  before { allow(Metalware::Utils::Editor).to receive(:open) }
 
   it 'errors if the asset doesnt exist' do
     expect do
@@ -28,7 +28,7 @@ RSpec.describe Metalware::Commands::Asset::Edit do
     let(:asset_path) { Metalware::FilePath.asset(saved_asset) }
     let(:test_content) { { key: 'value' } }
 
-    before(:each) { Metalware::Data.dump(asset_path, test_content) }
+    before { Metalware::Data.dump(asset_path, test_content) }
 
     def run_command
       Metalware::Utils.run_command(described_class,
@@ -47,7 +47,7 @@ RSpec.describe Metalware::Commands::Asset::Edit do
     let(:asset_name) { 'asset1' }
     let(:command_arguments) { [asset_name] }
 
-    before(:each) do
+    before do
       Metalware::Data.dump(Metalware::FilePath.asset(asset_name), {})
     end
 

--- a/spec/commands/asset/edit_spec.rb
+++ b/spec/commands/asset/edit_spec.rb
@@ -11,17 +11,15 @@ RSpec.describe Metalware::Commands::Asset::Edit do
   it 'errors if the asset doesnt exist' do
     expect do
       Metalware::Utils.run_command(described_class,
-                                    'missing-type',
-                                    'name',
-                                    stderr: StringIO.new)
+                                   'missing-type',
+                                   'name',
+                                   stderr: StringIO.new)
     end.to raise_error(Metalware::InvalidInput)
   end
-  
+
   context 'when using a saved asset' do
     before do
-      FileSystem.root_setup do |fs|
-        fs.with_minimal_repo
-      end
+      FileSystem.root_setup(&:with_minimal_repo)
     end
 
     let(:saved_asset) { 'saved-asset' }
@@ -32,13 +30,13 @@ RSpec.describe Metalware::Commands::Asset::Edit do
 
     def run_command
       Metalware::Utils.run_command(described_class,
-                                    saved_asset,
-                                    stderr: StringIO.new)
+                                   saved_asset,
+                                   stderr: StringIO.new)
     end
 
     it 'calls for the saved asset to be opened and copied into a temp file' do
       expect(Metalware::Utils::Editor).to receive(:open_copy)
-                                      .with(asset_path, asset_path)
+        .with(asset_path, asset_path)
       run_command
     end
   end

--- a/spec/commands/asset/edit_spec.rb
+++ b/spec/commands/asset/edit_spec.rb
@@ -6,7 +6,7 @@ require 'filesystem'
 require 'shared_examples/asset_command_that_assigns_a_node'
 
 RSpec.describe Metalware::Commands::Asset::Edit do
-  before :each { allow(Metalware::Utils::Editor).to receive(:open) }
+  before(:each) { allow(Metalware::Utils::Editor).to receive(:open) }
 
   it 'errors if the asset doesnt exist' do
     expect do
@@ -28,7 +28,7 @@ RSpec.describe Metalware::Commands::Asset::Edit do
     let(:asset_path) { Metalware::FilePath.asset(saved_asset) }
     let(:test_content) { { key: 'value' } }
 
-    before :each { Metalware::Data.dump(asset_path, test_content) }
+    before(:each) { Metalware::Data.dump(asset_path, test_content) }
 
     def run_command
       Metalware::Utils.run_command(described_class,
@@ -47,7 +47,7 @@ RSpec.describe Metalware::Commands::Asset::Edit do
     let(:asset_name) { 'asset1' }
     let(:command_arguments) { [asset_name] }
 
-    before :each do
+    before(:each) do
       Metalware::Data.dump(Metalware::FilePath.asset(asset_name), {})
     end
 

--- a/spec/commands/asset/link_spec.rb
+++ b/spec/commands/asset/link_spec.rb
@@ -7,10 +7,10 @@ require 'filesystem'
 RSpec.describe Metalware::Commands::Asset::Link do
   include AlcesUtils
 
-  let :asset_name { 'asset_test' }
-  let :node_name { 'test_node' }
-  let :node { alces.nodes.find_by_name(node_name) }
-  let :content { { node: { node_name.to_sym => asset_name } } }
+  let(:asset_name) { 'asset_test' }
+  let(:node_name) { 'test_node' }
+  let(:node) { alces.nodes.find_by_name(node_name) }
+  let(:content) { { node: { node_name.to_sym => asset_name } } }
 
   AlcesUtils.mock(self, :each) do
     mock_node(node_name)
@@ -34,8 +34,8 @@ RSpec.describe Metalware::Commands::Asset::Link do
       FileSystem.root_setup(&:with_minimal_repo)
     end
 
-    let :asset_path { Metalware::FilePath.asset(asset_name) }
-    let :asset_content { { key: 'value' } }
+    let(:asset_path) { Metalware::FilePath.asset(asset_name) }
+    let(:asset_content) { { key: 'value' } }
 
     before :each { Metalware::Data.dump(asset_path, asset_content) } 
 

--- a/spec/commands/asset/unlink_spec.rb
+++ b/spec/commands/asset/unlink_spec.rb
@@ -6,10 +6,10 @@ require 'alces_utils'
 RSpec.describe Metalware::Commands::Asset::Unlink do
   include AlcesUtils
 
-  let :asset_name { 'asset_test' }
-  let :node_name { 'test_node' }
-  let :node { alces.nodes.find_by_name(node_name) }
-  let :content { { node: { node_name.to_sym => asset_name } } }
+  let(:asset_name) { 'asset_test' }
+  let(:node_name) { 'test_node' }
+  let(:node) { alces.nodes.find_by_name(node_name) }
+  let(:content) { { node: { node_name.to_sym => asset_name } } }
 
   AlcesUtils.mock(self, :each) do
     mock_node(node_name)
@@ -33,9 +33,9 @@ RSpec.describe Metalware::Commands::Asset::Unlink do
       FileSystem.root_setup(&:with_minimal_repo)
     end
 
-    let :asset_path { Metalware::FilePath.asset(asset_name) }
-    let :asset_content { { key: 'value' } }
-    let :cache_content { { node: { node_name.to_sym => asset_name } } }
+    let(:asset_path) { Metalware::FilePath.asset(asset_name) }
+    let(:asset_content) { { key: 'value' } }
+    let(:cache_content) { { node: { node_name.to_sym => asset_name } } }
 
     before :each do 
       Metalware::Data.dump(asset_path, asset_content)

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Metalware::Commands::Build do
     AlcesUtils.kill_other_threads
   end
 
-  let :build_wait_time { Metalware::Constants::BUILD_POLL_SLEEP * 5 }
+  let(:build_wait_time) { Metalware::Constants::BUILD_POLL_SLEEP * 5 }
 
   def run_build(node_group, delay_report_built: nil, **options_hash)
     Timeout.timeout build_wait_time do
@@ -78,7 +78,7 @@ RSpec.describe Metalware::Commands::Build do
   end
 
   # Mocks the test node
-  let :testnode { alces.nodes.find_by_name('testnode01') }
+  let(:testnode) { alces.nodes.find_by_name('testnode01') }
   AlcesUtils.mock self, :each do
     config(testnode, build_method: :kickstart)
     hexadecimal_ip(testnode)
@@ -129,9 +129,9 @@ RSpec.describe Metalware::Commands::Build do
       end
     end
 
-    let :test_group_name { 'some_random_test_group' }
-    let :testnodes { alces.groups.find_by_name test_group_name }
-    let :delay_build { build_wait_time / 10 }
+    let(:test_group_name) { 'some_random_test_group' }
+    let(:testnodes) { alces.groups.find_by_name test_group_name }
+    let(:delay_build) { build_wait_time / 10 }
 
     it 'starts all the builds' do
       testnodes.nodes do |node|

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -33,7 +33,7 @@ require 'alces_utils'
 RSpec.describe Metalware::Commands::Build do
   include AlcesUtils
 
-  before :each do
+  before(:each) do
     # Shortens the wait times for the tests
     stub_const('Metalware::Constants::BUILD_POLL_SLEEP', 0.1)
     # Makes sure there aren't any other threads
@@ -70,7 +70,7 @@ RSpec.describe Metalware::Commands::Build do
   end
 
   # Sets up the filesystem
-  before :each do
+  before(:each) do
     FileSystem.root_setup do |fs|
       fs.with_repo_fixtures('repo')
       fs.with_genders_fixtures
@@ -84,7 +84,7 @@ RSpec.describe Metalware::Commands::Build do
     hexadecimal_ip(testnode)
   end
 
-  before :each do
+  before(:each) do
     SpecUtils.use_mock_dependency(self)
   end
 

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -33,7 +33,7 @@ require 'alces_utils'
 RSpec.describe Metalware::Commands::Build do
   include AlcesUtils
 
-  before(:each) do
+  before do
     # Shortens the wait times for the tests
     stub_const('Metalware::Constants::BUILD_POLL_SLEEP', 0.1)
     # Makes sure there aren't any other threads
@@ -70,7 +70,7 @@ RSpec.describe Metalware::Commands::Build do
   end
 
   # Sets up the filesystem
-  before(:each) do
+  before do
     FileSystem.root_setup do |fs|
       fs.with_repo_fixtures('repo')
       fs.with_genders_fixtures
@@ -84,7 +84,7 @@ RSpec.describe Metalware::Commands::Build do
     hexadecimal_ip(testnode)
   end
 
-  before(:each) do
+  before do
     SpecUtils.use_mock_dependency(self)
   end
 

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metalware::Commands::Configure::Domain do
     FileSystem.setup(&:with_minimal_repo)
   end
 
-  before :each do
+  before(:each) do
     SpecUtils.mock_validate_genders_success(self)
   end
 

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metalware::Commands::Configure::Domain do
     FileSystem.setup(&:with_minimal_repo)
   end
 
-  before(:each) do
+  before do
     SpecUtils.mock_validate_genders_success(self)
   end
 

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Metalware::Commands::Configure::Domain do
     )
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup(&:with_minimal_repo)
   end
 

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
 
           expect(new_cache.primary_groups).to eq [
             'testnodes',
-            'orphan'
+            'orphan',
           ]
         end
       end
@@ -88,7 +88,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
           expect(new_cache.primary_groups).to eq [
             'first_group',
             'second_group',
-            'orphan'
+            'orphan',
           ]
         end
       end
@@ -104,7 +104,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
           expect(new_cache.primary_groups).to eq [
             'first_group',
             'second_group',
-            'orphan'
+            'orphan',
           ]
         end
       end

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
     FileSystem.setup(&:with_minimal_repo)
   end
 
-  before :each do
+  before(:each) do
     SpecUtils.mock_validate_genders_success(self)
   end
 

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
     FileSystem.setup(&:with_minimal_repo)
   end
 
-  before(:each) do
+  before do
     SpecUtils.mock_validate_genders_success(self)
   end
 

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
     Metalware::GroupCache.new
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup(&:with_minimal_repo)
   end
 

--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -12,19 +12,19 @@ RSpec.describe Metalware::Commands::Configure::Node do
     )
   end
 
-  let :initial_alces { Metalware::Namespaces::Alces.new }
-  let :alces do
+  let(:initial_alces) { Metalware::Namespaces::Alces.new }
+  let(:alces) do
     allow(initial_alces).to receive(:groups).and_return(
       double('groups', testnodes: test_group)
     )
     initial_alces
   end
 
-  let :test_group do
+  let(:test_group) do
     Metalware::Namespaces::Group.new(initial_alces, 'testnodes', index: 1)
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_minimal_repo
       fs.dump(Metalware::FilePath.domain_answers, {})

--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Metalware::Commands::Configure::Node do
     end
   end
 
-  before :each do
+  before(:each) do
     SpecUtils.use_mock_genders(self)
     SpecUtils.mock_validate_genders_success(self)
     allow(Metalware::Namespaces::Alces).to receive(:new).and_return(alces)

--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Metalware::Commands::Configure::Node do
     end
   end
 
-  before(:each) do
+  before do
     SpecUtils.use_mock_genders(self)
     SpecUtils.mock_validate_genders_success(self)
     allow(Metalware::Namespaces::Alces).to receive(:new).and_return(alces)

--- a/spec/commands/console_spec.rb
+++ b/spec/commands/console_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Metalware::Commands::Console do
   end
 
   describe 'when run on bare metal' do
-    let :node_name { 'node01' }
-    let :node_config do
+    let(:node_name) { 'node01' }
+    let(:node_config) do
       {
         networks: {
           bmc: {

--- a/spec/commands/each_spec.rb
+++ b/spec/commands/each_spec.rb
@@ -31,7 +31,7 @@ require 'namespaces/alces'
 RSpec.describe Metalware::Commands::Each do
   include AlcesUtils
 
-  before(:each) do
+  before do
     FileSystem.root_setup do |fs|
       fs.with_genders_fixtures
       fs.with_clone_fixture('configs/unit-test.yaml')
@@ -45,12 +45,12 @@ RSpec.describe Metalware::Commands::Each do
   end
 
   # Spoofs the nodes group
-  before(:each) do
+  before do
     allow(alces).to receive(:groups).and_return(groups)
   end
 
   # Turns off loading of answers as they are not needed
-  before(:each) do
+  before do
     allow(Metalware::HashMergers::Answer).to \
       receive(:new).and_return(double('answer', merge: {}))
   end

--- a/spec/commands/each_spec.rb
+++ b/spec/commands/each_spec.rb
@@ -31,7 +31,7 @@ require 'namespaces/alces'
 RSpec.describe Metalware::Commands::Each do
   include AlcesUtils
 
-  before :each do
+  before(:each) do
     FileSystem.root_setup do |fs|
       fs.with_genders_fixtures
       fs.with_clone_fixture('configs/unit-test.yaml')
@@ -45,12 +45,12 @@ RSpec.describe Metalware::Commands::Each do
   end
 
   # Spoofs the nodes group
-  before :each do
+  before(:each) do
     allow(alces).to receive(:groups).and_return(groups)
   end
 
   # Turns off loading of answers as they are not needed
-  before :each do
+  before(:each) do
     allow(Metalware::HashMergers::Answer).to \
       receive(:new).and_return(double('answer', merge: {}))
   end

--- a/spec/commands/each_spec.rb
+++ b/spec/commands/each_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Metalware::Commands::Each do
     SpecUtils.use_unit_test_config(self)
   end
 
-  let :groups do
+  let(:groups) do
     g = Metalware::Namespaces::Group.new(alces, 'nodes', index: 1)
     Metalware::Namespaces::MetalArray.new([g])
   end

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Metalware::Commands::Ipmi do
     end
 
     # Allow the system command to receive `nodeattr` commands
-    before :each do
+    before(:each) do
       with_args = [/\Anodeattr.*/, an_instance_of(Hash)]
       allow(Metalware::SystemCommand).to \
         receive(:run).with(*with_args).and_call_original

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe Metalware::Commands::Ipmi do
     # XXX The setup for these tests is duplicated from those for power; should
     # DRY this up.
 
-    let :node_names { ['node01', 'node02', 'node03'] }
-    let :group { 'nodes' }
-    let :gender { 'my_super_awesome_gender' }
-    let :namespace_config do
+    let(:node_names) { ['node01', 'node02', 'node03'] }
+    let(:group) { 'nodes' }
+    let(:gender) { 'my_super_awesome_gender' }
+    let(:namespace_config) do
       {
         networks: {
           bmc: {
@@ -71,22 +71,22 @@ RSpec.describe Metalware::Commands::Ipmi do
     end
 
     context 'when run for group' do
-      let :test_gender { group }
+      let(:test_gender) { group }
       include_examples 'runs on each node'
     end
 
     context 'when run for a gender' do
-      let :test_gender { gender }
+      let(:test_gender) { gender }
       include_examples 'runs on each node'
     end
   end
 
   describe Metalware::Commands::Ipmi::Command do
     subject { Metalware::Commands::Ipmi::Command }
-    let :regular_command { 'regular_command' }
-    let :options_command { 'options_command' }
-    let :args { [nil, regular_command] }
-    let :options { OpenStruct.new(command: options_command) }
+    let(:regular_command) { 'regular_command' }
+    let(:options_command) { 'options_command' }
+    let(:args) { [nil, regular_command] }
+    let(:options) { OpenStruct.new(command: options_command) }
 
     describe '::parse' do
       it 'errors if both command inputs are used' do

--- a/spec/commands/ipmi_spec.rb
+++ b/spec/commands/ipmi_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Metalware::Commands::Ipmi do
     end
 
     # Allow the system command to receive `nodeattr` commands
-    before(:each) do
+    before do
       with_args = [/\Anodeattr.*/, an_instance_of(Hash)]
       allow(Metalware::SystemCommand).to \
         receive(:run).with(*with_args).and_call_original

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Metalware::Commands::Overview do
     end
   end
 
-  before :each do
+  before(:each) do
     allow(Metalware::Overview::Table).to \
       receive(:new).with(any_args).and_call_original
   end
@@ -44,7 +44,7 @@ RSpec.describe Metalware::Commands::Overview do
       }
     end
 
-    before :each do
+    before(:each) do
       Metalware::Data.dump Metalware::FilePath.overview, overview_hash
     end
 

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Metalware::Commands::Overview do
     end
   end
 
-  before(:each) do
+  before do
     allow(Metalware::Overview::Table).to \
       receive(:new).with(any_args).and_call_original
   end
@@ -44,7 +44,7 @@ RSpec.describe Metalware::Commands::Overview do
       }
     end
 
-    before(:each) do
+    before do
       Metalware::Data.dump Metalware::FilePath.overview, overview_hash
     end
 

--- a/spec/commands/overview_spec.rb
+++ b/spec/commands/overview_spec.rb
@@ -6,7 +6,7 @@ require 'fixtures/shared_context/overview'
 RSpec.describe Metalware::Commands::Overview do
   include_context 'overview context'
 
-  let :name_hash { { header: 'Group Name', value: '<%= group.name %>' } }
+  let(:name_hash) { { header: 'Group Name', value: '<%= group.name %>' } }
 
   def run_command
     AlcesUtils.redirect_std(:stdout) do
@@ -37,7 +37,7 @@ RSpec.describe Metalware::Commands::Overview do
   end
 
   context 'with a overview.yaml' do
-    let :overview_hash do
+    let(:overview_hash) do
       {
         domain: [{ header: 'h1', value: 'v1' }, { header: 'h2', value: 'v2' }],
         group: fields,

--- a/spec/commands/plugin/activate_spec.rb
+++ b/spec/commands/plugin/activate_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe Metalware::Commands::Plugin::Activate do
     )
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_minimal_repo
       fs.mkdir_p example_plugin_dir
     end
   end
 
-  let :example_plugin_dir { File.join Metalware::FilePath.plugins_dir, example_plugin_name }
-  let :example_plugin_name { 'example' }
+  let(:example_plugin_dir) { File.join Metalware::FilePath.plugins_dir, example_plugin_name }
+  let(:example_plugin_name) { 'example' }
 
   def example_plugin
     Metalware::Plugins.all.find do |plugin|

--- a/spec/commands/plugin/deactivate_spec.rb
+++ b/spec/commands/plugin/deactivate_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe Metalware::Commands::Plugin::Deactivate do
     )
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_minimal_repo
       fs.mkdir_p example_plugin_dir
     end
   end
 
-  let :example_plugin_dir { File.join Metalware::FilePath.plugins_dir, example_plugin_name }
-  let :example_plugin_name { 'example' }
+  let(:example_plugin_dir) { File.join Metalware::FilePath.plugins_dir, example_plugin_name }
+  let(:example_plugin_name) { 'example' }
 
   def example_plugin
     Metalware::Plugins.all.find do |plugin|

--- a/spec/commands/plugin/list_spec.rb
+++ b/spec/commands/plugin/list_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Metalware::Commands::Plugin::List do
     )
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_minimal_repo
       fs.mkdir_p example_plugin_dir_1
@@ -43,9 +43,9 @@ RSpec.describe Metalware::Commands::Plugin::List do
     end
   end
 
-  let :example_plugin_dir_1 { File.join Metalware::FilePath.plugins_dir, 'example01' }
-  let :example_plugin_dir_2 { File.join Metalware::FilePath.plugins_dir, 'example02' }
-  let :junk_other_plugins_dir_file { File.join Metalware::FilePath.plugins_dir, 'junk' }
+  let(:example_plugin_dir_1) { File.join Metalware::FilePath.plugins_dir, 'example01' }
+  let(:example_plugin_dir_2) { File.join Metalware::FilePath.plugins_dir, 'example02' }
+  let(:junk_other_plugins_dir_file) { File.join Metalware::FilePath.plugins_dir, 'junk' }
 
   it 'outputs line for each plugin subdirectory' do
     filesystem.test do

--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Metalware::Commands::Power do
   end
 
   describe 'when run on bare metal' do
-    let :node_names { ['node01', 'node02', 'node03'] }
-    let :group { 'nodes' }
-    let :namespace_config do
+    let(:node_names) { ['node01', 'node02', 'node03'] }
+    let(:group) { 'nodes' }
+    let(:namespace_config) do
       {
         networks: {
           bmc: {

--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Metalware::Commands::Power do
     end
 
     # Allow the system command to receive `nodeattr` commands
-    before :each do
+    before(:each) do
       with_args = [/\Anodeattr.*/, an_instance_of(Hash)]
       allow(Metalware::SystemCommand).to \
         receive(:run).with(*with_args).and_call_original

--- a/spec/commands/power_spec.rb
+++ b/spec/commands/power_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Metalware::Commands::Power do
     end
 
     # Allow the system command to receive `nodeattr` commands
-    before(:each) do
+    before do
       with_args = [/\Anodeattr.*/, an_instance_of(Hash)]
       allow(Metalware::SystemCommand).to \
         receive(:run).with(*with_args).and_call_original

--- a/spec/commands/remove/group_spec.rb
+++ b/spec/commands/remove/group_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Metalware::Commands::Remove::Group do
     validation_off
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_minimal_repo
       fs.with_answer_fixtures('setup1/answers')
@@ -44,11 +44,11 @@ RSpec.describe Metalware::Commands::Remove::Group do
     end
   end
 
-  let :loader { Metalware::Validation::Loader.new }
-  let :cache { loader.group_cache[:primary_groups] }
+  let(:loader) { Metalware::Validation::Loader.new }
+  let(:cache) { loader.group_cache[:primary_groups] }
 
-  let :initial_files { answer_files }
-  let :deleted_files { initial_files - answer_files }
+  let(:initial_files) { answer_files }
+  let(:deleted_files) { initial_files - answer_files }
 
   before :each do
     SpecUtils.mock_validate_genders_success(self)

--- a/spec/commands/remove/group_spec.rb
+++ b/spec/commands/remove/group_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Metalware::Commands::Remove::Group do
   let(:initial_files) { answer_files }
   let(:deleted_files) { initial_files - answer_files }
 
-  before :each do
+  before(:each) do
     SpecUtils.mock_validate_genders_success(self)
     filesystem.test { initial_files }
   end

--- a/spec/commands/remove/group_spec.rb
+++ b/spec/commands/remove/group_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Metalware::Commands::Remove::Group do
   let(:initial_files) { answer_files }
   let(:deleted_files) { initial_files - answer_files }
 
-  before(:each) do
+  before do
     SpecUtils.mock_validate_genders_success(self)
     filesystem.test { initial_files }
   end

--- a/spec/commands/status_spec.rb
+++ b/spec/commands/status_spec.rb
@@ -33,7 +33,7 @@ require 'filesystem'
 RSpec.describe Metalware::Status::Monitor do
   include AlcesUtils
 
-  before :each do
+  before(:each) do
     FileSystem.root_setup do |fs|
       fs.with_genders_fixtures
       fs.with_clone_fixture('configs/unit-test.yaml')

--- a/spec/commands/status_spec.rb
+++ b/spec/commands/status_spec.rb
@@ -33,7 +33,7 @@ require 'filesystem'
 RSpec.describe Metalware::Status::Monitor do
   include AlcesUtils
 
-  before(:each) do
+  before do
     FileSystem.root_setup do |fs|
       fs.with_genders_fixtures
       fs.with_clone_fixture('configs/unit-test.yaml')
@@ -54,7 +54,7 @@ RSpec.describe Metalware::Status::Monitor do
   end
 
   context 'create_jobs is ran' do
-    before(:each) do
+    before do
       @monitor.instance_eval { @started_jobs = 0 }
       @monitor.define_singleton_method(:start_next_job,
                                        ->(_idx) { @started_jobs += 1 })

--- a/spec/commands/sync_spec.rb
+++ b/spec/commands/sync_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Metalware::Commands::Sync do
     let(:files) { ['first', 'second', 'third'].map { |f| "/tmp/#{f}" } }
     let(:validate_file) { '/tmp/validate-file' }
 
-    before :each do
+    before(:each) do
       Metalware::Staging.update do |staging|
         good_validator = Metalware::Testing::GoodValidation.to_s
         staging.push_file(validate_file, '', validator: good_validator)
@@ -43,7 +43,7 @@ RSpec.describe Metalware::Commands::Sync do
     end
 
     context 'with valid files (aka no errors expected)' do
-      before :each { run_sync }
+      before(:each) { run_sync }
 
       it 'moves the files into place' do
         files.each { |f| expect(File.exist?(f)).to eq(true) }
@@ -58,7 +58,7 @@ RSpec.describe Metalware::Commands::Sync do
       let(:bad_file) { '/tmp/bad-validator-file' }
       let(:stderr) { StringIO.new }
 
-      before :each do
+      before(:each) do
         # Allows the error to be printed
         allow(Metalware::Output).to \
           (receive(:stderr).and_wrap_original { |_m, *arg| warn arg })

--- a/spec/commands/sync_spec.rb
+++ b/spec/commands/sync_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Metalware::Commands::Sync do
   delegate :manifest, to: Metalware::Staging
 
   describe '#sync_files' do
-    let :files { ['first', 'second', 'third'].map { |f| "/tmp/#{f}" } }
-    let :validate_file { '/tmp/validate-file' }
+    let(:files) { ['first', 'second', 'third'].map { |f| "/tmp/#{f}" } }
+    let(:validate_file) { '/tmp/validate-file' }
 
     before :each do
       Metalware::Staging.update do |staging|
@@ -55,8 +55,8 @@ RSpec.describe Metalware::Commands::Sync do
     end
 
     context 'with a validation error' do
-      let :bad_file { '/tmp/bad-validator-file' }
-      let :stderr { StringIO.new }
+      let(:bad_file) { '/tmp/bad-validator-file' }
+      let(:stderr) { StringIO.new }
 
       before :each do
         # Allows the error to be printed

--- a/spec/commands/sync_spec.rb
+++ b/spec/commands/sync_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Metalware::Commands::Sync do
     let(:files) { ['first', 'second', 'third'].map { |f| "/tmp/#{f}" } }
     let(:validate_file) { '/tmp/validate-file' }
 
-    before(:each) do
+    before do
       Metalware::Staging.update do |staging|
         good_validator = Metalware::Testing::GoodValidation.to_s
         staging.push_file(validate_file, '', validator: good_validator)
@@ -43,7 +43,7 @@ RSpec.describe Metalware::Commands::Sync do
     end
 
     context 'with valid files (aka no errors expected)' do
-      before(:each) { run_sync }
+      before { run_sync }
 
       it 'moves the files into place' do
         files.each { |f| expect(File.exist?(f)).to eq(true) }
@@ -58,7 +58,7 @@ RSpec.describe Metalware::Commands::Sync do
       let(:bad_file) { '/tmp/bad-validator-file' }
       let(:stderr) { StringIO.new }
 
-      before(:each) do
+      before do
         # Allows the error to be printed
         allow(Metalware::Output).to \
           (receive(:stderr).and_wrap_original { |_m, *arg| warn arg })

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Metalware::Configurator do
 
   # Do not want to use readline to get input in tests as tests will then
   # hang waiting for input.
-  before :each do
+  before(:each) do
     allow(Metalware::Configurator).to receive(:use_readline).and_return(false)
   end
 
@@ -432,7 +432,7 @@ RSpec.describe Metalware::Configurator do
       Metalware::GroupCache.new
     end
 
-    before :each do
+    before(:each) do
       define_questions(node: [
                          {
                            identifier: 'string_q',
@@ -449,7 +449,7 @@ RSpec.describe Metalware::Configurator do
   end
 
   context 'with a dependent questions' do
-    before :each do
+    before(:each) do
       define_questions(domain: [
                          {
                            identifier: 'parent',
@@ -522,7 +522,7 @@ RSpec.describe Metalware::Configurator do
       subject do
         alces.groups.find_by_name(group_name).answer.to_h[identifier]
       end
-      before :each { configure_group }
+      before(:each) { configure_group }
 
       let(:load_answer) do
         path = Metalware::FilePath.group_answers(group_name)
@@ -550,7 +550,7 @@ RSpec.describe Metalware::Configurator do
       end
 
       context 'when the new answer matches a previously saved answer' do
-        before :each { configure_group }
+        before(:each) { configure_group }
         let(:answer) { 'Some random answer' }
         let(:saved_answer) { answer }
         include_examples 'gets the answer'
@@ -573,7 +573,7 @@ RSpec.describe Metalware::Configurator do
         mock_node(node_name, group_name)
       end
 
-      before :each do
+      before(:each) do
         conf = Metalware::Configurator.for_node(alces, node_name)
         configure_with_answers([answer], test_obj: conf)
       end
@@ -602,7 +602,7 @@ RSpec.describe Metalware::Configurator do
         Metalware::Data.load(path)[identifier]
       end
 
-      before :each do
+      before(:each) do
         conf = Metalware::Configurator.for_local(alces)
         configure_with_answers([answer], test_obj: conf)
       end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -33,30 +33,30 @@ require 'alces_utils'
 RSpec.describe Metalware::Configurator do
   include AlcesUtils
 
-  let :input do
+  let(:input) do
     Tempfile.new
   end
 
-  let :output do
+  let(:output) do
     Tempfile.new
   end
 
   # Spoofs HighLine to always return the testing version of highline
-  let! :highline do
+  let!(:highline) do
     hl = HighLine.new(input, output)
     allow(HighLine).to receive(:new).and_return(hl)
     hl
   end
 
-  let :answers do
+  let(:answers) do
     loader.domain_answers
   end
 
-  let :higher_level_answer_files { [] }
+  let(:higher_level_answer_files) { [] }
 
-  let :loader { Metalware::Validation::Loader.new }
+  let(:loader) { Metalware::Validation::Loader.new }
 
-  let :configurator do
+  let(:configurator) do
     make_configurator
   end
 
@@ -425,8 +425,8 @@ RSpec.describe Metalware::Configurator do
   end
 
   context 'with an orphan node' do
-    let :orphan { 'i_am_a_orphan_node' }
-    let :configure_orphan { Metalware::Configurator.for_node(alces, orphan) }
+    let(:orphan) { 'i_am_a_orphan_node' }
+    let(:configure_orphan) { Metalware::Configurator.for_node(alces, orphan) }
 
     def new_group_cache
       Metalware::GroupCache.new
@@ -478,14 +478,14 @@ RSpec.describe Metalware::Configurator do
   end
 
   context 'with existing domain level answer' do
-    let :original_default { 'original-default-answer' }
-    let :group_name { 'my-super-awesome-group' }
-    let :group_default { 'I am the group level yaml default' }
-    let :node_default { 'I am the node level yaml default' }
-    let :local_default { 'I am the local level yaml default' }
-    let :domain_answer { 'Domain answer with ERB, <%= node.name %>' }
-    let :identifier { :question_identifier }
-    let :question do
+    let(:original_default) { 'original-default-answer' }
+    let(:group_name) { 'my-super-awesome-group' }
+    let(:group_default) { 'I am the group level yaml default' }
+    let(:node_default) { 'I am the node level yaml default' }
+    let(:local_default) { 'I am the local level yaml default' }
+    let(:domain_answer) { 'Domain answer with ERB, <%= node.name %>' }
+    let(:identifier) { :question_identifier }
+    let(:question) do
       {
         identifier: identifier.to_s,
         question: 'Where was my question set?',
@@ -524,46 +524,46 @@ RSpec.describe Metalware::Configurator do
       end
       before :each { configure_group }
 
-      let :load_answer do
+      let(:load_answer) do
         path = Metalware::FilePath.group_answers(group_name)
         Metalware::Data.load(path)[identifier]
       end
 
       context 'when the answer matches the original default' do
-        let :answer { original_default }
-        let :saved_answer { original_default }
+        let(:answer) { original_default }
+        let(:saved_answer) { original_default }
         include_examples 'gets the answer'
       end
 
       context 'when the answer matches the domain answer' do
-        let :answer { domain_answer }
-        let :saved_answer { nil }
+        let(:answer) { domain_answer }
+        let(:saved_answer) { nil }
         include_examples 'gets the answer'
       end
 
       # NOTE: The group level default should be ignored Thus Configurator
       # should behave as if it is any other random input
       context 'when the answer matches the group level default' do
-        let :answer { group_default }
-        let :saved_answer { group_default }
+        let(:answer) { group_default }
+        let(:saved_answer) { group_default }
         include_examples 'gets the answer'
       end
 
       context 'when the new answer matches a previously saved answer' do
         before :each { configure_group }
-        let :answer { 'Some random answer' }
-        let :saved_answer { answer }
+        let(:answer) { 'Some random answer' }
+        let(:saved_answer) { answer }
         include_examples 'gets the answer'
       end
     end
 
     context 'when configuring a node' do
-      let :node_name { 'my_super_awesome_node' }
-      let :group_answer { 'I am the group level answer' }
+      let(:node_name) { 'my_super_awesome_node' }
+      let(:group_answer) { 'I am the group level answer' }
       subject do
         alces.nodes.find_by_name(node_name).answer.to_h[identifier]
       end
-      let :load_answer do
+      let(:load_answer) do
         path = Metalware::FilePath.node_answers(node_name)
         Metalware::Data.load(path)[identifier]
       end
@@ -581,14 +581,14 @@ RSpec.describe Metalware::Configurator do
       # The node yaml default should be ignored and saved like any other
       # answer
       context 'when the answer matches the node level default' do
-        let :answer { node_default }
-        let :saved_answer { node_default }
+        let(:answer) { node_default }
+        let(:saved_answer) { node_default }
         include_examples 'gets the answer'
       end
 
       context 'when the answer matches the group level' do
-        let :answer { group_answer }
-        let :saved_answer { nil }
+        let(:answer) { group_answer }
+        let(:saved_answer) { nil }
         include_examples 'gets the answer'
       end
     end
@@ -597,7 +597,7 @@ RSpec.describe Metalware::Configurator do
       subject do
         alces.local.answer.to_h[identifier]
       end
-      let :load_answer do
+      let(:load_answer) do
         path = Metalware::FilePath.local_answers
         Metalware::Data.load(path)[identifier]
       end
@@ -608,16 +608,16 @@ RSpec.describe Metalware::Configurator do
       end
 
       context 'when the answer matches the domain default' do
-        let :answer { domain_answer }
-        let :saved_answer { nil }
+        let(:answer) { domain_answer }
+        let(:saved_answer) { nil }
         include_examples 'gets the answer'
       end
 
       # The local yaml defaults should be ignored and thus treated like
       # any other answer
       context 'when the answer matches the local level default' do
-        let :answer { local_default }
-        let :saved_answer { local_default }
+        let(:answer) { local_default }
+        let(:saved_answer) { local_default }
         include_examples 'gets the answer'
       end
     end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -77,13 +77,8 @@ RSpec.describe Metalware::Configurator do
     yield
     tmp.close
   rescue StandardError => e
-    begin
-      $stdout.rewind
-      STDERR.puts $stdout.read
-    rescue StandardError
-      # XXX Not handling this gives a Rubocop warning; should we do something
-      # here?
-    end
+    $stdout.rewind
+    STDERR.puts $stdout.read
     raise e
   ensure
     $stdout = STDOUT

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Metalware::Configurator do
 
   # Do not want to use readline to get input in tests as tests will then
   # hang waiting for input.
-  before(:each) do
+  before do
     allow(Metalware::Configurator).to receive(:use_readline).and_return(false)
   end
 
@@ -432,7 +432,7 @@ RSpec.describe Metalware::Configurator do
       Metalware::GroupCache.new
     end
 
-    before(:each) do
+    before do
       define_questions(node: [
                          {
                            identifier: 'string_q',
@@ -449,7 +449,7 @@ RSpec.describe Metalware::Configurator do
   end
 
   context 'with a dependent questions' do
-    before(:each) do
+    before do
       define_questions(domain: [
                          {
                            identifier: 'parent',
@@ -522,7 +522,7 @@ RSpec.describe Metalware::Configurator do
       subject do
         alces.groups.find_by_name(group_name).answer.to_h[identifier]
       end
-      before(:each) { configure_group }
+      before { configure_group }
 
       let(:load_answer) do
         path = Metalware::FilePath.group_answers(group_name)
@@ -550,7 +550,7 @@ RSpec.describe Metalware::Configurator do
       end
 
       context 'when the new answer matches a previously saved answer' do
-        before(:each) { configure_group }
+        before { configure_group }
         let(:answer) { 'Some random answer' }
         let(:saved_answer) { answer }
         include_examples 'gets the answer'
@@ -573,7 +573,7 @@ RSpec.describe Metalware::Configurator do
         mock_node(node_name, group_name)
       end
 
-      before(:each) do
+      before do
         conf = Metalware::Configurator.for_node(alces, node_name)
         configure_with_answers([answer], test_obj: conf)
       end
@@ -602,7 +602,7 @@ RSpec.describe Metalware::Configurator do
         Metalware::Data.load(path)[identifier]
       end
 
-      before(:each) do
+      before do
         conf = Metalware::Configurator.for_local(alces)
         configure_with_answers([answer], test_obj: conf)
       end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -27,9 +27,9 @@ require 'data'
 require 'filesystem'
 
 RSpec.describe Metalware::Data do
-  let :data_file_path { '/path/to/some_data.yaml' }
+  let(:data_file_path) { '/path/to/some_data.yaml' }
 
-  let :string_keyed_data do
+  let(:string_keyed_data) do
     {
       'a_key' => 'foo',
       'another_key' => {
@@ -38,7 +38,7 @@ RSpec.describe Metalware::Data do
     }
   end
 
-  let :symbol_keyed_data do
+  let(:symbol_keyed_data) do
     {
       a_key: 'foo',
       another_key: {
@@ -47,9 +47,9 @@ RSpec.describe Metalware::Data do
     }
   end
 
-  let :invalid_yaml { '[half an array' }
+  let(:invalid_yaml) { '[half an array' }
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.mkdir_p(File.dirname(data_file_path))
     end

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Metalware::Dependency do
   end
 
   context 'with repo dependencies' do
-    before :each do
+    before(:each) do
       filesystem.with_repo_fixtures('repo')
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Metalware::Dependency do
   end
 
   context 'with blank configure.yaml dependencies' do
-    before :each do
+    before(:each) do
       filesystem.with_repo_fixtures('repo')
     end
 
@@ -117,7 +117,7 @@ RSpec.describe Metalware::Dependency do
     end
 
     context 'when answer files exist' do
-      before :each do
+      before(:each) do
         filesystem.with_minimal_repo
         filesystem.with_answer_fixtures('answers/basic_structure')
       end
@@ -132,7 +132,7 @@ RSpec.describe Metalware::Dependency do
     end
 
     context 'with optional dependencies' do
-      before :each do
+      before(:each) do
         filesystem.with_minimal_repo
         filesystem.with_answer_fixtures('answers/basic_structure')
       end

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Metalware::Dependency do
   end
 
   context 'with repo dependencies' do
-    before(:each) do
+    before do
       filesystem.with_repo_fixtures('repo')
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Metalware::Dependency do
   end
 
   context 'with blank configure.yaml dependencies' do
-    before(:each) do
+    before do
       filesystem.with_repo_fixtures('repo')
     end
 
@@ -117,7 +117,7 @@ RSpec.describe Metalware::Dependency do
     end
 
     context 'when answer files exist' do
-      before(:each) do
+      before do
         filesystem.with_minimal_repo
         filesystem.with_answer_fixtures('answers/basic_structure')
       end
@@ -132,7 +132,7 @@ RSpec.describe Metalware::Dependency do
     end
 
     context 'with optional dependencies' do
-      before(:each) do
+      before do
         filesystem.with_minimal_repo
         filesystem.with_answer_fixtures('answers/basic_structure')
       end

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -35,7 +35,7 @@ require 'alces_utils'
 RSpec.describe Metalware::Dependency do
   include AlcesUtils
 
-  let :filesystem { FileSystem.setup }
+  let(:filesystem) { FileSystem.setup }
 
   def enforce_dependencies(dependencies_hash = {})
     filesystem.test do |_fs|

--- a/spec/dependency_specifications_spec.rb
+++ b/spec/dependency_specifications_spec.rb
@@ -28,7 +28,7 @@ require 'dependency_specifications'
 require 'namespaces/alces'
 
 RSpec.describe Metalware::DependencySpecifications do
-  let :alces { Metalware::Namespaces::Alces.new }
+  let(:alces) { Metalware::Namespaces::Alces.new }
 
   subject do
     Metalware::DependencySpecifications.new(alces)

--- a/spec/dns/named_spec.rb
+++ b/spec/dns/named_spec.rb
@@ -33,8 +33,8 @@ require 'alces_utils'
 RSpec.describe Metalware::DNS::Named do
   include AlcesUtils
 
-  let :file_path { Metalware::FilePath }
-  let :filesystem do
+  let(:file_path) { Metalware::FilePath }
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_minimal_repo
       named = 'named.conf.erb'
@@ -43,7 +43,7 @@ RSpec.describe Metalware::DNS::Named do
     end
   end
 
-  let :correct_base_named_conf do
+  let(:correct_base_named_conf) do
     externaldns = named.send(:repo_config)[:externaldns]
     "DNS: #{externaldns}"
   end

--- a/spec/file_path_spec.rb
+++ b/spec/file_path_spec.rb
@@ -27,7 +27,7 @@ require 'file_path'
 
 RSpec.describe Metalware::FilePath do
   describe 'dynamic constant paths' do
-    let :file_path { Metalware::FilePath }
+    let(:file_path) { Metalware::FilePath }
 
     it 'defines a constant file path' do
       expect(file_path.metalware_data).to eq(Metalware::Constants::METALWARE_DATA_PATH)

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -130,7 +130,7 @@ class FileSystem
   end
 
   def with_validation_error_file
-    FakeFS::FileSystem.clone(Metalware::Validation::Configure::ERROR_FILE)
+    FakeFS::FileSystem.clone(Metalware::FilePath.dry_validation_errors)
   end
 
   def with_repo_fixtures(repo_fixtures_dir)

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -203,7 +203,7 @@ class FileSystem
       '/var/lib/metalware/assets',
       '/var/named',
       '/var/log/metalware',
-      File.join(Metalware::Constants::METALWARE_INSTALL_PATH, 'templates')
+      File.join(Metalware::Constants::METALWARE_INSTALL_PATH, 'templates'),
     ].each do |path|
       FileUtils.mkdir_p(path)
     end

--- a/spec/fixtures/shared_context/overview.rb
+++ b/spec/fixtures/shared_context/overview.rb
@@ -5,9 +5,9 @@ require 'alces_utils'
 RSpec.shared_context 'overview context' do
   include AlcesUtils
 
-  let :config_value { 'config_value' }
-  let :static { 'static' }
-  let :fields do
+  let(:config_value) { 'config_value' }
+  let(:static) { 'static' }
+  let(:fields) do
     [
       { header: 'heading1', value: static },
       { header: 'heading2', value: '<%= scope.config.key %>' },

--- a/spec/group_cache_spec.rb
+++ b/spec/group_cache_spec.rb
@@ -29,13 +29,13 @@ require 'alces_utils'
 RSpec.describe Metalware::GroupCache do
   include AlcesUtils
 
-  let :cache { new_cache }
+  let(:cache) { new_cache }
 
   def new_cache
     Metalware::GroupCache.new
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_group_cache_fixture('cache/groups.yaml')
     end

--- a/spec/hash_mergers/answer_spec.rb
+++ b/spec/hash_mergers/answer_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Metalware::HashMergers::Answer do
     end
   end
 
-  before :each do
+  before(:each) do
     Metalware::Data.dump Metalware::FilePath.configure_file, questions
   end
 
@@ -80,7 +80,7 @@ RSpec.describe Metalware::HashMergers::Answer do
   end
 
   context 'with answer files' do
-    before :each do
+    before(:each) do
       Metalware::Data.dump(
         Metalware::FilePath.domain_answers,
         identifier => answers(alces.domain)

--- a/spec/hash_mergers/answer_spec.rb
+++ b/spec/hash_mergers/answer_spec.rb
@@ -9,13 +9,13 @@ require 'file_path'
 RSpec.describe Metalware::HashMergers::Answer do
   include AlcesUtils
 
-  let :group { AlcesUtils.mock(self) { mock_group('new_group') } }
-  let :node do
+  let(:group) { AlcesUtils.mock(self) { mock_group('new_group') } }
+  let(:node) do
     AlcesUtils.mock(self) { mock_node('new_node', group.name) }
   end
 
-  let :identifier { :question_identifier }
-  let :questions do
+  let(:identifier) { :question_identifier }
+  let(:questions) do
     {
       domain: [{
         identifier: identifier.to_s,

--- a/spec/hash_mergers/answer_spec.rb
+++ b/spec/hash_mergers/answer_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Metalware::HashMergers::Answer do
     end
   end
 
-  before(:each) do
+  before do
     Metalware::Data.dump Metalware::FilePath.configure_file, questions
   end
 
@@ -80,7 +80,7 @@ RSpec.describe Metalware::HashMergers::Answer do
   end
 
   context 'with answer files' do
-    before(:each) do
+    before do
       Metalware::Data.dump(
         Metalware::FilePath.domain_answers,
         identifier => answers(alces.domain)

--- a/spec/hash_mergers/hash_merger_spec.rb
+++ b/spec/hash_mergers/hash_merger_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metalware::HashMergers::HashMerger do
     validation_off
   end
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_repo_fixtures('merged_hash')
       fs.with_answer_fixtures('merged_hash/answers')
@@ -40,7 +40,7 @@ RSpec.describe Metalware::HashMergers::HashMerger do
   end
 
   context 'with domain scope' do
-    let :merged_hash { build_merged_hash }
+    let(:merged_hash) { build_merged_hash }
 
     it 'returns the domain config' do
       filesystem.test do
@@ -50,7 +50,7 @@ RSpec.describe Metalware::HashMergers::HashMerger do
   end
 
   context 'with single group' do
-    let :merged_hash do
+    let(:merged_hash) do
       build_merged_hash(groups: ['group2'])
     end
 
@@ -69,7 +69,7 @@ RSpec.describe Metalware::HashMergers::HashMerger do
   end
 
   context 'with multiple groups' do
-    let :merged_hash do
+    let(:merged_hash) do
       build_merged_hash(groups: ['group1', 'group2'])
     end
 
@@ -90,7 +90,7 @@ RSpec.describe Metalware::HashMergers::HashMerger do
   end
 
   context 'with multiple groups and a node' do
-    let :merged_hash do
+    let(:merged_hash) do
       build_merged_hash(
         groups: ['group1', 'group2'],
         node: 'node3'

--- a/spec/hash_mergers/metal_recursive_open_struct_spec.rb
+++ b/spec/hash_mergers/metal_recursive_open_struct_spec.rb
@@ -21,13 +21,13 @@ module Metalware
 end
 
 RSpec.describe Metalware::HashMergers::MetalRecursiveOpenStruct do
-  let :alces do
+  let(:alces) do
     namespace = Metalware::Namespaces::Alces.new
     allow(namespace).to receive(:testing).and_return(build_default_hash)
     namespace
   end
 
-  let :struct { build_default_hash }
+  let(:struct) { build_default_hash }
 
   def build_default_hash
     my_hash = {
@@ -72,7 +72,7 @@ RSpec.describe Metalware::HashMergers::MetalRecursiveOpenStruct do
   end
 
   context 'with array of hashes' do
-    let :array_of_hashes do
+    let(:array_of_hashes) do
       my_hash = {
         array: [
           { key: 'value' },
@@ -92,8 +92,8 @@ RSpec.describe Metalware::HashMergers::MetalRecursiveOpenStruct do
   end
 
   context 'when using an inherited class' do
-    let :data { { sub_hash: { key: 'value' } } }
-    let :inherited_class do
+    let(:data) { { sub_hash: { key: 'value' } } }
+    let(:inherited_class) do
       Metalware::TestInheritedMetalRecursiveOpenStruct
     end
     subject { inherited_class.new(data) }

--- a/spec/hunter_updater_spec.rb
+++ b/spec/hunter_updater_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Metalware::HunterUpdater do
     end
 
     context 'with existing hunter content' do
-      before(:each) do
+      before do
         Metalware::Data.dump(hunter_file, somenode01: 'some_mac_address')
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Metalware::HunterUpdater do
     end
 
     context 'when hunter file does not exist yet' do
-      before(:each) do
+      before do
         File.delete(hunter_file)
       end
 

--- a/spec/hunter_updater_spec.rb
+++ b/spec/hunter_updater_spec.rb
@@ -28,8 +28,8 @@ require 'hunter_updater'
 require 'output'
 
 RSpec.describe Metalware::HunterUpdater do
-  let :hunter_file { Tempfile.new.path }
-  let :updater { Metalware::HunterUpdater.new(hunter_file) }
+  let(:hunter_file) { Tempfile.new.path }
+  let(:updater) { Metalware::HunterUpdater.new(hunter_file) }
 
   def hunter_yaml
     Metalware::Data.load(hunter_file)

--- a/spec/hunter_updater_spec.rb
+++ b/spec/hunter_updater_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Metalware::HunterUpdater do
     end
 
     context 'with existing hunter content' do
-      before :each do
+      before(:each) do
         Metalware::Data.dump(hunter_file, somenode01: 'some_mac_address')
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Metalware::HunterUpdater do
     end
 
     context 'when hunter file does not exist yet' do
-      before :each do
+      before(:each) do
         File.delete(hunter_file)
       end
 

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe '`metal build`' do
     end
   end
 
-  before :each do
+  before(:each) do
     kill_any_metal_processes
 
     FileUtils.remove(TEST_DIR, force: true)
@@ -234,7 +234,7 @@ RSpec.describe '`metal build`' do
         let(:stdin) { StringIO.new }
         let(:highline) { HighLine.new(stdin) }
 
-        before :each do
+        before(:each) do
           allow(HighLine).to receive(:new).and_return(highline)
         end
 

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -35,7 +35,7 @@ require 'minimal_repo'
 RSpec.describe '`metal build`' do
   TEST_DIR = 'tmp/integration-test'
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.with_minimal_repo
       fs.with_answer_fixtures('answers/integration-test')
@@ -108,7 +108,7 @@ RSpec.describe '`metal build`' do
     kill_any_metal_processes
   end
 
-  let :file_path { Metalware::FilePath }
+  let(:file_path) { Metalware::FilePath }
 
   def touch_complete_file(name)
     path = file_path.build_complete(alces.nodes.find_by_name(name))
@@ -117,7 +117,7 @@ RSpec.describe '`metal build`' do
   end
 
   context 'for single node' do
-    let :node { 'testnode01' }
+    let(:node) { 'testnode01' }
 
     it 'works' do
       build_node(node) do |thread|
@@ -135,7 +135,7 @@ RSpec.describe '`metal build`' do
   end
 
   context 'for gender group' do
-    let :nodes { ['testnode01', 'testnode02', 'testnode03'] }
+    let(:nodes) { ['testnode01', 'testnode02', 'testnode03'] }
 
     it 'works' do
       build_node('nodes', gender: true) do |thread|
@@ -231,8 +231,8 @@ RSpec.describe '`metal build`' do
       end
 
       context 'with mocked highline' do
-        let :stdin { StringIO.new }
-        let :highline { HighLine.new(stdin) }
+        let(:stdin) { StringIO.new }
+        let(:highline) { HighLine.new(stdin) }
 
         before :each do
           allow(HighLine).to receive(:new).and_return(highline)

--- a/spec/integration/build_spec.rb
+++ b/spec/integration/build_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe '`metal build`' do
     end
   end
 
-  before(:each) do
+  before do
     kill_any_metal_processes
 
     FileUtils.remove(TEST_DIR, force: true)
@@ -234,7 +234,7 @@ RSpec.describe '`metal build`' do
         let(:stdin) { StringIO.new }
         let(:highline) { HighLine.new(stdin) }
 
-        before(:each) do
+        before do
           allow(HighLine).to receive(:new).and_return(highline)
         end
 

--- a/spec/minimal_repo.rb
+++ b/spec/minimal_repo.rb
@@ -49,11 +49,11 @@ module MinimalRepo
                                   local: []),
       # Define the build interface to be whatever the first interface is; this
       # should always be sufficient for testing purposes.
-      'server.yaml': YAML.dump(build_interface: NetworkInterface.interfaces.first)
+      'server.yaml': YAML.dump(build_interface: NetworkInterface.interfaces.first),
     }.freeze
 
     ABSOLUTE_FILES = {
-      '/var/lib/tftpboot/pxelinux.cfg/': nil
+      '/var/lib/tftpboot/pxelinux.cfg/': nil,
     }.freeze
 
     def create_at(path)

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Metalware::Namespaces::Alces do
   end
 
   describe 'default template namespace' do
-    let :domain_config { { key: 'domain' } }
+    let(:domain_config) { { key: 'domain' } }
 
     AlcesUtils.mock self, :each do
       config(alces.domain, domain_config)
@@ -135,11 +135,11 @@ RSpec.describe Metalware::Namespaces::Alces do
   # This allows the dynamic namespace to be set as if it was rendering a real
   # template
   describe '#scope' do
-    let :scope_template { '<%= alces.scope.class %>' }
-    let :node_class { Metalware::Namespaces::Node }
-    let :group_class { Metalware::Namespaces::Group }
-    let :node_double { double(node_class, class: node_class) }
-    let :group_double { double(group_class, class: group_class) }
+    let(:scope_template) { '<%= alces.scope.class %>' }
+    let(:node_class) { Metalware::Namespaces::Node }
+    let(:group_class) { Metalware::Namespaces::Group }
+    let(:node_double) { double(node_class, class: node_class) }
+    let(:group_double) { double(group_class, class: group_class) }
 
     def render_scope_template(**dynamic)
       alces.render_erb_template(scope_template, **dynamic).constantize
@@ -165,10 +165,10 @@ RSpec.describe Metalware::Namespaces::Alces do
   end
 
   shared_examples 'scope method tests' do |scope_class|
-    let :scope_str { scope_class.to_s }
-    let :test_h { double(test: scope_str) }
+    let(:scope_str) { scope_class.to_s }
+    let(:test_h) { double(test: scope_str) }
 
-    let :scope do
+    let(:scope) do
       d = double(scope_class, class: scope_str, config: test_h, answer: test_h)
       d.define_singleton_method(:is_a?) do |input|
         input == scope_class

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Metalware::Namespaces::Alces do
       d
     end
 
-    before :each do
+    before(:each) do
       allow(alces).to receive(:scope).and_return(scope)
     end
 

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Metalware::Namespaces::Alces do
       d
     end
 
-    before(:each) do
+    before do
       allow(alces).to receive(:scope).and_return(scope)
     end
 

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe Metalware::Namespaces::AssetArray do
       path = Metalware::FilePath.asset(asset[:name])
       Metalware::Data.dump(path, asset[:data])
     end
-  end 
+  end
 
   describe '#new' do
     context 'when there is an asset called "each"' do
       before do
         each_path = Metalware::FilePath.asset('each')
-        Metalware::Data.dump(each_path, { data: 'some-data' })
+        Metalware::Data.dump(each_path, data: 'some-data')
       end
 
       it 'errors due to the existing method' do

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     Metalware::HashMergers::MetalRecursiveOpenStruct
   end
 
-  before(:each) do
+  before do
     assets.each do |asset|
       path = Metalware::FilePath.asset(asset[:name])
       Metalware::Data.dump(path, asset[:data])
@@ -41,7 +41,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
 
   describe '#new' do
     context 'when there is an asset called "each"' do
-      before(:each) do
+      before do
         each_path = Metalware::FilePath.asset('each')
         Metalware::Data.dump(each_path, { data: 'some-data' })
       end

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -27,11 +27,12 @@ RSpec.describe Metalware::Namespaces::AssetArray do
       asset[:data].merge(metadata: { name: asset[:name] })
     end
   end
+
   let(:metal_ros) do
     Metalware::HashMergers::MetalRecursiveOpenStruct
   end
 
-  before :each do
+  before(:each) do
     assets.each do |asset|
       path = Metalware::FilePath.asset(asset[:name])
       Metalware::Data.dump(path, asset[:data])
@@ -40,7 +41,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
 
   describe '#new' do
     context 'when there is an asset called "each"' do
-      before :each do
+      before(:each) do
         each_path = Metalware::FilePath.asset('each')
         Metalware::Data.dump(each_path, { data: 'some-data' })
       end

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Metalware::Namespaces::AssetArray do
 
   # DO NOT use AlcesUtils in the section. It tests features required
   # by the namespace itself.
-  let :alces_copy { Metalware::Namespaces::Alces.new }
-  let :assets do
+  let(:alces_copy) { Metalware::Namespaces::Alces.new }
+  let(:assets) do
     [
       {
         name: 'asset1',
@@ -22,12 +22,12 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     ]
   end
 
-  let :assets_data do
+  let(:assets_data) do
     assets.map do |asset|
       asset[:data].merge(metadata: { name: asset[:name] })
     end
   end
-  let :metal_ros do
+  let(:metal_ros) do
     Metalware::HashMergers::MetalRecursiveOpenStruct
   end
 
@@ -59,9 +59,9 @@ RSpec.describe Metalware::Namespaces::AssetArray do
   end
 
   context 'when loading the second asset' do
-    let :index { 1 }
-    let :asset { assets[index] }
-    let :asset_data { assets_data[index] }
+    let(:index) { 1 }
+    let(:asset) { assets[index] }
+    let(:asset_data) { assets_data[index] }
 
     def expect_to_only_load_asset_data_once
       expect(Metalware::Data).to receive(:load).once.and_call_original
@@ -124,17 +124,17 @@ RSpec.describe Metalware::Namespaces::AssetArray do
   context 'when referencing other asset (":<asset_name>")' do
     include AlcesUtils
 
-    let :asset1 { alces.assets.find_by_name(asset1_name) }
-    let :asset2 { alces.assets.find_by_name(asset2_name) }
-    let :asset1_name { 'test-asset1' }
-    let :asset2_name { 'test-asset2' }
-    let :asset1_raw_data do
+    let(:asset1) { alces.assets.find_by_name(asset1_name) }
+    let(:asset2) { alces.assets.find_by_name(asset2_name) }
+    let(:asset1_name) { 'test-asset1' }
+    let(:asset2_name) { 'test-asset2' }
+    let(:asset1_raw_data) do
       {
         key: "#{asset1_name}-data",
         link: ":#{asset2_name}",
       }
     end
-    let :asset2_raw_data do
+    let(:asset2_raw_data) do
       {
         key: "#{asset2_name}-data",
         link: ":#{asset1_name}",

--- a/spec/namespaces/domain_spec.rb
+++ b/spec/namespaces/domain_spec.rb
@@ -5,11 +5,11 @@ require 'shared_examples/hash_merger_namespace'
 require 'namespaces/alces'
 require 'spec_utils'
 
-RSpec.describe Metalware::Namespaces::Node do
+RSpec.describe Metalware::Namespaces::Domain do
   include AlcesUtils
 
-  include_examples Metalware::Namespaces::HashMergerNamespace,
-                   'alces.domain'
+  subject { alces.domain }
+  include_examples Metalware::Namespaces::HashMergerNamespace
 
   before { SpecUtils.use_mock_determine_hostip_script(self) }
 

--- a/spec/namespaces/domain_spec.rb
+++ b/spec/namespaces/domain_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Metalware::Namespaces::Node do
   include_examples Metalware::Namespaces::HashMergerNamespace,
                    'alces.domain'
 
-  before(:each) { SpecUtils.use_mock_determine_hostip_script(self) }
+  before { SpecUtils.use_mock_determine_hostip_script(self) }
 
   it 'has a hostip' do
     expect(alces.domain.hostip).to eq('1.2.3.4')

--- a/spec/namespaces/domain_spec.rb
+++ b/spec/namespaces/domain_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Metalware::Namespaces::Node do
   include_examples Metalware::Namespaces::HashMergerNamespace,
                    'alces.domain'
 
-  before :each { SpecUtils.use_mock_determine_hostip_script(self) }
+  before(:each) { SpecUtils.use_mock_determine_hostip_script(self) }
 
   it 'has a hostip' do
     expect(alces.domain.hostip).to eq('1.2.3.4')

--- a/spec/namespaces/group_spec.rb
+++ b/spec/namespaces/group_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Metalware::Namespaces::Node do
   end
 
   context 'with a mocked genders file' do
-    before :each do
+    before(:each) do
       AlcesUtils.mock self do
         mock_group('group1')
         mock_group('group2')

--- a/spec/namespaces/group_spec.rb
+++ b/spec/namespaces/group_spec.rb
@@ -5,19 +5,19 @@ require 'shared_examples/hash_merger_namespace'
 require 'namespaces/alces'
 require 'spec_utils'
 
-RSpec.describe Metalware::Namespaces::Node do
+RSpec.describe Metalware::Namespaces::Group do
   include AlcesUtils
 
   context 'with mocked group' do
     let(:test_group) { 'some_test_group' }
+    subject { alces.groups.first }
 
     AlcesUtils.mock self, :each do
       mock_group(test_group)
       mock_node('random_node', test_group)
     end
 
-    include_examples Metalware::Namespaces::HashMergerNamespace,
-                     'alces.groups.first'
+    include_examples Metalware::Namespaces::HashMergerNamespace
   end
 
   context 'with a mocked genders file' do

--- a/spec/namespaces/group_spec.rb
+++ b/spec/namespaces/group_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Metalware::Namespaces::Node do
   include AlcesUtils
 
   context 'with mocked group' do
-    let :test_group { 'some_test_group' }
+    let(:test_group) { 'some_test_group' }
 
     AlcesUtils.mock self, :each do
       mock_group(test_group)

--- a/spec/namespaces/group_spec.rb
+++ b/spec/namespaces/group_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Metalware::Namespaces::Node do
   end
 
   context 'with a mocked genders file' do
-    before(:each) do
+    before do
       AlcesUtils.mock self do
         mock_group('group1')
         mock_group('group2')

--- a/spec/namespaces/metal_array_spec.rb
+++ b/spec/namespaces/metal_array_spec.rb
@@ -11,9 +11,9 @@ require 'nodeattr_interface'
 # be ensured.
 #
 RSpec.describe Metalware::Namespaces::MetalArray do
-  let :alces { Metalware::Namespaces::Alces.new }
+  let(:alces) { Metalware::Namespaces::Alces.new }
 
-  let :node_names { ['node1', 'node2', 'node3'] }
+  let(:node_names) { ['node1', 'node2', 'node3'] }
 
   before :each do
     allow(Metalware::NodeattrInterface).to \

--- a/spec/namespaces/metal_array_spec.rb
+++ b/spec/namespaces/metal_array_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metalware::Namespaces::MetalArray do
 
   let(:node_names) { ['node1', 'node2', 'node3'] }
 
-  before(:each) do
+  before do
     allow(Metalware::NodeattrInterface).to \
       receive(:all_nodes).and_return(node_names)
   end

--- a/spec/namespaces/metal_array_spec.rb
+++ b/spec/namespaces/metal_array_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metalware::Namespaces::MetalArray do
 
   let(:node_names) { ['node1', 'node2', 'node3'] }
 
-  before :each do
+  before(:each) do
     allow(Metalware::NodeattrInterface).to \
       receive(:all_nodes).and_return(node_names)
   end

--- a/spec/namespaces/mixins/white_list_hasher_spec.rb
+++ b/spec/namespaces/mixins/white_list_hasher_spec.rb
@@ -5,7 +5,7 @@ require 'namespaces/mixins/white_list_hasher'
 require 'ostruct'
 
 RSpec.describe Metalware::Namespaces::Mixins::WhiteListHasher do
-  let :test_obj do
+  let(:test_obj) do
     double(
       white_method1: 1,
       white_method2: 2,
@@ -21,16 +21,16 @@ RSpec.describe Metalware::Namespaces::Mixins::WhiteListHasher do
     ).extend Metalware::Namespaces::Mixins::WhiteListHasher
   end
 
-  let :recursive_hash_obj do
+  let(:recursive_hash_obj) do
     OpenStruct.new(am_i_a_ostuct: 'no, I should be a hash')
   end
 
-  let :white_list { (1..3).map { |i| "white_method#{i}" } }
-  let :recursive_white_list { ['recursive_hash_obj'] }
-  let :array_white_list { [:array_method] }
+  let(:white_list) { (1..3).map { |i| "white_method#{i}" } }
+  let(:recursive_white_list) { ['recursive_hash_obj'] }
+  let(:array_white_list) { [:array_method] }
 
-  let :test_hash { test_obj.to_h }
-  let :expected_number_of_keys do
+  let(:test_hash) { test_obj.to_h }
+  let(:expected_number_of_keys) do
     [
       white_list,
       recursive_white_list,

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Metalware::Namespaces::Node do
     ##
     # Mocks the HashMergers
     #
-    before :each do
+    before(:each) do
       allow(Metalware::HashMergers::Config).to receive(:new)
         .and_return(double('config', merge: config_hash))
       allow(Metalware::HashMergers::Answer).to receive(:new)
@@ -73,7 +73,7 @@ RSpec.describe Metalware::Namespaces::Node do
     ##
     # Spoofs the results of NodeattrInterface
     #
-    before :each do
+    before(:each) do
       allow(Metalware::NodeattrInterface).to \
         receive(:genders_for_node).and_return(['primary_group'])
       allow(Metalware::NodeattrInterface).to \
@@ -83,7 +83,7 @@ RSpec.describe Metalware::Namespaces::Node do
     end
 
     # Spoofs the hostip
-    before :each { SpecUtils.use_mock_determine_hostip_script(self) }
+    before(:each) { SpecUtils.use_mock_determine_hostip_script(self) }
 
     it 'can access the node name' do
       expect(node.name).to eq(node_name)
@@ -198,7 +198,7 @@ RSpec.describe Metalware::Namespaces::Node do
       let(:cache) { Metalware::Cache::Asset.new }
       
       context 'with an assigned asset' do
-        before :each do
+        before(:each) do
           Metalware::Data.dump(asset_path, content)
           cache.assign_asset_to_node(asset_name, node)
           cache.save
@@ -229,7 +229,7 @@ RSpec.describe Metalware::Namespaces::Node do
     let(:unconfigured_plugin) { 'unconfigured_plugin' }
     let(:deactivated_plugin) { 'deactivated_plugin' }
 
-    before :each do
+    before(:each) do
       FileSystem.root_setup do |fs|
         fs.with_minimal_repo
 

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Metalware::Namespaces::Node do
     ##
     # Mocks the HashMergers
     #
-    before(:each) do
+    before do
       allow(Metalware::HashMergers::Config).to receive(:new)
         .and_return(double('config', merge: config_hash))
       allow(Metalware::HashMergers::Answer).to receive(:new)
@@ -73,7 +73,7 @@ RSpec.describe Metalware::Namespaces::Node do
     ##
     # Spoofs the results of NodeattrInterface
     #
-    before(:each) do
+    before do
       allow(Metalware::NodeattrInterface).to \
         receive(:genders_for_node).and_return(['primary_group'])
       allow(Metalware::NodeattrInterface).to \
@@ -83,7 +83,7 @@ RSpec.describe Metalware::Namespaces::Node do
     end
 
     # Spoofs the hostip
-    before(:each) { SpecUtils.use_mock_determine_hostip_script(self) }
+    before { SpecUtils.use_mock_determine_hostip_script(self) }
 
     it 'can access the node name' do
       expect(node.name).to eq(node_name)
@@ -198,7 +198,7 @@ RSpec.describe Metalware::Namespaces::Node do
       let(:cache) { Metalware::Cache::Asset.new }
       
       context 'with an assigned asset' do
-        before(:each) do
+        before do
           Metalware::Data.dump(asset_path, content)
           cache.assign_asset_to_node(asset_name, node)
           cache.save
@@ -229,7 +229,7 @@ RSpec.describe Metalware::Namespaces::Node do
     let(:unconfigured_plugin) { 'unconfigured_plugin' }
     let(:deactivated_plugin) { 'deactivated_plugin' }
 
-    before(:each) do
+    before do
       FileSystem.root_setup do |fs|
         fs.with_minimal_repo
 

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Metalware::Namespaces::Node do
   end
 
   context 'without AlcesUtils' do
-    let :alces do
+    let(:alces) do
       a = Metalware::Namespaces::Alces.new
       allow(a).to receive(:groups).and_return(
         Metalware::Namespaces::MetalArray.new(
@@ -46,19 +46,19 @@ RSpec.describe Metalware::Namespaces::Node do
       node
     end
 
-    let :test_value { 'test value set in namespace/node_spec.rb' }
-    let :primary_group_index { 'primary_group_index' }
-    let :node_name { 'node02' }
-    let :node_array { ['some_other_node', node_name] }
+    let(:test_value) { 'test value set in namespace/node_spec.rb' }
+    let(:primary_group_index) { 'primary_group_index' }
+    let(:node_name) { 'node02' }
+    let(:node_array) { ['some_other_node', node_name] }
 
-    let :config_hash do
+    let(:config_hash) do
       Metalware::Constants::HASH_MERGER_DATA_STRUCTURE.new(
         key: test_value,
         erb_value1: '<%= alces.node.config.key  %>'
       ) { |template_string| node.render_erb_template(template_string) }
     end
 
-    let :node { Metalware::Namespaces::Node.create(alces, node_name) }
+    let(:node) { Metalware::Namespaces::Node.create(alces, node_name) }
 
     ##
     # Mocks the HashMergers
@@ -116,8 +116,8 @@ RSpec.describe Metalware::Namespaces::Node do
     end
 
     describe '#==' do
-      let :foonode { Metalware::Namespaces::Node.create(alces, 'foonode') }
-      let :barnode { Metalware::Namespaces::Node.create(alces, 'barnode') }
+      let(:foonode) { Metalware::Namespaces::Node.create(alces, 'foonode') }
+      let(:barnode) { Metalware::Namespaces::Node.create(alces, 'barnode') }
 
       it 'returns false if other object is not a Node' do
         other_object = Struct.new(:name).new('foonode')
@@ -134,7 +134,7 @@ RSpec.describe Metalware::Namespaces::Node do
     end
 
     describe '#build_method' do
-      let :node { Metalware::Namespaces::Node.create(alces, 'node01') }
+      let(:node) { Metalware::Namespaces::Node.create(alces, 'node01') }
 
       def mock_build_method(method, my_node = node)
         config = OpenStruct.new(build_method: method)
@@ -164,11 +164,11 @@ RSpec.describe Metalware::Namespaces::Node do
       end
 
       context "with the 'local' node" do
-        let :local do
+        let(:local) do
           Metalware::Namespaces::Node.create(alces, 'local')
         end
 
-        let :local_build { Metalware::BuildMethods::Local }
+        let(:local_build) { Metalware::BuildMethods::Local }
 
         def local_node_uses_local_build?(config_build_method)
           mock_build_method(config_build_method, local)
@@ -192,10 +192,10 @@ RSpec.describe Metalware::Namespaces::Node do
     end
 
     describe '#asset' do
-      let :content { { node: { node_name.to_sym => 'asset_test' } } }
-      let :asset_name { 'asset_test' }
-      let :asset_path { Metalware::FilePath.asset(asset_name) }
-      let :cache { Metalware::Cache::Asset.new }
+      let(:content) { { node: { node_name.to_sym => 'asset_test' } } }
+      let(:asset_name) { 'asset_test' }
+      let(:asset_path) { Metalware::FilePath.asset(asset_name) }
+      let(:cache) { Metalware::Cache::Asset.new }
       
       context 'with an assigned asset' do
         before :each do
@@ -219,15 +219,15 @@ RSpec.describe Metalware::Namespaces::Node do
 
   # Test `#plugins` without the rampant mocking above.
   describe '#plugins' do
-    let :node { Metalware::Namespaces::Node.create(alces, 'node01') }
-    let :alces { Metalware::Namespaces::Alces.new }
+    let(:node) { Metalware::Namespaces::Node.create(alces, 'node01') }
+    let(:alces) { Metalware::Namespaces::Alces.new }
 
     # XXX Need to handle situation of plugin being enabled for node but not
     # available globally?
-    let :enabled_plugin { 'enabled_plugin' }
-    let :disabled_plugin { 'disabled_plugin' }
-    let :unconfigured_plugin { 'unconfigured_plugin' }
-    let :deactivated_plugin { 'deactivated_plugin' }
+    let(:enabled_plugin) { 'enabled_plugin' }
+    let(:disabled_plugin) { 'disabled_plugin' }
+    let(:unconfigured_plugin) { 'unconfigured_plugin' }
+    let(:deactivated_plugin) { 'deactivated_plugin' }
 
     before :each do
       FileSystem.root_setup do |fs|

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Metalware::Namespaces::Node do
       let(:asset_name) { 'asset_test' }
       let(:asset_path) { Metalware::FilePath.asset(asset_name) }
       let(:cache) { Metalware::Cache::Asset.new }
-      
+
       context 'with an assigned asset' do
         before do
           Metalware::Data.dump(asset_path, content)

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe Metalware::Namespaces::Node do
       mock_group(AlcesUtils.default_group)
     end
 
-    include_examples Metalware::Namespaces::HashMergerNamespace,
-                     'alces.nodes.first'
+    subject { alces.nodes.first }
+
+    include_examples Metalware::Namespaces::HashMergerNamespace
   end
 
   context 'without AlcesUtils' do

--- a/spec/namespaces/plugin_spec.rb
+++ b/spec/namespaces/plugin_spec.rb
@@ -6,14 +6,14 @@ require 'spec_utils'
 RSpec.describe Metalware::Namespaces::Plugin do
   include AlcesUtils
 
-  let :node do
+  let(:node) do
     Metalware::Namespaces::Node.create(alces, node_name)
   end
-  let :node_name { 'some_node' }
-  let :node_group_name { 'some_group' }
+  let(:node_name) { 'some_node' }
+  let(:node_group_name) { 'some_group' }
 
-  let :plugin_name { 'my_plugin' }
-  let :plugin do
+  let(:plugin_name) { 'my_plugin' }
+  let(:plugin) do
     Metalware::Plugins.all.find { |plugin| plugin.name == plugin_name }
   end
 

--- a/spec/namespaces/plugin_spec.rb
+++ b/spec/namespaces/plugin_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metalware::Namespaces::Plugin do
 
   subject { described_class.new(plugin, node: node) }
 
-  before(:each) do
+  before do
     FileSystem.root_setup do |fs|
       fs.setup do
         plugin_config_dir = File.join(Metalware::FilePath.plugins_dir, plugin_name, 'config')

--- a/spec/namespaces/plugin_spec.rb
+++ b/spec/namespaces/plugin_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metalware::Namespaces::Plugin do
 
   subject { described_class.new(plugin, node: node) }
 
-  before :each do
+  before(:each) do
     FileSystem.root_setup do |fs|
       fs.setup do
         plugin_config_dir = File.join(Metalware::FilePath.plugins_dir, plugin_name, 'config')

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -27,7 +27,7 @@ require 'network'
 
 RSpec.describe Metalware::Network do
   describe '#valid_interface?' do
-    before(:each) do
+    before do
       expect(NetworkInterface).to receive(:interfaces).and_return(
         ['eth0', 'eth1']
       )

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -27,7 +27,7 @@ require 'network'
 
 RSpec.describe Metalware::Network do
   describe '#valid_interface?' do
-    before :each do
+    before(:each) do
       expect(NetworkInterface).to receive(:interfaces).and_return(
         ['eth0', 'eth1']
       )

--- a/spec/nodeattr_interface_spec.rb
+++ b/spec/nodeattr_interface_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Metalware::NodeattrInterface do
   include AlcesUtils
 
   context 'with setup1 genders' do
-    before(:each) do
+    before do
       FileSystem.root_setup do |fs|
         fs.with_genders_fixtures('setup1/genders')
       end
@@ -46,7 +46,7 @@ RSpec.describe Metalware::NodeattrInterface do
   end
 
   context 'using mock genders' do
-    before(:each) do
+    before do
       FileSystem.root_setup(&:with_genders_fixtures)
     end
 

--- a/spec/nodeattr_interface_spec.rb
+++ b/spec/nodeattr_interface_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Metalware::NodeattrInterface do
   end
 
   describe '#validate_genders_file' do
-    let :genders_file { Tempfile.new }
-    let :genders_path { genders_file.path }
+    let(:genders_file) { Tempfile.new }
+    let(:genders_path) { genders_file.path }
 
     subject do
       Metalware::NodeattrInterface.validate_genders_file(genders_path)

--- a/spec/nodeattr_interface_spec.rb
+++ b/spec/nodeattr_interface_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Metalware::NodeattrInterface do
   include AlcesUtils
 
   context 'with setup1 genders' do
-    before :each do
+    before(:each) do
       FileSystem.root_setup do |fs|
         fs.with_genders_fixtures('setup1/genders')
       end
@@ -46,7 +46,7 @@ RSpec.describe Metalware::NodeattrInterface do
   end
 
   context 'using mock genders' do
-    before :each do
+    before(:each) do
       FileSystem.root_setup(&:with_genders_fixtures)
     end
 

--- a/spec/overview/table_spec.rb
+++ b/spec/overview/table_spec.rb
@@ -6,9 +6,9 @@ require 'fixtures/shared_context/overview'
 RSpec.describe Metalware::Overview::Table do
   include_context 'overview context'
 
-  let :namespaces { alces.groups }
+  let(:namespaces) { alces.groups }
 
-  let :table do
+  let(:table) do
     Metalware::Overview::Table.new(namespaces, fields).render
   end
 
@@ -20,7 +20,7 @@ RSpec.describe Metalware::Overview::Table do
     table.lines[3..-2].join("\n")
   end
 
-  let :headers { fields.map { |h| h[:header] } }
+  let(:headers) { fields.map { |h| h[:header] } }
 
   it 'includes the headers in the table' do
     headers.each do |h|

--- a/spec/plugins/plugin_spec.rb
+++ b/spec/plugins/plugin_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Metalware::Plugins::Plugin do
-  let :plugin_dir_path { Pathname.new('/path/to/some-plugin') }
+  let(:plugin_dir_path) { Pathname.new('/path/to/some-plugin') }
   subject { described_class.new(plugin_dir_path) }
 
   describe '#enabled_question_identifier' do

--- a/spec/question_tree_spec.rb
+++ b/spec/question_tree_spec.rb
@@ -5,7 +5,7 @@ require 'validation/configure'
 
 RSpec.describe Metalware::QuestionTree do
   context 'with a nexted question hash' do
-    let :identifier_hash do
+    let(:identifier_hash) do
       {
         domain: 'domain_identifier',
         domain2: 'second_domain_identifier',
@@ -17,9 +17,9 @@ RSpec.describe Metalware::QuestionTree do
       }
     end
 
-    let :identifiers { identifier_hash.values.map(&:to_sym) }
+    let(:identifiers) { identifier_hash.values.map(&:to_sym) }
 
-    let :question_hash do
+    let(:question_hash) do
       {
         domain: [
           {
@@ -59,8 +59,8 @@ RSpec.describe Metalware::QuestionTree do
     subject { Metalware::Validation::Configure.new(question_hash).tree }
 
     shared_examples 'a filtered traversal' do |base_method|
-      let :filtered_method { :"filtered_#{base_method}" }
-      let :enum { subject.public_send(filtered_method) }
+      let(:filtered_method) { :"filtered_#{base_method}" }
+      let(:enum) { subject.public_send(filtered_method) }
 
       it 'is defined' do
         expect(subject).to respond_to(filtered_method)
@@ -121,23 +121,23 @@ RSpec.describe Metalware::QuestionTree do
   end
 
   describe '#root_defaults' do
-    let :domain_question do
+    let(:domain_question) do
       { identifier: 'domain_question' }
     end
 
-    let :group_question do
+    let(:group_question) do
       { identifier: 'group_question' }
     end
 
-    let :node_question do
+    let(:node_question) do
       { identifier: 'node_question' }
     end
 
-    let :local_question do
+    let(:local_question) do
       { identifier: 'local_question' }
     end
 
-    let :correct_defaults do
+    let(:correct_defaults) do
       {
         domain_question[:identifier].to_sym => 'domain_default',
         group_question[:identifier].to_sym => 'group_default',
@@ -146,7 +146,7 @@ RSpec.describe Metalware::QuestionTree do
       }
     end
 
-    let :question_hash do
+    let(:question_hash) do
       {
         domain: make('domain_default', domain_question),
         group: make('group_default', domain_question, group_question),
@@ -168,7 +168,7 @@ RSpec.describe Metalware::QuestionTree do
       end
     end
 
-    let :tree { Metalware::Validation::Configure.new(question_hash).tree }
+    let(:tree) { Metalware::Validation::Configure.new(question_hash).tree }
 
     [:domain, :group, :node, :local].each do |section|
       context "when called on the '#{section}' section" do

--- a/spec/shared_examples/asset_command_that_assigns_a_node.rb
+++ b/spec/shared_examples/asset_command_that_assigns_a_node.rb
@@ -1,4 +1,6 @@
 
+# frozen_string_literal: true
+
 require 'alces_utils'
 require 'cache/asset'
 

--- a/spec/shared_examples/asset_command_that_assigns_a_node.rb
+++ b/spec/shared_examples/asset_command_that_assigns_a_node.rb
@@ -7,8 +7,8 @@ require 'cache/asset'
 RSpec.shared_examples 'asset command that assigns a node' do
   include AlcesUtils
 
-  let :asset_cache { Metalware::Cache::Asset.new }
-  let :node_name { 'test-node' }
+  let(:asset_cache) { Metalware::Cache::Asset.new }
+  let(:node_name) { 'test-node' }
 
   def run_command
     Metalware::Utils.run_command(described_class,
@@ -24,7 +24,7 @@ RSpec.shared_examples 'asset command that assigns a node' do
   end
 
   context 'when the node exists' do
-    let! :node { AlcesUtils.mock(self) { mock_node(node_name) } }
+    let!(:node) { AlcesUtils.mock(self) { mock_node(node_name) } }
 
     it 'assigns the asset to the node' do
       run_command

--- a/spec/shared_examples/hash_merger_namespace.rb
+++ b/spec/shared_examples/hash_merger_namespace.rb
@@ -7,16 +7,16 @@ require 'alces_utils'
 RSpec.shared_examples \
   Metalware::Namespaces::HashMergerNamespace do |test_obj_str|
 
-  let :test_obj { eval(test_obj_str) }
+  let(:test_obj) { eval(test_obj_str) }
 
-  let :test_config do
+  let(:test_config) do
     {
       test_config: 'I am the config',
       files: [],
     }
   end
 
-  let :test_answer do
+  let(:test_answer) do
     { test_answer: 'I am the answer' }
   end
 

--- a/spec/shared_examples/hash_merger_namespace.rb
+++ b/spec/shared_examples/hash_merger_namespace.rb
@@ -5,9 +5,7 @@ require 'namespaces/alces'
 require 'alces_utils'
 
 RSpec.shared_examples \
-  Metalware::Namespaces::HashMergerNamespace do |test_obj_str|
-
-  let(:test_obj) { eval(test_obj_str) }
+  Metalware::Namespaces::HashMergerNamespace do
 
   let(:test_config) do
     {
@@ -22,16 +20,16 @@ RSpec.shared_examples \
 
   describe '#to_h' do
     AlcesUtils.mock self, :each do
-      config(test_obj, test_config)
-      answer(test_obj, test_answer)
+      config(subject, test_config)
+      answer(subject, test_answer)
     end
 
     it 'converts the config into a hash' do
-      expect(test_obj.to_h[:config]).to eq(test_config)
+      expect(subject.to_h[:config]).to eq(test_config)
     end
 
     it 'converts the answer into a hash' do
-      expect(test_obj.to_h[:answer]).to eq(test_answer)
+      expect(subject.to_h[:answer]).to eq(test_answer)
     end
   end
 end

--- a/spec/slow/status/job_spec.rb
+++ b/spec/slow/status/job_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Metalware::Status::Job do
 
       results = Metalware::Status::Job.results
       expect(results).to eq(@node => {
-                              @cmd => 'timeout'
+                              @cmd => 'timeout',
                             })
     end
 
@@ -110,7 +110,7 @@ RSpec.describe Metalware::Status::Job do
 
       expect(Metalware::Status::Job.results).to eq(@node => {
                                                      ping: 'PING_NODE',
-                                                     power: 'POWER_STATUS'
+                                                     power: 'POWER_STATUS',
                                                    })
     end
   end

--- a/spec/slow/status/job_spec.rb
+++ b/spec/slow/status/job_spec.rb
@@ -29,7 +29,7 @@ require 'spec_utils'
 require 'timeout'
 
 RSpec.describe Metalware::Status::Job do
-  before :all do
+  before(:all) do
     Metalware::Status::Job.send(:define_method, :busy_sleep, lambda {
       until 1 == 2; end
     })
@@ -38,7 +38,7 @@ RSpec.describe Metalware::Status::Job do
     })
   end
 
-  before :example do
+  before(:example) do
     SpecUtils.use_mock_genders(self)
     @cmd = :busy_sleep
     @node = 'node_name_not_found'

--- a/spec/slow/status/monitor_spec.rb
+++ b/spec/slow/status/monitor_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Metalware::Status::Monitor do
 
   let(:nodes) { alces.nodes.map(&:name) }
 
-  before :each do
+  before(:each) do
     FileSystem.root_setup(&:with_genders_fixtures)
     SpecUtils.use_mock_genders(self)
     @cmds = [:ping, :power]
@@ -52,7 +52,7 @@ RSpec.describe Metalware::Status::Monitor do
   end
 
   context 'when threading jobs' do
-    before :each do
+    before(:each) do
       allow_any_instance_of(Metalware::Status::Job).to receive(:start) {
         t = Thread.new { sleep }
         t.define_singleton_method(:thread, -> { self })

--- a/spec/slow/status/monitor_spec.rb
+++ b/spec/slow/status/monitor_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Metalware::Status::Monitor do
 
   let(:nodes) { alces.nodes.map(&:name) }
 
-  before(:each) do
+  before do
     FileSystem.root_setup(&:with_genders_fixtures)
     SpecUtils.use_mock_genders(self)
     @cmds = [:ping, :power]
@@ -52,7 +52,7 @@ RSpec.describe Metalware::Status::Monitor do
   end
 
   context 'when threading jobs' do
-    before(:each) do
+    before do
       allow_any_instance_of(Metalware::Status::Job).to receive(:start) {
         t = Thread.new { sleep }
         t.define_singleton_method(:thread, -> { self })

--- a/spec/slow/status/monitor_spec.rb
+++ b/spec/slow/status/monitor_spec.rb
@@ -32,7 +32,7 @@ require 'filesystem'
 RSpec.describe Metalware::Status::Monitor do
   include AlcesUtils
 
-  let :nodes { alces.nodes.map(&:name) }
+  let(:nodes) { alces.nodes.map(&:name) }
 
   before :each do
     FileSystem.root_setup(&:with_genders_fixtures)

--- a/spec/staging_spec.rb
+++ b/spec/staging_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Metalware::Staging do
     let(:test_sync) { '/etc/some-random-location' }
     let(:test_staging) { File.join('/var/lib/metalware/staging', test_sync) }
 
-    before(:each) do
+    before do
       update { |staging| staging.push_file(test_sync, test_content) }
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Metalware::Staging do
   describe '#delete_file_if' do
     let(:files) { ['first', 'second', 'third'].map { |f| "/tmp/#{f}" } }
 
-    before(:each) do
+    before do
       Metalware::Staging.update do |staging|
         files.each { |f| staging.push_file(f, '') }
       end
@@ -115,7 +115,7 @@ RSpec.describe Metalware::Staging do
         File.read(file).gsub(/^$\n/, '').split("\n")
       end
 
-      before(:each) do
+      before do
         Metalware::Staging.update do |staging|
           staging.push_file(managed_file, managed_content, managed: true)
           staging.delete_file_if do |file|

--- a/spec/staging_spec.rb
+++ b/spec/staging_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Metalware::Staging do
     let(:test_sync) { '/etc/some-random-location' }
     let(:test_staging) { File.join('/var/lib/metalware/staging', test_sync) }
 
-    before :each do
+    before(:each) do
       update { |staging| staging.push_file(test_sync, test_content) }
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Metalware::Staging do
   describe '#delete_file_if' do
     let(:files) { ['first', 'second', 'third'].map { |f| "/tmp/#{f}" } }
 
-    before :each do
+    before(:each) do
       Metalware::Staging.update do |staging|
         files.each { |f| staging.push_file(f, '') }
       end
@@ -115,7 +115,7 @@ RSpec.describe Metalware::Staging do
         File.read(file).gsub(/^$\n/, '').split("\n")
       end
 
-      before :each do
+      before(:each) do
         Metalware::Staging.update do |staging|
           staging.push_file(managed_file, managed_content, managed: true)
           staging.delete_file_if do |file|

--- a/spec/staging_spec.rb
+++ b/spec/staging_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Metalware::Staging do
   end
 
   describe '#push_file' do
-    let :test_content { 'I am a test file' }
-    let :test_sync { '/etc/some-random-location' }
-    let :test_staging { File.join('/var/lib/metalware/staging', test_sync) }
+    let(:test_content) { 'I am a test file' }
+    let(:test_sync) { '/etc/some-random-location' }
+    let(:test_staging) { File.join('/var/lib/metalware/staging', test_sync) }
 
     before :each do
       update { |staging| staging.push_file(test_sync, test_content) }
@@ -68,7 +68,7 @@ RSpec.describe Metalware::Staging do
   end
 
   describe '#delete_file_if' do
-    let :files { ['first', 'second', 'third'].map { |f| "/tmp/#{f}" } }
+    let(:files) { ['first', 'second', 'third'].map { |f| "/tmp/#{f}" } }
 
     before :each do
       Metalware::Staging.update do |staging|
@@ -108,8 +108,8 @@ RSpec.describe Metalware::Staging do
     end
 
     context 'with a managed file' do
-      let :managed_file { '/tmp/managed' }
-      let :managed_content { 'Managed Content' }
+      let(:managed_file) { '/tmp/managed' }
+      let(:managed_content) { 'Managed Content' }
 
       def read_managed_content(file = managed_file)
         File.read(file).gsub(/^$\n/, '').split("\n")

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Metalware::Templater do
     end
 
     context 'with repo' do
-      before :each do
+      before(:each) do
         filesystem.with_repo_fixtures('repo')
       end
 
@@ -230,7 +230,7 @@ RSpec.describe Metalware::Templater do
         [existing_contents, "\n", rendered_file_section_regex].join
       end
 
-      before :each do
+      before(:each) do
         filesystem.write(output_path, existing_contents)
       end
 
@@ -259,7 +259,7 @@ RSpec.describe Metalware::Templater do
         "BEFORE\n\n" + rendered_file_section_regex + "\n\nAFTER"
       end
 
-      before :each do
+      before(:each) do
         filesystem.write(output_path, existing_contents)
       end
 

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -37,7 +37,7 @@ EMPTY_REPO_PATH = File.join(FIXTURES_PATH, 'configs/empty-repo.yaml')
 RSpec.describe Metalware::Templater do
   include AlcesUtils
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup do |fs|
       fs.write template_path, template.strip_heredoc
     end
@@ -46,7 +46,7 @@ RSpec.describe Metalware::Templater do
   # XXX Could adjust tests using this to only use template with parts they
   # need, to make them simpler and less dependent on changes to this or each
   # other.
-  let :template do
+  let(:template) do
     <<-EOF
     This is a test template
     some_passed_value: <%= domain.config.some_passed_value %>
@@ -57,7 +57,7 @@ RSpec.describe Metalware::Templater do
     EOF
   end
 
-  let :template_path { '/template' }
+  let(:template_path) { '/template' }
 
   def expect_renders(template_parameters, expected)
     filesystem.test do |_fs|
@@ -106,7 +106,7 @@ RSpec.describe Metalware::Templater do
       end
 
       context 'when template uses property of unset parameter' do
-        let :template do
+        let(:template) do
           'unset.parameter: <%= unset.parameter %>'
         end
 
@@ -122,9 +122,9 @@ RSpec.describe Metalware::Templater do
   end
 
   describe '#render_to_file' do
-    let :template { "simple template without ERB\n" }
-    let :output_path { '/output' }
-    let :output { File.read(output_path) }
+    let(:template) { "simple template without ERB\n" }
+    let(:output_path) { '/output' }
+    let(:output) { File.read(output_path) }
 
     def render_to_file_with_block(&block)
       Metalware::Templater.render_to_file(
@@ -165,11 +165,11 @@ RSpec.describe Metalware::Templater do
 
   describe '#render_managed_file' do
     # XXX Similar to above.
-    let :template { 'simple template without ERB' }
-    let :output_path { '/output' }
-    let :output { File.read(output_path) }
+    let(:template) { 'simple template without ERB' }
+    let(:output_path) { '/output' }
+    let(:output) { File.read(output_path) }
 
-    let :rendered_file_section_regex do
+    let(:rendered_file_section_regex) do
       [
         Metalware::Templater::MANAGED_START,
         Metalware::Templater::MANAGED_COMMENT,
@@ -224,9 +224,9 @@ RSpec.describe Metalware::Templater do
     end
 
     context 'when file exists without markers' do
-      let :existing_contents { "existing file contents\n" }
+      let(:existing_contents) { "existing file contents\n" }
 
-      let :rendered_file_regex do
+      let(:rendered_file_regex) do
         [existing_contents, "\n", rendered_file_section_regex].join
       end
 
@@ -243,7 +243,7 @@ RSpec.describe Metalware::Templater do
     end
 
     context 'when file exists with markers' do
-      let :existing_contents do
+      let(:existing_contents) do
         <<-EOF.strip_heredoc
         BEFORE
 
@@ -255,7 +255,7 @@ RSpec.describe Metalware::Templater do
         EOF
       end
 
-      let :rendered_file_regex do
+      let(:rendered_file_regex) do
         "BEFORE\n\n" + rendered_file_section_regex + "\n\nAFTER"
       end
 

--- a/spec/templater_spec.rb
+++ b/spec/templater_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Metalware::Templater do
     end
 
     context 'with repo' do
-      before(:each) do
+      before do
         filesystem.with_repo_fixtures('repo')
       end
 
@@ -230,7 +230,7 @@ RSpec.describe Metalware::Templater do
         [existing_contents, "\n", rendered_file_section_regex].join
       end
 
-      before(:each) do
+      before do
         filesystem.write(output_path, existing_contents)
       end
 
@@ -259,7 +259,7 @@ RSpec.describe Metalware::Templater do
         "BEFORE\n\n" + rendered_file_section_regex + "\n\nAFTER"
       end
 
-      before(:each) do
+      before do
         filesystem.write(output_path, existing_contents)
       end
 

--- a/spec/templating/nil_detection_wrapper_spec.rb
+++ b/spec/templating/nil_detection_wrapper_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
     let(:object) do
       RecursiveOpenStruct.new(
         nil: nil,
-        true: true,
-        false: false,
+        true_key: true,
+        false_key: false,
         key1: {
           key2: {
             key3: {
@@ -92,13 +92,13 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
     end
 
     it 'false is still a FalseClass' do
-      expect(wrapped_object.false).to be_a(FalseClass)
-      expect(wrapped_object.false).to be_falsey
+      expect(wrapped_object.false_key).to be_a(FalseClass)
+      expect(wrapped_object.false_key).to be_falsey
     end
 
     it 'true is still a TrueClass' do
-      expect(wrapped_object.true).to be_a(TrueClass)
-      expect(wrapped_object.true).to be_truthy
+      expect(wrapped_object.true_key).to be_a(TrueClass)
+      expect(wrapped_object.true_key).to be_truthy
     end
   end
 

--- a/spec/templating/nil_detection_wrapper_spec.rb
+++ b/spec/templating/nil_detection_wrapper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
     expect(metal_log).to receive(:warn).once.with(/.*#{msg}\Z/)
   end
 
-  let :metal_log { Metalware::MetalLog.metal_log }
+  let(:metal_log) { Metalware::MetalLog.metal_log }
 
   it 'the wrap command returns a binding' do
     expect(Metalware::Templating::NilDetectionWrapper.wrap(nil)).to \
@@ -25,7 +25,7 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
   end
 
   context 'with a falsey result' do
-    let :false_obj do
+    let(:false_obj) do
       build_wrapper_object(OpenStruct.new(nil_key: nil, false_key: false))
     end
 
@@ -43,15 +43,15 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
   end
 
   context 'with a wrapped integer' do
-    let :object { 100 }
-    let :wrapped_object { build_wrapper_object(object) }
+    let(:object) { 100 }
+    let(:wrapped_object) { build_wrapper_object(object) }
 
     it 'the wrapped object is equal to the object' do
       expect(wrapped_object).to eq(object)
     end
 
     context 'when multipled by 0' do
-      let :zero_object { wrapped_object * 0 }
+      let(:zero_object) { wrapped_object * 0 }
 
       it 'equals the correct value' do
         expect(zero_object).to eq(0)
@@ -64,7 +64,7 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
   end
 
   context 'with a recursive_open_struct object' do
-    let :object do
+    let(:object) do
       RecursiveOpenStruct.new(
         nil: nil,
         true: true,
@@ -79,7 +79,7 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
       )
     end
 
-    let :wrapped_object { build_wrapper_object(object) }
+    let(:wrapped_object) { build_wrapper_object(object) }
 
     it 'issues for a simple nil return value' do
       expect_warning('nil')
@@ -103,7 +103,7 @@ RSpec.describe Metalware::Templating::NilDetectionWrapper do
   end
 
   context 'with multiple input arguments' do
-    let :wrapped_object do
+    let(:wrapped_object) do
       d = double('object', test: nil, :[] => nil)
       build_wrapper_object(d)
     end

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Metalware::Utils::Editor do
   let(:default_editor) { described_class::DEFAULT_EDITOR }
 
   context 'with the environment variables unset' do
-    before :each do |example|
+    before(:each) do |example|
       ENV.delete('VISUAL')
       ENV.delete('EDITOR')
     end
@@ -18,7 +18,7 @@ RSpec.describe Metalware::Utils::Editor do
 
       context 'when $EDITOR is set' do
         let(:editor) { 'EDITOR-ENV-VAR' }
-        before :each { ENV['EDITOR'] = editor }
+        before(:each) { ENV['EDITOR'] = editor }
 
         it 'uses the $EDITOR env var' do
           expect(described_class.editor).to eq(editor)
@@ -26,7 +26,7 @@ RSpec.describe Metalware::Utils::Editor do
 
         context 'when $VISUAL is set' do
           let(:visual) { 'VISUAL-ENV-VAR' }
-          before :each { ENV['VISUAL'] = visual }
+          before(:each) { ENV['VISUAL'] = visual }
 
           it 'uses the $VISUAL env var' do
             expect(described_class.editor).to eq(visual)
@@ -54,7 +54,7 @@ RSpec.describe Metalware::Utils::Editor do
       let(:destination) { '/var/destination-file.yaml' }
       let(:initial_content) { { key: 'value' } }
 
-      before :each do
+      before(:each) do
         allow(Metalware::Utils::Editor).to receive(:open)
         Metalware::Data.dump(source, initial_content)
       end

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -3,7 +3,7 @@
 require 'utils/editor'
 
 RSpec.describe Metalware::Utils::Editor do
-  let :default_editor { described_class::DEFAULT_EDITOR }
+  let(:default_editor) { described_class::DEFAULT_EDITOR }
 
   context 'with the environment variables unset' do
     before :each do |example|
@@ -17,7 +17,7 @@ RSpec.describe Metalware::Utils::Editor do
       end
 
       context 'when $EDITOR is set' do
-        let :editor { 'EDITOR-ENV-VAR' }
+        let(:editor) { 'EDITOR-ENV-VAR' }
         before :each { ENV['EDITOR'] = editor }
 
         it 'uses the $EDITOR env var' do
@@ -25,7 +25,7 @@ RSpec.describe Metalware::Utils::Editor do
         end
 
         context 'when $VISUAL is set' do
-          let :visual { 'VISUAL-ENV-VAR' }
+          let(:visual) { 'VISUAL-ENV-VAR' }
           before :each { ENV['VISUAL'] = visual }
 
           it 'uses the $VISUAL env var' do
@@ -36,7 +36,7 @@ RSpec.describe Metalware::Utils::Editor do
     end
 
     describe '#open' do
-      let :file { '/tmp/some-random-file' }
+      let(:file) { '/tmp/some-random-file' }
 
       it 'opens the file in the default editor' do
         cmd = "#{default_editor} #{file}"
@@ -50,9 +50,9 @@ RSpec.describe Metalware::Utils::Editor do
 
 
     describe '#open_copy' do
-      let :source { '/var/source-file.yaml' }
-      let :destination { '/var/destination-file.yaml' }
-      let :initial_content { { key: 'value' } }
+      let(:source) { '/var/source-file.yaml' }
+      let(:destination) { '/var/destination-file.yaml' }
+      let(:initial_content) { { key: 'value' } }
 
       before :each do
         allow(Metalware::Utils::Editor).to receive(:open)

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Metalware::Utils::Editor do
   let(:default_editor) { described_class::DEFAULT_EDITOR }
 
   context 'with the environment variables unset' do
-    before do |example|
+    before do |_example|
       ENV.delete('VISUAL')
       ENV.delete('EDITOR')
     end
@@ -47,7 +47,6 @@ RSpec.describe Metalware::Utils::Editor do
         sleep 0.001 while thr.alive?
       end
     end
-
 
     describe '#open_copy' do
       let(:source) { '/var/source-file.yaml' }

--- a/spec/utils/editor_spec.rb
+++ b/spec/utils/editor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Metalware::Utils::Editor do
   let(:default_editor) { described_class::DEFAULT_EDITOR }
 
   context 'with the environment variables unset' do
-    before(:each) do |example|
+    before do |example|
       ENV.delete('VISUAL')
       ENV.delete('EDITOR')
     end
@@ -18,7 +18,7 @@ RSpec.describe Metalware::Utils::Editor do
 
       context 'when $EDITOR is set' do
         let(:editor) { 'EDITOR-ENV-VAR' }
-        before(:each) { ENV['EDITOR'] = editor }
+        before { ENV['EDITOR'] = editor }
 
         it 'uses the $EDITOR env var' do
           expect(described_class.editor).to eq(editor)
@@ -26,7 +26,7 @@ RSpec.describe Metalware::Utils::Editor do
 
         context 'when $VISUAL is set' do
           let(:visual) { 'VISUAL-ENV-VAR' }
-          before(:each) { ENV['VISUAL'] = visual }
+          before { ENV['VISUAL'] = visual }
 
           it 'uses the $VISUAL env var' do
             expect(described_class.editor).to eq(visual)
@@ -54,7 +54,7 @@ RSpec.describe Metalware::Utils::Editor do
       let(:destination) { '/var/destination-file.yaml' }
       let(:initial_content) { { key: 'value' } }
 
-      before(:each) do
+      before do
         allow(Metalware::Utils::Editor).to receive(:open)
         Metalware::Data.dump(source, initial_content)
       end

--- a/spec/validation/answer_spec.rb
+++ b/spec/validation/answer_spec.rb
@@ -33,23 +33,23 @@ RSpec.describe Metalware::Validation::Answer do
       domain: [
         {
           identifier: 'string_question',
-          question: 'Am I a string?'
+          question: 'Am I a string?',
         },
         {
           identifier: 'integer_question',
           question: 'Am I a integer',
-          type: 'integer'
+          type: 'integer',
         },
         {
           identifier: 'bool_question',
           question: 'Am I a boolean',
-          type: 'boolean'
-        }
+          type: 'boolean',
+        },
       ],
 
       group: [],
       node: [],
-      local: []
+      local: [],
     }
   end
 
@@ -57,7 +57,7 @@ RSpec.describe Metalware::Validation::Answer do
     {
       string_question: 'string',
       integer_question: 100,
-      bool_question: true
+      bool_question: true,
     }
   end
 
@@ -88,7 +88,7 @@ RSpec.describe Metalware::Validation::Answer do
   context 'with an invalid answer hash' do
     it 'contains an answer to a missing question' do
       answers = {
-        a_missing_question: 'I do not appear in configure.yaml'
+        a_missing_question: 'I do not appear in configure.yaml',
       }
       results, validator = run_answer_validation(answers)
       expect(results.errors.keys).to include(:missing_questions)

--- a/spec/validation/answer_spec.rb
+++ b/spec/validation/answer_spec.rb
@@ -28,7 +28,7 @@ require 'alces_utils'
 
 RSpec.describe Metalware::Validation::Answer do
   include AlcesUtils
-  let :question_tree do
+  let(:question_tree) do
     {
       domain: [
         {
@@ -53,7 +53,7 @@ RSpec.describe Metalware::Validation::Answer do
     }
   end
 
-  let :valid_answers do
+  let(:valid_answers) do
     {
       string_question: 'string',
       integer_question: 100,

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -32,7 +32,7 @@ require 'alces_utils'
 RSpec.describe Metalware::Validation::Configure do
   include AlcesUtils
 
-  before(:each) { FileSystem.root_setup(&:with_validation_error_file) }
+  before { FileSystem.root_setup(&:with_validation_error_file) }
 
   let(:file_path) { Metalware::FilePath }
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -32,7 +32,7 @@ require 'alces_utils'
 RSpec.describe Metalware::Validation::Configure do
   include AlcesUtils
 
-  before :each { FileSystem.root_setup(&:with_validation_error_file) }
+  before(:each) { FileSystem.root_setup(&:with_validation_error_file) }
 
   let(:file_path) { Metalware::FilePath }
 

--- a/spec/validation/configure_spec.rb
+++ b/spec/validation/configure_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Metalware::Validation::Configure do
 
   before :each { FileSystem.root_setup(&:with_validation_error_file) }
 
-  let :file_path { Metalware::FilePath }
+  let(:file_path) { Metalware::FilePath }
 
-  let :correct_hash do
+  let(:correct_hash) do
     {
       ##
       # Questions are not part of the specification for a valid configure.yaml

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Metalware::Validation::Loader do
 
     subject { described_class.new }
 
-    before(:each) do
+    before do
       FileSystem.root_setup do |fs|
         fs.dump(Metalware::FilePath.configure_file, configure_questions_hash)
 
@@ -107,7 +107,7 @@ RSpec.describe Metalware::Validation::Loader do
         end
 
         context 'when plugin activated' do
-          before(:each) do
+          before do
             FileSystem.root_setup do |fs|
               fs.activate_plugin('example')
             end
@@ -142,7 +142,7 @@ RSpec.describe Metalware::Validation::Loader do
           end
 
           context 'when no configure.yaml for plugin' do
-            before(:each) do
+            before do
               FileSystem.root_setup do |fs|
                 fs.rm_rf example_plugin_dir
                 fs.mkdir_p example_plugin_dir

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -26,11 +26,11 @@ require 'validation/loader'
 
 RSpec.describe Metalware::Validation::Loader do
   describe '#question_tree' do
-    let :configure_sections do
+    let(:configure_sections) do
       Metalware::Constants::CONFIGURE_SECTIONS
     end
 
-    let :configure_questions_hash do
+    let(:configure_questions_hash) do
       configure_sections.map do |section|
         [
           section, [{
@@ -41,7 +41,7 @@ RSpec.describe Metalware::Validation::Loader do
       end.to_h
     end
 
-    let :example_plugin_configure_questions_hash do
+    let(:example_plugin_configure_questions_hash) do
       configure_sections.map do |section|
         dependent_question = {
           identifier: "example_plugin_#{section}_dependent_identifier",
@@ -56,11 +56,11 @@ RSpec.describe Metalware::Validation::Loader do
       end.to_h
     end
 
-    let :example_plugin_dir do
+    let(:example_plugin_dir) do
       File.join(Metalware::FilePath.plugins_dir, 'example')
     end
 
-    let :sections_to_loaded_questions do
+    let(:sections_to_loaded_questions) do
       configure_sections.map do |section|
         [section, subject.question_tree[section].children]
       end.to_h
@@ -113,7 +113,7 @@ RSpec.describe Metalware::Validation::Loader do
             end
           end
 
-          let :plugin_enabled_question do
+          let(:plugin_enabled_question) do
             questions = sections_to_loaded_questions[section]
             questions.find do |question|
               question.content.identifier ==

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Metalware::Validation::Loader do
         [
           section, [{
             identifier: "#{section}_identifier",
-            question: "#{section}_question"
+            question: "#{section}_question",
           }]
         ]
       end.to_h
@@ -45,12 +45,12 @@ RSpec.describe Metalware::Validation::Loader do
       configure_sections.map do |section|
         dependent_question = {
           identifier: "example_plugin_#{section}_dependent_identifier",
-          question: "example_plugin_#{section}_dependent_question"
+          question: "example_plugin_#{section}_dependent_question",
         }
         top_level_question = {
           identifier: "example_plugin_#{section}_identifier",
           question: "example_plugin_#{section}_question",
-          dependent: [dependent_question]
+          dependent: [dependent_question],
         }
         [section, [top_level_question]]
       end.to_h

--- a/spec/validation/loader_spec.rb
+++ b/spec/validation/loader_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Metalware::Validation::Loader do
 
     subject { described_class.new }
 
-    before :each do
+    before(:each) do
       FileSystem.root_setup do |fs|
         fs.dump(Metalware::FilePath.configure_file, configure_questions_hash)
 
@@ -107,7 +107,7 @@ RSpec.describe Metalware::Validation::Loader do
         end
 
         context 'when plugin activated' do
-          before :each do
+          before(:each) do
             FileSystem.root_setup do |fs|
               fs.activate_plugin('example')
             end
@@ -142,7 +142,7 @@ RSpec.describe Metalware::Validation::Loader do
           end
 
           context 'when no configure.yaml for plugin' do
-            before :each do
+            before(:each) do
               FileSystem.root_setup do |fs|
                 fs.rm_rf example_plugin_dir
                 fs.mkdir_p example_plugin_dir

--- a/spec/validation/saver_spec.rb
+++ b/spec/validation/saver_spec.rb
@@ -45,12 +45,12 @@ Metalware::Validation::Saver::Methods.prepend(SaverSpec::TestingMethods)
 RSpec.describe Metalware::Validation::Saver do
   include AlcesUtils
 
-  let :path { Metalware::FilePath }
-  let :saver { Metalware::Validation::Saver.new }
-  let :stubbed_answer_load { OpenStruct.new(data: data) }
-  let :data { { key: 'data' } }
+  let(:path) { Metalware::FilePath }
+  let(:saver) { Metalware::Validation::Saver.new }
+  let(:stubbed_answer_load) { OpenStruct.new(data: data) }
+  let(:data) { { key: 'data' } }
 
-  let :filesystem do
+  let(:filesystem) do
     FileSystem.setup(&:with_minimal_repo)
   end
 

--- a/src/answers_table_creator.rb
+++ b/src/answers_table_creator.rb
@@ -39,7 +39,7 @@ module Metalware
         'Question',
         'Domain',
         group_name ? "Group: #{group_name}" : nil,
-        node_name ?  "Node: #{node_name}" : nil
+        node_name ?  "Node: #{node_name}" : nil,
       ].reject(&:nil?)
     end
 
@@ -49,7 +49,7 @@ module Metalware
           identifier,
           domain_answer(question: identifier),
           group_answer(question: identifier, group_name: group_name),
-          node_answer(question: identifier, node_name: node_name)
+          node_answer(question: identifier, node_name: node_name),
         ].reject(&:nil?)
       end
     end

--- a/src/build_files_retriever.rb
+++ b/src/build_files_retriever.rb
@@ -90,8 +90,6 @@ module Metalware
         end.to_h
       end
 
-      private
-
       def retrieve_for_section(section)
         file_hashes = files[section].map do |file|
           file_hash_for(section, file)

--- a/src/build_files_retriever.rb
+++ b/src/build_files_retriever.rb
@@ -142,7 +142,7 @@ module Metalware
         name = File.basename(identifier)
         {
           raw: identifier,
-          name: name
+          name: name,
         }
       end
 

--- a/src/build_methods/build_method.rb
+++ b/src/build_methods/build_method.rb
@@ -58,7 +58,7 @@ module Metalware
 
       BuildFilesRenderer = KeywordStruct.new(:templater, :namespace) do
         def render
-          namespace.files.each do |_section, files|
+          namespace.files.each_value do |files|
             files.select { |file| file[:error].nil? }.map do |file|
               templater.render(
                 namespace,

--- a/src/cli_helper/parser.rb
+++ b/src/cli_helper/parser.rb
@@ -57,6 +57,7 @@ module Metalware
       def parse_command_attributes(command, attributes)
         @calling_obj.command command do |c|
           attributes.each do |a, v|
+            next if a == 'autocomplete'
             case a
             when 'action'
               c.action eval(v)
@@ -75,8 +76,6 @@ module Metalware
                 subcommand = "#{command} #{subcommand}"
                 parse_command_attributes(subcommand, subattributes)
               end
-            when 'autocomplete'
-              # Intentionally left blank as it is used by autocomplete only
             else
               c.send("#{a}=", v.respond_to?(:chomp) ? v.chomp : v)
             end

--- a/src/command_helpers/base_command.rb
+++ b/src/command_helpers/base_command.rb
@@ -49,7 +49,7 @@ module Metalware
       attr_reader :args, :options
 
       def pre_setup(args, options)
-        set_global_log_options(options)
+        setup_global_log_options(options)
         log_command
         @args = args
         @options = options
@@ -59,7 +59,7 @@ module Metalware
         enforce_dependency
       end
 
-      def set_global_log_options(options)
+      def setup_global_log_options(options)
         MetalLog.strict = !!options.strict
         MetalLog.quiet = !!options.quiet
       end

--- a/src/command_helpers/configure_command.rb
+++ b/src/command_helpers/configure_command.rb
@@ -75,8 +75,8 @@ module Metalware
         {
           repo: ['configure.yaml'],
           optional: {
-            configure: [relative_answer_file]
-          }
+            configure: [relative_answer_file],
+          },
         }
       end
 

--- a/src/commands/build.rb
+++ b/src/commands/build.rb
@@ -84,7 +84,7 @@ module Metalware
       def dependency_hash
         {
           repo: repo_dependencies,
-          configure: ['domain.yaml']
+          configure: ['domain.yaml'],
         }
       end
 

--- a/src/commands/each.rb
+++ b/src/commands/each.rb
@@ -44,7 +44,7 @@ module Metalware
           rendered_cmd = node.render_erb_template(command)
           opt = {
             out: $stdout.fileno ? $stdout.fileno : 1,
-            err: $stderr.fileno ? $stderr.fileno : 2
+            err: $stderr.fileno ? $stderr.fileno : 2,
           }
           system(rendered_cmd, opt)
         end

--- a/src/commands/remove/group.rb
+++ b/src/commands/remove/group.rb
@@ -51,7 +51,7 @@ module Metalware
 
         def dependency_hash
           {
-            configure: ["groups/#{primary_group}.yaml"]
+            configure: ["groups/#{primary_group}.yaml"],
           }
         end
 

--- a/src/commands/repo/update.rb
+++ b/src/commands/repo/update.rb
@@ -82,7 +82,7 @@ module Metalware
 
         def dependency_hash
           {
-            repo: []
+            repo: [],
           }
         end
       end

--- a/src/commands/view_answers/domain.rb
+++ b/src/commands/view_answers/domain.rb
@@ -16,7 +16,7 @@ module Metalware
         def dependency_hash
           {
             repo: ['configure.yaml'],
-            configure: ['domain.yaml']
+            configure: ['domain.yaml'],
           }
         end
       end

--- a/src/commands/view_answers/group.rb
+++ b/src/commands/view_answers/group.rb
@@ -23,7 +23,7 @@ module Metalware
         def dependency_hash
           {
             repo: ['configure.yaml'],
-            configure: ['domain.yaml', "groups/#{group_name}.yaml"]
+            configure: ['domain.yaml', "groups/#{group_name}.yaml"],
           }
         end
       end

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -29,47 +29,10 @@ require 'validation/saver'
 require 'file_path'
 require 'group_cache'
 require 'configurator/question'
+require 'configurator/class_methods'
 
 module Metalware
   class Configurator
-    class << self
-      def for_domain(alces)
-        new(
-          alces,
-          questions_section: :domain
-        )
-      end
-
-      def for_group(alces, group_name)
-        new(
-          alces,
-          questions_section: :group,
-          name: group_name
-        )
-      end
-
-      def for_node(alces, node_name)
-        return for_local(alces) if node_name == 'local'
-        new(
-          alces,
-          questions_section: :node,
-          name: node_name
-        )
-      end
-
-      def for_local(alces)
-        new(
-          alces,
-          questions_section: :local
-        )
-      end
-
-      # Used by the tests to switch readline on and off
-      def use_readline
-        true
-      end
-    end
-
     def initialize(
       alces,
       questions_section:,

--- a/src/configurator.rb
+++ b/src/configurator.rb
@@ -48,9 +48,6 @@ module Metalware
         )
       end
 
-      # Note: This is slightly inconsistent with `for_group`, as that just
-      # takes a group name and this takes a Node object (as we need to be able
-      # to access the Node's primary group).
       def for_node(alces, node_name)
         return for_local(alces) if node_name == 'local'
         new(

--- a/src/configurator/class_methods.rb
+++ b/src/configurator/class_methods.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Metalware
+  class Configurator
+    class << self
+      def for_domain(alces)
+        new(
+          alces,
+          questions_section: :domain
+        )
+      end
+
+      def for_group(alces, group_name)
+        new(
+          alces,
+          questions_section: :group,
+          name: group_name
+        )
+      end
+
+      def for_node(alces, node_name)
+        return for_local(alces) if node_name == 'local'
+        new(
+          alces,
+          questions_section: :node,
+          name: node_name
+        )
+      end
+
+      def for_local(alces)
+        new(
+          alces,
+          questions_section: :local
+        )
+      end
+
+      # Used by the tests to switch readline on and off
+      def use_readline
+        true
+      end
+    end
+  end
+end

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -62,6 +62,10 @@ module Metalware
     METALWARE_NAMED_PATH = '/etc/named/metalware.conf'
     VAR_NAMED_PATH = '/var/named'
 
+    DRY_VALIDATION_ERRORS_PATH = File.join(METALWARE_INSTALL_PATH,
+                                           'src/validation',
+                                           'errors.yaml')
+
     CONFIGURE_SECTIONS = [:domain, :group, :node, :local].freeze
     CONFIGURE_INTERNAL_QUESTION_PREFIX = 'metalware_internal'
 

--- a/src/dependency_specifications.rb
+++ b/src/dependency_specifications.rb
@@ -16,8 +16,8 @@ module Metalware
         repo: ['configure.yaml'],
         configure: ['domain.yaml', "groups/#{group.name}.yaml"],
         optional: {
-          configure: ["nodes/#{name}.yaml"]
-        }
+          configure: ["nodes/#{name}.yaml"],
+        },
       }
     end
 

--- a/src/dns/hosts.rb
+++ b/src/dns/hosts.rb
@@ -58,7 +58,7 @@ module Metalware
 
       def staging_options
         {
-          service: self.class.name
+          service: self.class.name,
         }
       end
     end

--- a/src/dns/named.rb
+++ b/src/dns/named.rb
@@ -71,8 +71,8 @@ module Metalware
         {
           named: {
             zone: zone,
-            net: net
-          }
+            net: net,
+          },
         }
       end
 
@@ -97,7 +97,7 @@ module Metalware
       def staging_options
         {
           mkdir: true,
-          service: self.class.name
+          service: self.class.name,
         }
       end
     end

--- a/src/group_cache.rb
+++ b/src/group_cache.rb
@@ -91,7 +91,7 @@ module Metalware
       payload = {
         next_index: next_available_index,
         primary_groups: groups_hash,
-        orphans: orphans
+        orphans: orphans,
       }
       Data.dump(file_path.group_cache, payload)
       @data = nil # Reloads the cached file

--- a/src/gui/config/environments/development.rb
+++ b/src/gui/config/environments/development.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
+      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}",
     }
   else
     config.action_controller.perform_caching = false

--- a/src/gui/config/environments/test.rb
+++ b/src/gui/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/src/hash_mergers/metal_recursive_open_struct.rb
+++ b/src/hash_mergers/metal_recursive_open_struct.rb
@@ -32,7 +32,7 @@ module Metalware
       end
 
       def each
-        table.keys.each { |key| yield(key, send(key)) }
+        table.each_key { |key| yield(key, send(key)) }
       end
 
       def to_h

--- a/src/managed_file.rb
+++ b/src/managed_file.rb
@@ -45,7 +45,7 @@ module Metalware
           MANAGED_START,
           MANAGED_COMMENT,
           rendered_template,
-          MANAGED_END
+          MANAGED_END,
         ].join("\n") + "\n"
       end
     end

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -105,7 +105,7 @@ module Metalware
                        :build_complete_url,
                        :build_complete_path,
                        :hexadecimal_ip,
-                       :build_method
+                       :build_method,
                      ])
       end
 

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -63,7 +63,7 @@ module Metalware
         [
           Constants::CONFIGURE_INTERNAL_QUESTION_PREFIX,
           'plugin_enabled',
-          plugin_name
+          plugin_name,
         ].join('--')
       end
 

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -70,10 +70,8 @@ module Metalware
       private
 
       def validate_plugin_exists!(plugin_name)
-        unless exists?(plugin_name)
-          raise MetalwareError,
-                "Unknown plugin: #{plugin_name}"
-        end
+        return if exists?(plugin_name)
+        raise MetalwareError, "Unknown plugin: #{plugin_name}"
       end
 
       def update_deactivated_plugins!(new_deactivated_plugins)

--- a/src/plugins/configure_questions_builder.rb
+++ b/src/plugins/configure_questions_builder.rb
@@ -44,7 +44,7 @@ module Metalware
           identifier: plugin.enabled_question_identifier,
           question: "Should '#{plugin.name}' plugin be enabled for #{section}?",
           type: 'boolean',
-          dependent: questions_for_section(section)
+          dependent: questions_for_section(section),
         }
       end
 

--- a/src/question_tree.rb
+++ b/src/question_tree.rb
@@ -14,7 +14,7 @@ module Metalware
       :each,
       :breadth_each,
       :postordered_each,
-      :preordered_each
+      :preordered_each,
     ].freeze
 
     BASE_TRAVERSALS.each do |base_method|

--- a/src/render_methods/dhcp.rb
+++ b/src/render_methods/dhcp.rb
@@ -31,7 +31,7 @@ module Metalware
           {
             managed: managed?,
             validator: name,
-            service: name
+            service: name,
           }
         end
 

--- a/src/render_methods/render_method.rb
+++ b/src/render_methods/render_method.rb
@@ -35,7 +35,7 @@ module Metalware
         def staging_opts
           {
             managed: managed?,
-            validator: name
+            validator: name,
           }
         end
 

--- a/src/staging.rb
+++ b/src/staging.rb
@@ -83,7 +83,7 @@ module Metalware
     def default_push_options
       {
         managed: false,
-        validator: nil
+        validator: nil,
       }
     end
 

--- a/src/status/job.rb
+++ b/src/status/job.rb
@@ -62,7 +62,7 @@ module Metalware
       # ----- THREAD METHODS BELOW THIS LINE ------
       CMD_LIBRARY = {
         power: :job_power_status,
-        ping: :job_ping_node
+        ping: :job_ping_node,
       }.freeze
 
       def run_command

--- a/src/status/job.rb
+++ b/src/status/job.rb
@@ -81,8 +81,6 @@ module Metalware
       rescue Timeout::Error
         _send_signal_and_wait(9)
       rescue Errno::ESRCH
-        # XXX Not handling this gives a Rubocop warning; should we do something
-        # here?
       end
 
       def _send_signal_and_wait(signum)

--- a/src/system_command.rb
+++ b/src/system_command.rb
@@ -49,7 +49,7 @@ module Metalware
         {
           stdout: stdout,
           stderr: stderr,
-          status: status
+          status: status,
         }
       end
 

--- a/src/templater.rb
+++ b/src/templater.rb
@@ -143,7 +143,7 @@ module Metalware
           MANAGED_START,
           MANAGED_COMMENT,
           rendered_template,
-          MANAGED_END
+          MANAGED_END,
         ].join("\n") + "\n"
       end
 

--- a/src/templating/nil_detection_wrapper.rb
+++ b/src/templating/nil_detection_wrapper.rb
@@ -55,7 +55,7 @@ module Metalware
         if s == '[]'
           key = a.shift
           key = (key.is_a?(Symbol) ? ":#{key}" : "'#{key}'")
-          s = "[#{key}]".dup
+          s = '[' + key + ']'
         end
         return s if a.empty? && b.nil?
         s << '('

--- a/src/validation/answer.rb
+++ b/src/validation/answer.rb
@@ -43,7 +43,7 @@ module Metalware
           end],
           [:AnswerTypeSchema, proc do
             AnswerTypeSchema.call(validation_hash)
-          end]
+          end],
         ]
         tests.each do |(test_name, test_proc)|
           @validation_result = test_proc.call
@@ -95,7 +95,7 @@ module Metalware
         @validation_hash ||= begin
           payload = {
             answers: [],
-            missing_questions: []
+            missing_questions: [],
           }
           answers.each_with_object(payload) do |(question, answer), pay|
             if questions_in_section&.key?(question)
@@ -103,7 +103,7 @@ module Metalware
                 {
                   question: question,
                   answer: answer,
-                  type: questions_in_section[question].type
+                  type: questions_in_section[question].type,
                 }.tap { |h| h[:type] = 'string' if h[:type].nil? }
               )
             else

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -59,7 +59,7 @@ module Metalware
         @tree ||= begin
           root_hash = {
             pass: true,
-            result: TopLevelSchema.call(data: questions_hash)
+            result: TopLevelSchema.call(data: questions_hash),
           }
           QuestionTree.new('ROOT', root_hash).tap do |root|
             add_children(root, root) do
@@ -104,7 +104,7 @@ module Metalware
         question_data = questions_hash[section] || []
         data = {
           section: section,
-          result: DependantSchema.call(dependent: question_data)
+          result: DependantSchema.call(dependent: question_data),
         }
         node_s = QuestionTree.new(section, data)
         add_children(root, node_s) do

--- a/src/validation/configure.rb
+++ b/src/validation/configure.rb
@@ -30,12 +30,13 @@ require 'constants'
 require 'question_tree'
 require 'stringio'
 
+require 'validation/configure/schemas'
+
 module Metalware
   module Validation
     class Configure
       # NOTE: Supported types in error.yaml message must be updated manually
       SUPPORTED_TYPES = ['string', 'integer', 'boolean'].freeze
-      ERROR_FILE = File.join(File.dirname(__FILE__), 'errors.yaml').freeze
 
       def self.type_check(type, value)
         case type
@@ -145,91 +146,6 @@ module Metalware
             end
           end
         end
-      end
-
-      DependantSchema = Dry::Validation.Schema do
-        configure do
-          config.messages_file = ERROR_FILE
-          config.namespace = :configure
-        end
-
-        optional(:dependent) { array? && (each { hash? }) }
-      end
-
-      QuestionFieldSchema = Dry::Validation.Schema do
-        configure do
-          config.messages_file = ERROR_FILE
-          config.namespace = :configure
-
-          def supported_type?(value)
-            SUPPORTED_TYPES.include?(value)
-          end
-
-          def default?(value)
-            return true if value.is_a?(String)
-            value.respond_to?(:empty?) ? value.empty? : true
-          end
-        end
-
-        required(:identifier) { filled? & str? }
-        required(:question) { filled? & str? }
-        optional(:optional) { bool? }
-        optional(:type) { supported_type? }
-        optional(:default) { default? }
-        optional(:choice) { array? }
-      end
-
-      QuestionSchema = Dry::Validation.Schema do
-        configure do
-          config.messages_file = ERROR_FILE
-          config.namespace = :configure
-
-          def default_type?(value)
-            default = value[:default]
-            type = value[:type]
-            return true if default.nil?
-            ::Metalware::Validation::Configure.type_check(type, default)
-          end
-
-          def choice_with_default?(value)
-            return true if value[:choice].nil? || value[:default].nil?
-            return false unless value[:choice].is_a?(Array)
-            value[:choice].include?(value[:default])
-          end
-
-          def choice_type?(value)
-            return true if value[:choice].nil?
-            return false unless value[:choice].is_a?(Array)
-            value[:choice].each do |choice|
-              type = value[:type]
-              r = ::Metalware::Validation::Configure.type_check(type, choice)
-              return false unless r
-            end
-            true
-          end
-        end
-
-        required(:question) do
-          default_type? & \
-            choice_with_default? & \
-            choice_type? & \
-            schema(DependantSchema) & \
-            schema(QuestionFieldSchema)
-        end
-      end
-
-      TopLevelSchema = Dry::Validation.Schema do
-        configure do
-          config.messages_file = ERROR_FILE
-          config.namespace = :configure
-
-          def top_level_keys?(data)
-            section = Constants::CONFIGURE_SECTIONS.dup.push(:questions)
-            (data.keys - section).empty?
-          end
-        end
-
-        required(:data) { top_level_keys? }
       end
     end
   end

--- a/src/validation/configure/schemas.rb
+++ b/src/validation/configure/schemas.rb
@@ -63,7 +63,7 @@ module Metalware
             default = value[:default]
             type = value[:type]
             return true if default.nil?
-            ::Metalware::Validation::Configure.type_check(type, default)
+            Configure.type_check(type, default)
           end
 
           def choice_with_default?(value)

--- a/src/validation/configure/schemas.rb
+++ b/src/validation/configure/schemas.rb
@@ -77,14 +77,16 @@ module Metalware
           end
 
           def choice_type?(value)
-            return true if value[:choice].nil?
-            return false unless value[:choice].is_a?(Array)
-            value[:choice].each do |choice|
-              type = value[:type]
-              r = ::Metalware::Validation::Configure.type_check(type, choice)
-              return false unless r
+            if value[:choice].is_a?(Array)
+              value[:choice].all? do |choice|
+                type = value[:type]
+                Configure.type_check(type, choice)
+              end
+            elsif value[:choice].nil?
+              true
+            else
+              false
             end
-            true
           end
         end
 

--- a/src/validation/configure/schemas.rb
+++ b/src/validation/configure/schemas.rb
@@ -36,8 +36,13 @@ module Metalware
           end
 
           def default?(value)
-            return true if value.is_a?(String)
-            value.respond_to?(:empty?) ? value.empty? : true
+            if value.is_a?(String)
+              true
+            elsif value.respond_to?(:empty?)
+              value.empty?
+            else
+              true
+            end
           end
         end
 
@@ -62,9 +67,13 @@ module Metalware
           end
 
           def choice_with_default?(value)
-            return true if value[:choice].nil? || value[:default].nil?
-            return false unless value[:choice].is_a?(Array)
-            value[:choice].include?(value[:default])
+            if [value[:choice], value[:default]].include?(nil)
+              true
+            elsif value[:choice].is_a?(Array)
+              value[:choice].include?(value[:default])
+            else
+              false
+            end
           end
 
           def choice_type?(value)

--- a/src/validation/configure/schemas.rb
+++ b/src/validation/configure/schemas.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Metalware
+  module Validation
+    class Configure
+      TopLevelSchema = Dry::Validation.Schema do
+        configure do
+          config.messages_file = FilePath.dry_validation_errors
+          config.namespace = :configure
+
+          def top_level_keys?(data)
+            section = Constants::CONFIGURE_SECTIONS.dup.push(:questions)
+            (data.keys - section).empty?
+          end
+        end
+
+        required(:data) { top_level_keys? }
+      end
+
+      DependantSchema = Dry::Validation.Schema do
+        configure do
+          config.messages_file = FilePath.dry_validation_errors
+          config.namespace = :configure
+        end
+
+        optional(:dependent) { array? && (each { hash? }) }
+      end
+
+      QuestionFieldSchema = Dry::Validation.Schema do
+        configure do
+          config.messages_file = FilePath.dry_validation_errors
+          config.namespace = :configure
+
+          def supported_type?(value)
+            SUPPORTED_TYPES.include?(value)
+          end
+
+          def default?(value)
+            return true if value.is_a?(String)
+            value.respond_to?(:empty?) ? value.empty? : true
+          end
+        end
+
+        required(:identifier) { filled? & str? }
+        required(:question) { filled? & str? }
+        optional(:optional) { bool? }
+        optional(:type) { supported_type? }
+        optional(:default) { default? }
+        optional(:choice) { array? }
+      end
+
+      QuestionSchema = Dry::Validation.Schema do
+        configure do
+          config.messages_file = FilePath.dry_validation_errors
+          config.namespace = :configure
+
+          def default_type?(value)
+            default = value[:default]
+            type = value[:type]
+            return true if default.nil?
+            ::Metalware::Validation::Configure.type_check(type, default)
+          end
+
+          def choice_with_default?(value)
+            return true if value[:choice].nil? || value[:default].nil?
+            return false unless value[:choice].is_a?(Array)
+            value[:choice].include?(value[:default])
+          end
+
+          def choice_type?(value)
+            return true if value[:choice].nil?
+            return false unless value[:choice].is_a?(Array)
+            value[:choice].each do |choice|
+              type = value[:type]
+              r = ::Metalware::Validation::Configure.type_check(type, choice)
+              return false unless r
+            end
+            true
+          end
+        end
+
+        required(:question) do
+          default_type? & \
+            choice_with_default? & \
+            choice_type? & \
+            schema(DependantSchema) & \
+            schema(QuestionFieldSchema)
+        end
+      end
+    end
+  end
+end

--- a/src/validation/loader.rb
+++ b/src/validation/loader.rb
@@ -70,7 +70,7 @@ module Metalware
       def all_questions_for_section(section)
         [
           repo_configure_questions,
-          *plugin_configure_questions
+          *plugin_configure_questions,
         ].flat_map do |question_group|
           question_group[section]
         end


### PR DESCRIPTION
This PR makes a bunch of style changes that have been building up. The first few commits concern updating `let :symbol` to be `let(:symbol)`. This update was required when the `parser` gem was updated (which is used by `rubocop`).

There was a bit of confusion about which version of `RuboCop` had to be used. Initially it was updated to version `0.54.0`, however this is incompatible with `CodeClimate` that is still running version `0.52.1`. Hence rubocop has been downgraded back to `0.52.1`.

The remaining commits work through the backlog of `rubocop` errors. See commits for details.