### PR TITLE
Add asset type to the metadata

### DIFF
--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -26,7 +26,10 @@ RSpec.describe Metalware::Namespaces::AssetArray do
 
   let(:assets_data) do
     assets.map do |asset|
-      asset[:data].merge(metadata: { name: asset[:name] })
+      asset[:data].merge(metadata: {
+                           name: asset[:name],
+                           type: asset[:types_dir].singularize,
+                         })
     end
   end
 

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -16,7 +16,7 @@ module Metalware
         end
 
         def type
-          @type ||= File.basename(File.dirname(path).singularize)
+          @type ||= File.basename(File.dirname(path)).singularize
         end
 
         def data

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -15,6 +15,10 @@ module Metalware
           @name ||= File.basename(path, '.yaml')
         end
 
+        def type
+          @type ||= File.basename(File.dirname(path).singularize)
+        end
+
         def data
           @data ||= begin
             data_class = Constants::HASH_MERGER_DATA_STRUCTURE
@@ -34,7 +38,7 @@ module Metalware
         attr_reader :alces, :path
 
         def load_file
-          Data.load(path).merge(metadata: { name: name })
+          Data.load(path).merge(metadata: { name: name, type: type })
         end
       end
 


### PR DESCRIPTION
The type associated with an asset is now stored in it's metadata, based on the directory the asset is located within.