### PR TITLE
Requested changes to the asset link and unlink commands

### DIFF
--- a/spec/commands/asset/link_spec.rb
+++ b/spec/commands/asset/link_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Metalware::Commands::Asset::Link do
 
   def run_command
     Metalware::Utils.run_command(described_class,
-                                 asset_name,
                                  node_name,
+                                 asset_name,
                                  stderr: StringIO.new)
   end
 

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -25,18 +25,19 @@ module Metalware
         data[:node][node.name.to_sym]
       end
 
-      def unassign_asset(asset_name, node_name = nil)
+      def unassign_asset(asset_name)
         data[:node].delete_if do |node, asset|
-          next unless asset == asset_name
-          check_node_name_if_given(node, node_name)
+          asset == asset_name
+        end
+      end
+
+      def unassign_node(node_name)
+        data[:node].delete_if do |node, _asset|
+          node == node_name.to_sym
         end
       end
 
       private
-
-      def check_node_name_if_given(node, node_name)
-        node_name ? (node == node_name.to_sym) : true
-      end
 
       def blank_cache
         { node: {} }

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -51,7 +51,7 @@ subcommands:
     action: Commands::Asset::Link
 
   asset_unlink: &asset_unlink
-    syntax: metal asset unlink ASSET_NAME NODE_NAME [options]
+    syntax: metal asset unlink NODE_NAME [options]
     summary: Remove a relationship between an asset and a node
     action: Commands::Asset::Unlink
 

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -46,7 +46,7 @@ subcommands:
     action: Commands::Asset::Delete
 
   asset_link: &asset_link
-    syntax: metal asset link ASSET_NAME NODE_NAME [options]
+    syntax: metal asset link NODE_NAME ASSET_NAME [options]
     summary: Add a relationship between an asset and a node
     action: Commands::Asset::Link
 

--- a/src/command_helpers/asset_helper.rb
+++ b/src/command_helpers/asset_helper.rb
@@ -26,8 +26,13 @@ module Metalware
         asset_cache.save
       end
 
-      def unassign_asset_from_node_if_given(asset_name, node_name = nil)
-        asset_cache.unassign_asset(asset_name, node_name)
+      def unassign_asset_from_cache(asset_name)
+        asset_cache.unassign_asset(asset_name)
+        asset_cache.save
+      end
+
+      def unassign_node_from_cache(node_name)
+        asset_cache.unassign_node(node_name)
         asset_cache.save
       end
 

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -20,7 +20,7 @@ module Metalware
 
         def run
           error_if_asset_file_doesnt_exist(asset_path)
-          unassign_asset_from_node_if_given(asset_name)
+          unassign_asset_from_cache(asset_name)
           delete_asset
         end
 

--- a/src/commands/asset/link.rb
+++ b/src/commands/asset/link.rb
@@ -11,9 +11,9 @@ module Metalware
         attr_reader :asset_name, :asset_path
 
         def setup
-          @asset_name = args[0]
+          @asset_name = args[1]
           @asset_path = FilePath.asset(asset_name)
-          @node = alces.nodes.find_by_name(args[1])
+          @node = alces.nodes.find_by_name(args[0])
         end
 
         def run

--- a/src/commands/asset/unlink.rb
+++ b/src/commands/asset/unlink.rb
@@ -8,17 +8,14 @@ module Metalware
 
         private
 
-        attr_reader :asset_name, :asset_path, :node_name
+        attr_reader :node_name
 
         def setup
-          @asset_name = args[0]
-          @asset_path = FilePath.asset(asset_name)
-          @node_name = args[1]
+          @node_name = args[0]
         end
 
         def run
-          error_if_asset_file_doesnt_exist(asset_path)
-          unassign_asset_from_node_if_given(asset_name, node_name)
+          unassign_node_from_cache(node_name)
         end
       end
     end


### PR DESCRIPTION
## Changes
### Asset Link
Syntax: `metal asset link NODE_NAME ASSET_NAME [options]`
### Asset Unlink
Syntax : `metal asset unlink NODE_NAME [options]`
Behavior: Will remove the link for NODE_NAME **only**
### Methods
* Split `unassign_asset` so that it is only concerned about removing the relationship(s) for the given asset and is never concerned about what node(s) are involved. 
* There is now an `unassign_node` method to worry about the removal of a node's relationship.
* The `CommandHelpers::AssetHelper` now has two methods to help with the above two functionalities
  * `unassign_asset_from_cache` and `unassign_node_from_cache`