### PR TITLE
Utilise the update cache method

### DIFF
--- a/src/command_helpers/has_asset_concern.rb
+++ b/src/command_helpers/has_asset_concern.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Metalware
-  module CommandHelpers
-    module HasAssetConcern
-    end
-  end
-end

--- a/src/command_helpers/has_asset_concern.rb
+++ b/src/command_helpers/has_asset_concern.rb
@@ -3,9 +3,6 @@
 module Metalware
   module CommandHelpers
     module HasAssetConcern
-      def asset_cache
-        @asset_cache ||= Cache::Asset.new
-      end
     end
   end
 end

--- a/src/command_helpers/record_editor.rb
+++ b/src/command_helpers/record_editor.rb
@@ -15,7 +15,7 @@ module Metalware
 
       def assign_asset_to_node_if_given(asset_name)
         return unless node
-        Cache::Asset.update do |cache| 
+        Cache::Asset.update do |cache|
           cache.assign_asset_to_node(asset_name, node)
         end
       end

--- a/src/command_helpers/record_editor.rb
+++ b/src/command_helpers/record_editor.rb
@@ -5,8 +5,6 @@ module Metalware
     class RecordEditor < BaseCommand
       private
 
-      include HasAssetConcern
-
       attr_accessor :node
 
       def unpack_node_from_options
@@ -17,8 +15,9 @@ module Metalware
 
       def assign_asset_to_node_if_given(asset_name)
         return unless node
-        asset_cache.assign_asset_to_node(asset_name, node)
-        asset_cache.save
+        Cache::Asset.update do |cache| 
+          cache.assign_asset_to_node(asset_name, node)
+        end
       end
 
       def copy_and_edit_record_file

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -9,8 +9,6 @@ module Metalware
       class Delete < CommandHelpers::BaseCommand
         private
 
-        include CommandHelpers::HasAssetConcern
-
         attr_reader :asset_name, :asset_path
 
         def setup

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -25,8 +25,7 @@ module Metalware
         end
 
         def unassign_asset_from_cache
-          asset_cache.unassign_asset(asset_name)
-          asset_cache.save
+          Cache::Asset.update { |cache| cache.unassign_asset(asset_name) }
         end
 
         def delete_asset

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -6,8 +6,6 @@ module Metalware
       class Edit < CommandHelpers::RecordEditor
         private
 
-        include CommandHelpers::HasAssetConcern
-
         attr_reader :asset_name, :asset_path
 
         alias source asset_path

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -6,6 +6,8 @@ module Metalware
       class Edit < CommandHelpers::RecordEditor
         private
 
+        include CommandHelpers::HasAssetConcern
+
         attr_reader :asset_name, :asset_path
 
         alias source asset_path

--- a/src/commands/asset/link.rb
+++ b/src/commands/asset/link.rb
@@ -18,7 +18,7 @@ module Metalware
         end
 
         def run
-          Cache::Asset.update do |cache|  
+          Cache::Asset.update do |cache|
             cache.assign_asset_to_node(asset_name, node)
           end
         end

--- a/src/commands/asset/link.rb
+++ b/src/commands/asset/link.rb
@@ -6,8 +6,6 @@ module Metalware
       class Link < CommandHelpers::BaseCommand
         private
 
-        include CommandHelpers::HasAssetConcern
-
         attr_reader :asset_name, :asset_path, :node
 
         def setup

--- a/src/commands/asset/link.rb
+++ b/src/commands/asset/link.rb
@@ -18,8 +18,9 @@ module Metalware
         end
 
         def run
-          asset_cache.assign_asset_to_node(asset_name, node)
-          asset_cache.save
+          Cache::Asset.update do |cache|  
+            cache.assign_asset_to_node(asset_name, node)
+          end
         end
       end
     end

--- a/src/commands/asset/unlink.rb
+++ b/src/commands/asset/unlink.rb
@@ -6,8 +6,6 @@ module Metalware
       class Unlink < CommandHelpers::BaseCommand
         private
 
-        include CommandHelpers::HasAssetConcern
-
         attr_reader :node_name
 
         def setup
@@ -19,8 +17,7 @@ module Metalware
         end
 
         def unassign_node_from_cache
-          asset_cache.unassign_node(node_name)
-          asset_cache.save
+          Cache::Asset.update { |cache| cache.unassign_node(node_name) }
         end
       end
     end


### PR DESCRIPTION
Within this is a small collection of changes to utilise the `Cache::Asset.update` method added in #388. These changes now mean that the cache is saved in place where appropriate. 

With these changes it also became apparent that `asset_cache` was serving no purpose any more and so I have removed it from `HasAssetConcern`