### PR TITLE
Change referencing asset from : to ^

### DIFF
--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     end
   end
 
-  context 'when referencing other asset (":<asset_name>")' do
+  context 'when referencing other asset ("^<asset_name>")' do
     include AlcesUtils
 
     let(:asset1) { alces.assets.find_by_name(asset1_name) }
@@ -132,13 +132,13 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     let(:asset1_raw_data) do
       {
         key: "#{asset1_name}-data",
-        link: ":#{asset2_name}",
+        link: "^#{asset2_name}",
       }
     end
     let(:asset2_raw_data) do
       {
         key: "#{asset2_name}-data",
-        link: ":#{asset1_name}",
+        link: "^#{asset1_name}",
       }
     end
 
@@ -155,7 +155,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
       expect(asset1.link).to eq(asset2)
     end
 
-    it 'only converts strings starting with ":" to an assets' do
+    it 'only converts strings starting with "^" to an assets' do
       expect(asset1.key).to eq(asset1_raw_data[:key])
     end
   end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -17,7 +17,7 @@ module Metalware
           @data ||= begin
             data_class = Constants::HASH_MERGER_DATA_STRUCTURE
             data_class.new(load_file) do |str|
-              if str[0] == ':'
+              if str[0] == '^'
                 other_asset_name = str[1..-1]
                 alces.assets.find_by_name(other_asset_name)
               else


### PR DESCRIPTION
Turns out, symbols are loaded from ruby when they start with a ":".
Unfortunately, MetalRecursiveOpenStruct does not convert symbols and
thus breaks the referencing between assets.

Instead, assets can reference each other by using "^ASSET_NAME". This
way it is loaded as a String into MetalRecursiveOpenStruct.

Otherwise the conversion is done in the same manner.