### PR TITLE
Store the asset files in sub directories by type

### DIFF
--- a/spec/alces_utils.rb
+++ b/spec/alces_utils.rb
@@ -187,8 +187,9 @@ module AlcesUtils
       group
     end
 
-    def create_asset(asset_name, data)
-      path = Metalware::FilePath.asset(asset_name)
+    def create_asset(asset_name, data, type: 'server')
+      path = Metalware::FilePath.asset(type.pluralize, asset_name)
+      FileUtils.mkdir_p(File.dirname(path))
       Metalware::Data.dump(path, data)
       alces.instance_variable_set(:@asset_cache, nil)
       alces.instance_variable_set(:@assets, nil)

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Metalware::Commands::Asset::Add do
     let(:save) { 'saved-asset' }
 
     let(:type_path) { Metalware::FilePath.asset_type(type) }
-    let(:save_path) { Metalware::FilePath.asset(save) }
+    let(:save_path) do
+      Metalware::FilePath.asset(type.pluralize, save)
+    end
 
     def run_command
       Metalware::Utils.run_command(described_class,

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     [
       {
         name: 'asset1',
+        types_dir: 'pdus',
         data: { key: 'value1' },
       },
       {
         name: 'asset2',
+        types_dir: 'racks',
         data: { key: 'value2' },
       },
     ]
@@ -34,7 +36,9 @@ RSpec.describe Metalware::Namespaces::AssetArray do
 
   before do
     assets.each do |asset|
-      path = Metalware::FilePath.asset(asset[:name])
+      path = Metalware::FilePath.asset(asset[:types_dir],
+                                       asset[:name])
+      FileUtils.mkdir_p(File.dirname(path))
       Metalware::Data.dump(path, asset[:data])
     end
   end
@@ -42,7 +46,8 @@ RSpec.describe Metalware::Namespaces::AssetArray do
   describe '#new' do
     context 'when there is an asset called "each"' do
       before do
-        each_path = Metalware::FilePath.asset('each')
+        each_path = Metalware::FilePath.asset('racks', 'each')
+        FileUtils.mkdir_p(File.dirname(each_path))
         Metalware::Data.dump(each_path, data: 'some-data')
       end
 

--- a/spec/records/path_spec.rb
+++ b/spec/records/path_spec.rb
@@ -36,12 +36,8 @@ RSpec.describe Metalware::Records::Path do
     end
   end
 
-  # NOTE: Once FilePath is updated, the legacy assets should become
-  # invisible
-  it 'can find a legacy assets' do
-    name = legacy_assets.last
-    path = File.expand_path(Metalware::FilePath.asset('.', name))
-    expect(described_class.asset(name)).to eq(path)
+  it 'can not find a legacy assets' do
+    expect(described_class.asset(legacy_assets.last)).to eq(nil)
   end
 
   context 'with an asset within a type directory' do

--- a/spec/records/path_spec.rb
+++ b/spec/records/path_spec.rb
@@ -21,15 +21,16 @@ RSpec.describe Metalware::Records::Path do
 
   # Creates the asset files
   before do
-    all_assets = []
+    paths = []
     asset_hash.each do |types_dir, names|
       names.each do |name|
-        all_assets << File.join(types_dir.to_s, name)
+        paths << Metalware::FilePath.asset(types_dir.to_s, name)
       end
     end
-    legacy_assets.each { |n| all_assets << n }
-    all_assets.each do |asset|
-      path = Metalware::FilePath.asset(asset)
+    legacy_assets.each do |legacy|
+      paths << File.expand_path(Metalware::FilePath.asset('.', legacy))
+    end
+    paths.each do |path|
       FileUtils.mkdir_p(File.dirname(path))
       FileUtils.touch(path)
     end
@@ -39,15 +40,15 @@ RSpec.describe Metalware::Records::Path do
   # invisible
   it 'can find a legacy assets' do
     name = legacy_assets.last
-    path = Metalware::FilePath.asset(name)
+    path = File.expand_path(Metalware::FilePath.asset('.', name))
     expect(described_class.asset(name)).to eq(path)
   end
 
   context 'with an asset within a type directory' do
-    let(:type) { asset_hash.keys.last }
-    let(:name) { asset_hash[type].last }
+    let(:types_dir) { asset_hash.keys.last }
+    let(:name) { asset_hash[types_dir].last }
     let(:expected_path) do
-      Metalware::FilePath.asset(File.join(type.to_s, name))
+      Metalware::FilePath.asset(types_dir.to_s, name)
     end
 
     it 'finds the asset' do

--- a/src/cli.rb
+++ b/src/cli.rb
@@ -27,6 +27,7 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 require 'rubygems'
 require 'bundler/setup'
 require 'commander'
+require 'config'
 require 'colorize'
 
 require 'commander_extensions'

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -17,7 +17,8 @@ module Metalware
           @type_name = args[0]
           @type_path = FilePath.asset_type(type_name)
           @asset_name = args[1]
-          @asset_path = FilePath.asset(asset_name)
+          @asset_path = FilePath.asset(type_name.pluralize,
+                                       asset_name)
           unpack_node_from_options
         end
 

--- a/src/config.rb
+++ b/src/config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#
+# This file contains ruby configuration that should be constant
+#
+
+# Make 'chassis' both the singular and plural
+require 'active_support/inflector'
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.irregular 'chassis', 'chassis'
+end

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -152,8 +152,9 @@ module Metalware
         File.join(repo, 'assets', type + '.yaml')
       end
 
-      def asset(name)
-        File.join(metalware_data, 'assets', name + '.yaml')
+      def asset(types_dir, name)
+        File.join(metalware_data, 'assets',
+                  types_dir, name + '.yaml')
       end
 
       def asset_cache

--- a/src/records/path.rb
+++ b/src/records/path.rb
@@ -6,10 +6,6 @@ module Metalware
   module Records
     class Path
       class << self
-        # NOTE: Currently this method wraps the FilePath method
-        # Eventually FilePath.asset will take a type input however
-        # Records::Path will contain all the file globing and thus
-        # will only require the name
         def asset(name, missing_error: false)
           assets.find { |path| name == File.basename(path, '.yaml') }
                 .tap do |path|
@@ -18,7 +14,7 @@ module Metalware
         end
 
         def assets
-          Dir.glob(FilePath.asset('**', '*'))
+          Dir.glob(FilePath.asset('[a-z]*', '*'))
         end
 
         private

--- a/src/records/path.rb
+++ b/src/records/path.rb
@@ -18,7 +18,7 @@ module Metalware
         end
 
         def assets
-          Dir.glob(FilePath.asset('**/*'))
+          Dir.glob(FilePath.asset('**', '*'))
         end
 
         private


### PR DESCRIPTION
Asset files are now stored in sub directories by `asset_type`. It is a simple case of updating the file path method to take a directory name to be used.

By convention, the directory name is a plural as it is a collection of file. Rails `inflections` are used to do the pluralisation. The `chassis` type however as an irregular inflection as the plural is also `chassis`.  This has been manually configured as `rails` by default pluralises it to `chasses`.

Now that the structure has been updated, the legacy paths are no longer supported and will not be detected by `Record::Path`