### PR TITLE
Handle the uniqueness of asset names more robustly

### DIFF
--- a/spec/commands/asset/delete_spec.rb
+++ b/spec/commands/asset/delete_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Metalware::Commands::Asset::Delete do
 
     it 'deletes the asset file' do
       run_command
-      expect(Metalware::Records::Path.asset(asset)).to be_nil
+      expect(Metalware::Records::Asset.path(asset)).to be_nil
     end
   end
 end

--- a/spec/commands/asset/edit_spec.rb
+++ b/spec/commands/asset/edit_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Metalware::Commands::Asset::Edit do
   context 'when using a saved asset' do
     let(:saved_asset) { 'saved-asset' }
     let(:test_content) { { key: 'value' } }
-    let(:asset_path) { Metalware::Records::Path.asset(saved_asset) }
+    let(:asset_path) { Metalware::Records::Asset.path(saved_asset) }
 
     AlcesUtils.mock(self, :each) do
       FileSystem.root_setup(&:with_minimal_repo)

--- a/spec/records/asset_spec.rb
+++ b/spec/records/asset_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 require 'spec_utils'
-require 'records/path'
 
-RSpec.describe Metalware::Records::Path do
+RSpec.describe Metalware::Records::Asset do
   let(:asset_hash) do
     {
       pdus: ['pdu1', 'pdu2'],
@@ -36,9 +35,9 @@ RSpec.describe Metalware::Records::Path do
     end
   end
 
-  describe '#asset' do
+  describe '#path' do
     it 'can not find a legacy assets' do
-      expect(described_class.asset(legacy_assets.last)).to eq(nil)
+      expect(described_class.path(legacy_assets.last)).to eq(nil)
     end
 
     context 'with an asset within a type directory' do
@@ -49,11 +48,11 @@ RSpec.describe Metalware::Records::Path do
       end
 
       it 'finds the asset' do
-        expect(described_class.asset(name)).to eq(expected_path)
+        expect(described_class.path(name)).to eq(expected_path)
       end
 
       it 'finds the asset with the missing_error flag' do
-        path = described_class.asset(name, missing_error: true)
+        path = described_class.path(name, missing_error: true)
         expect(path).to eq(expected_path)
       end
     end
@@ -62,12 +61,12 @@ RSpec.describe Metalware::Records::Path do
       let(:missing) { 'missing-asset' }
 
       it 'returns nil by default' do
-        expect(described_class.asset(missing)).to eq(nil)
+        expect(described_class.path(missing)).to eq(nil)
       end
 
       it 'errors with the missing_error flag' do
         expect do
-          described_class.asset(missing, missing_error: true)
+          described_class.path(missing, missing_error: true)
         end.to raise_error(Metalware::MissingRecordError)
       end
     end

--- a/spec/records/path_spec.rb
+++ b/spec/records/path_spec.rb
@@ -36,38 +36,51 @@ RSpec.describe Metalware::Records::Path do
     end
   end
 
-  it 'can not find a legacy assets' do
-    expect(described_class.asset(legacy_assets.last)).to eq(nil)
+  describe '#asset' do
+    it 'can not find a legacy assets' do
+      expect(described_class.asset(legacy_assets.last)).to eq(nil)
+    end
+
+    context 'with an asset within a type directory' do
+      let(:types_dir) { asset_hash.keys.last }
+      let(:name) { asset_hash[types_dir].last }
+      let(:expected_path) do
+        Metalware::FilePath.asset(types_dir.to_s, name)
+      end
+
+      it 'finds the asset' do
+        expect(described_class.asset(name)).to eq(expected_path)
+      end
+
+      it 'finds the asset with the missing_error flag' do
+        path = described_class.asset(name, missing_error: true)
+        expect(path).to eq(expected_path)
+      end
+    end
+
+    context 'with a missing asset' do
+      let(:missing) { 'missing-asset' }
+
+      it 'returns nil by default' do
+        expect(described_class.asset(missing)).to eq(nil)
+      end
+
+      it 'errors with the missing_error flag' do
+        expect do
+          described_class.asset(missing, missing_error: true)
+        end.to raise_error(Metalware::MissingRecordError)
+      end
+    end
   end
 
-  context 'with an asset within a type directory' do
-    let(:types_dir) { asset_hash.keys.last }
-    let(:name) { asset_hash[types_dir].last }
-    let(:expected_path) do
-      Metalware::FilePath.asset(types_dir.to_s, name)
+  describe '#avaliable?' do
+    it 'returns true if the asset is missing' do
+      expect(described_class.avaliable?('missing-asset')).to eq(true)
     end
 
-    it 'finds the asset' do
-      expect(described_class.asset(name)).to eq(expected_path)
-    end
-
-    it 'finds the asset with the missing_error flag' do
-      path = described_class.asset(name, missing_error: true)
-      expect(path).to eq(expected_path)
-    end
-  end
-
-  context 'with a missing asset' do
-    let(:missing) { 'missing-asset' }
-
-    it 'returns nil by default' do
-      expect(described_class.asset(missing)).to eq(nil)
-    end
-
-    it 'errors with the missing_error flag' do
-      expect do
-        described_class.asset(missing, missing_error: true)
-      end.to raise_error(Metalware::MissingRecordError)
+    it 'returns false if the asset exists' do
+      name = asset_hash.values.last.last
+      expect(described_class.avaliable?(name)).to eq(false)
     end
   end
 end

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -38,7 +38,7 @@ module Metalware
         end
 
         def error_if_asset_exists
-          return if Records::Path.avaliable?(asset_name)
+          return if Records::Asset.avaliable?(asset_name)
           raise InvalidInput, <<-EOF.squish
             The "#{asset_name}" asset already exists. Please use `metal
             asset edit` instead

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -8,7 +8,7 @@ module Metalware
       class Add < CommandHelpers::RecordEditor
         private
 
-        attr_reader :type_name, :type_path, :asset_path, :asset_name
+        attr_reader :type_name, :type_path, :asset_name
 
         alias source type_path
 

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -11,14 +11,11 @@ module Metalware
         attr_reader :type_name, :type_path, :asset_path, :asset_name
 
         alias source type_path
-        alias destination asset_path
 
         def setup
           @type_name = args[0]
           @type_path = FilePath.asset_type(type_name)
           @asset_name = args[1]
-          @asset_path = FilePath.asset(type_name.pluralize,
-                                       asset_name)
           unpack_node_from_options
         end
 
@@ -29,6 +26,10 @@ module Metalware
           assign_asset_to_node_if_given(asset_name)
         end
 
+        def destination
+          FilePath.asset(type_name.pluralize, asset_name)
+        end
+
         def error_if_type_is_missing
           return if File.exist?(type_path)
           raise InvalidInput, <<-EOF.squish
@@ -37,7 +38,7 @@ module Metalware
         end
 
         def error_if_asset_exists
-          return unless File.exist?(asset_path)
+          return if Records::Path.avaliable?(asset_name)
           raise InvalidInput, <<-EOF.squish
             The "#{asset_name}" asset already exists. Please use `metal
             asset edit` instead

--- a/src/commands/asset/delete.rb
+++ b/src/commands/asset/delete.rb
@@ -13,7 +13,7 @@ module Metalware
 
         def setup
           @asset_name = args[0]
-          @asset_path = Records::Path.asset(asset_name,
+          @asset_path = Records::Asset.path(asset_name,
                                             missing_error: true)
         end
 

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -13,7 +13,7 @@ module Metalware
 
         def setup
           @asset_name = args[0]
-          @asset_path = Records::Path.asset(asset_name,
+          @asset_path = Records::Asset.path(asset_name,
                                             missing_error: true)
           unpack_node_from_options
         end

--- a/src/commands/asset/link.rb
+++ b/src/commands/asset/link.rb
@@ -10,7 +10,7 @@ module Metalware
 
         def setup
           @asset_name = args[1]
-          @asset_path = Records::Path.asset(asset_name,
+          @asset_path = Records::Asset.path(asset_name,
                                             missing_error: true)
           @node = alces.nodes.find_by_name(args[0])
         end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'records/path'
+require 'records/asset'
 
 module Metalware
   module Namespaces
@@ -42,7 +42,7 @@ module Metalware
 
       def initialize(alces)
         @alces = alces
-        @asset_loaders = Records::Path.assets.map do |path|
+        @asset_loaders = Records::Asset.paths.map do |path|
           AssetLoader.new(alces, path).tap do |loader|
             raise_error_if_method_is_defined(loader.name)
             define_singleton_method(loader.name) { loader.data }

--- a/src/records/asset.rb
+++ b/src/records/asset.rb
@@ -4,21 +4,21 @@ require 'file_path'
 
 module Metalware
   module Records
-    class Path
+    class Asset
       class << self
-        def asset(name, missing_error: false)
-          assets.find { |path| name == File.basename(path, '.yaml') }
-                .tap do |path|
+        def path(name, missing_error: false)
+          paths.find { |path| name == File.basename(path, '.yaml') }
+               .tap do |path|
             raise_missing_asset(name) if missing_error && !path
           end
         end
 
-        def assets
+        def paths
           Dir.glob(FilePath.asset('[a-z]*', '*'))
         end
 
         def avaliable?(name)
-          !asset(name)
+          !path(name)
         end
 
         private

--- a/src/records/path.rb
+++ b/src/records/path.rb
@@ -17,6 +17,10 @@ module Metalware
           Dir.glob(FilePath.asset('[a-z]*', '*'))
         end
 
+        def avaliable?(name)
+          !asset(name)
+        end
+
         private
 
         def raise_missing_asset(name)


### PR DESCRIPTION
Previously the `asset add` command would check if an asset already existed by seeing if a file path exists that corresponds to the asset name. Whilst his method works, it is harder to extended when it comes to reserved names in the future. Instead a `available?` method has been defined instead which can be expanded on in the future.

The other major change in this PR is `Records::Path` has been renamed `Records::Asset`. Originally the `Path` class was going to contain code related to `layouts`. However `Path.available?` is not very descriptive and thus `Asset.available?` has taken its place.

A `Layout` class can be defined in the future that uses inheritance to share the common features with `Asset`.