### PR TITLE
Test build files with the correct data structure

### DIFF
--- a/spec/build_methods/build_method_spec.rb
+++ b/spec/build_methods/build_method_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Metalware::BuildMethods::BuildMethod do
       some_section: [{
         template_path: template_path,
         rendered_path: rendered_path,
-      }],
+      }]
     )
   end
 
@@ -56,7 +56,7 @@ RSpec.describe Metalware::BuildMethods::BuildMethod do
     Metalware::Constants::HASH_MERGER_DATA_STRUCTURE.new(
       some_section: [{
         error: 'error',
-      }],
+      }]
     )
   end
 

--- a/spec/build_methods/build_method_spec.rb
+++ b/spec/build_methods/build_method_spec.rb
@@ -44,20 +44,20 @@ RSpec.describe Metalware::BuildMethods::BuildMethod do
       fs.create rendered_path
     end
 
-    {
+    Metalware::Constants::HASH_MERGER_DATA_STRUCTURE.new(
       some_section: [{
         template_path: template_path,
         rendered_path: rendered_path,
       }],
-    }
+    )
   end
 
   let(:mock_files_with_errors) do
-    {
+    Metalware::Constants::HASH_MERGER_DATA_STRUCTURE.new(
       some_section: [{
         error: 'error',
       }],
-    }
+    )
   end
 
   subject do

--- a/src/hash_mergers/metal_recursive_open_struct.rb
+++ b/src/hash_mergers/metal_recursive_open_struct.rb
@@ -9,7 +9,7 @@ module Metalware
       include Enumerable
 
       def initialize(table = {}, &input_block)
-        @convert_string_block = input_block || Proc.new { |s| s }
+        @convert_string_block = input_block || proc { |s| s }
         @table = table
       end
 
@@ -36,7 +36,7 @@ module Metalware
       end
 
       def each_value
-        each { |_s, value| yield value }
+        each { |_s, value| yield value } # rubocop:disable Performance/HashEachMethods
       end
 
       def to_h

--- a/src/hash_mergers/metal_recursive_open_struct.rb
+++ b/src/hash_mergers/metal_recursive_open_struct.rb
@@ -8,8 +8,8 @@ module Metalware
     class MetalRecursiveOpenStruct
       include Enumerable
 
-      def initialize(table = {}, &convert_string_block)
-        @convert_string_block = convert_string_block
+      def initialize(table = {}, &input_block)
+        @convert_string_block = input_block || Proc.new { |s| s }
         @table = table
       end
 
@@ -33,6 +33,10 @@ module Metalware
 
       def each
         table.each_key { |key| yield(key, send(key)) }
+      end
+
+      def each_value
+        each { |_s, value| yield value }
       end
 
       def to_h


### PR DESCRIPTION
The build files render has silently broken due to a miss match
between how it is tested and actually used.

RuboCop was used to replace `each { |_k, value| ... }` with the
`each_value { v ... }` syntax. This works fine for a Hash however
MetalRecursiveOpenStruct does not implement `each_value` and
returns nill instead.

However the build method was being tested with a `Hash` and thus
passed. The test has now been updated to use MetalROS.

The bug was fixed by adding a `each_value` method to MetalROS.

The initialization of MetalROS has also been updated so it
includes a default string conversion block that just returns the
raw string. This should make using it in the tests easier.