### PR TITLE
Ensure the asset type directory exists before creating the asset

### DIFF
--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -25,6 +25,7 @@ module Metalware
         def run
           error_if_type_is_missing
           error_if_asset_exists
+          FileUtils.mkdir_p File.dirname(destination)
           copy_and_edit_record_file
           assign_asset_to_node_if_given(asset_name)
         end


### PR DESCRIPTION
Currently the framework is there to support the structure of having separate directories for each type but they are not being made. This PR implements a fix to ensure that the directory for the asset type exists before attempting to create the asset itself.