### PR TITLE
Move asset types from the repo

### DIFF
--- a/data/asset_types/chassis.yaml
+++ b/data/asset_types/chassis.yaml
@@ -1,0 +1,11 @@
+manufacturer: null
+slots: 4
+oob:
+  ip: null
+  netmask: null
+  user: null
+  password: null
+psus: null
+location:
+  rack: null
+  slot: null

--- a/data/asset_types/disk_array.yaml
+++ b/data/asset_types/disk_array.yaml
@@ -1,0 +1,8 @@
+oob:
+  ip: null
+  netmask: null
+  user: null
+  password: null
+location:
+  rack: null
+  slot: null

--- a/data/asset_types/network.yaml
+++ b/data/asset_types/network.yaml
@@ -1,0 +1,1 @@
+cable_colour: null

--- a/data/asset_types/network_adapter.yaml
+++ b/data/asset_types/network_adapter.yaml
@@ -1,0 +1,6 @@
+#port_name: cable_colour
+ports:
+  em1: null
+  em2: null
+  em3: null
+  em4: null

--- a/data/asset_types/network_switch.yaml
+++ b/data/asset_types/network_switch.yaml
@@ -1,0 +1,9 @@
+oob:
+  ip: null
+  netmask: null
+  user: null
+  password: null
+ports: 48
+location:
+  rack: null
+  slot: null

--- a/data/asset_types/pdu.yaml
+++ b/data/asset_types/pdu.yaml
@@ -1,0 +1,6 @@
+oob:
+  ip: null
+  netmask: null
+  user: null
+  password: null
+ports: 16

--- a/data/asset_types/psu.yaml
+++ b/data/asset_types/psu.yaml
@@ -1,0 +1,4 @@
+ports: 1
+location:
+  pdu: null
+  port: null

--- a/data/asset_types/rack.yaml
+++ b/data/asset_types/rack.yaml
@@ -1,0 +1,4 @@
+manufacturer: null
+slots: 42
+slot_orientation: horizontal
+pdus: null

--- a/data/asset_types/server.yaml
+++ b/data/asset_types/server.yaml
@@ -1,0 +1,12 @@
+manufacturer: null
+oob:
+  ip: null
+  netmask: null
+  user: null
+  password: null
+psus: null
+network_adapters: null
+location:
+  rack: null
+  chassis: null
+  slot: null

--- a/scripts/install
+++ b/scripts/install
@@ -93,7 +93,7 @@ chmod a+rw /var/lib/metalware/events
 ln -s /etc/hosts /var/lib/metalware/rendered/system/
 
 mkdir -p "${target}"
-cp -R "${source}/"{Gemfile,Gemfile.lock,bin,etc,libexec,src} "${target}"
+cp -R "${source}/"{Gemfile,Gemfile.lock,bin,etc,libexec,src,data} "${target}"
 cp ${source}/etc/logrotate.d/* /etc/logrotate.d/
 say_done $?
 

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe Metalware::Commands::Asset::Add do
 
   context 'when using the default type' do
     before do
-      FileSystem.root_setup(&:with_minimal_repo)
+      FileSystem.root_setup(&:with_asset_types)
     end
 
-    let(:type) { 'default' }
+    let(:type) { 'rack' }
     let(:save) { 'saved-asset' }
 
     let(:type_path) { Metalware::FilePath.asset_type(type) }
@@ -36,7 +36,7 @@ RSpec.describe Metalware::Commands::Asset::Add do
                                    stderr: StringIO.new)
     end
 
-    it 'calls for the type to be opened and copyed' do
+    it 'calls for the type to be opened and copied' do
       expect(Metalware::Utils::Editor).to receive(:open_copy)
         .with(type_path, save_path)
       run_command
@@ -51,10 +51,10 @@ RSpec.describe Metalware::Commands::Asset::Add do
   end
 
   context 'with a node argument' do
-    before { FileSystem.root_setup(&:with_minimal_repo) }
+    before { FileSystem.root_setup(&:with_asset_types) }
 
     let(:asset_name) { 'asset1' }
-    let(:command_arguments) { ['default', asset_name] }
+    let(:command_arguments) { ['rack', asset_name] }
 
     it_behaves_like 'asset command that assigns a node'
   end

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -187,6 +187,11 @@ class FileSystem
     )
   end
 
+  def with_asset_types
+    asset_types_dir_path = File.dirname(Metalware::FilePath.asset_type(''))
+    FakeFS::FileSystem.clone(asset_types_dir_path, asset_types_dir_path)
+  end
+
   # Create same directory hierarchy that would be created by a Metalware
   # install.
   def create_initial_directory_hierarchy

--- a/spec/minimal_repo.rb
+++ b/spec/minimal_repo.rb
@@ -42,7 +42,6 @@ module MinimalRepo
       'genders/default': '',
       'dhcp/default': '',
       'config/domain.yaml': '',
-      'assets/default.yaml': '',
       'configure.yaml': YAML.dump(questions: [],
                                   domain: [],
                                   group: [],

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -149,7 +149,7 @@ module Metalware
       end
 
       def asset_type(type)
-        File.join(repo, 'assets', type + '.yaml')
+        File.join(metalware_install, 'data/asset_types', type + '.yaml')
       end
 
       def asset(name)


### PR DESCRIPTION
All asset files within [metalware-default](https://github.com/alces-software/metalware-default) have been moved within `Metalware` itself, housed within `data/asset-types/`. 

The PR https://github.com/alces-software/metalware-default/pull/28 removes them from the repo and should be looked at in tandem with this one.