### PR TITLE
Method for updating the asset cache

### DIFF
--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -6,6 +6,10 @@ require 'cache/asset'
 RSpec.describe Metalware::Cache::Asset do
   include AlcesUtils
 
+  def update(&b)
+    Metalware::Cache::Asset.update(&b)
+  end
+
   let(:cache) { described_class.new }
   let(:cache_path) { Metalware::FilePath.asset_cache }
   let(:initial_content) do
@@ -124,6 +128,25 @@ RSpec.describe Metalware::Cache::Asset do
       cache.unassign_asset('missing_asset')
       new_cache = described_class.new
       expect(new_cache.data).to eq(initial_content)
+    end
+  end
+
+  describe '#update' do
+    it 'ensures it saves the cache after an error' do
+      expect do
+        update do |cache|
+          cache.assign_asset_to_node('asset_test', node)
+          raise RuntimeError
+        end
+      end.to raise_error(RuntimeError)
+      expect(cache.data).to eq(initial_content)
+    end
+
+    it 'updates the cache' do
+      update do |cache|
+        cache.assign_asset_to_node('asset_test', node)
+      end
+      expect(cache.data).to eq(initial_content)
     end
   end
 end

--- a/spec/cache/asset_spec.rb
+++ b/spec/cache/asset_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Metalware::Cache::Asset do
   include AlcesUtils
 
   def update(&b)
-    Metalware::Cache::Asset.update(&b)
+    described_class.update(&b)
   end
 
   let(:cache) { described_class.new }

--- a/src/cache/asset.rb
+++ b/src/cache/asset.rb
@@ -6,6 +6,13 @@ require 'data'
 module Metalware
   module Cache
     class Asset
+      def self.update
+        cache = new
+        yield cache if block_given?
+      ensure
+        cache&.save
+      end
+
       def data
         @data ||= begin
           raw_load = Data.load(FilePath.asset_cache)


### PR DESCRIPTION
We have increasingly seen the need to have a way of updating the asset cache in place. This PR adds the `Cache::Asset.update` method to do this.

I have held off from updating the asset commands to utilise this method until the `CommandHelpers::AssetHelper` is cleaned up.