### PR TITLE
Reserve the asset types and certain methods from being asset names 

### DIFF
--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Metalware::Commands::Asset::Add do
       Metalware::FilePath.asset(type.pluralize, save)
     end
 
-    def run_command
+    def run_command(asset_name = save)
       Metalware::Utils.run_command(described_class,
                                    type,
-                                   save,
+                                   asset_name,
                                    stderr: StringIO.new)
     end
 
@@ -49,6 +49,14 @@ RSpec.describe Metalware::Commands::Asset::Add do
       expect do
         run_command
       end.to raise_error(Metalware::InvalidInput)
+               .with_message(/already exists/)
+    end
+
+    it 'errors if the asset name is an asset type' do
+      expect do
+        run_command(type)
+      end.to raise_error(Metalware::InvalidInput)
+               .with_message(/is not a valid/)
     end
   end
 

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe Metalware::Commands::Asset::Add do
       expect do
         run_command
       end.to raise_error(Metalware::InvalidInput)
-               .with_message(/already exists/)
+        .with_message(/already exists/)
     end
 
     it 'errors if the asset name is an asset type' do
       expect do
         run_command(type)
       end.to raise_error(Metalware::InvalidInput)
-               .with_message(/is not a valid/)
+        .with_message(/is not a valid/)
     end
   end
 

--- a/spec/records/asset_spec.rb
+++ b/spec/records/asset_spec.rb
@@ -81,5 +81,17 @@ RSpec.describe Metalware::Records::Asset do
       name = asset_hash.values.last.last
       expect(described_class.available?(name)).to eq(false)
     end
+
+    context 'when using a reserved type name' do
+      let(:type) { 'rack' }
+
+      it 'returns false' do
+        expect(described_class.available?(type)).to eq(false)
+      end
+
+      it 'is false for the plural' do
+        expect(described_class.available?(type.pluralize)).to eq(false)
+      end
+    end
   end
 end

--- a/spec/records/asset_spec.rb
+++ b/spec/records/asset_spec.rb
@@ -82,6 +82,16 @@ RSpec.describe Metalware::Records::Asset do
       expect(described_class.available?(name)).to eq(false)
     end
 
+    asset_array = Metalware::Namespaces::AssetArray
+    {
+      'public' => asset_array.instance_methods.sort.first,
+      'private' => asset_array.private_instance_methods.sort.first
+    }.each do |type, method|
+      it "returns false for #{type} methods on AssetArray" do
+        expect(described_class.available?(method)).to eq(false)
+      end
+    end
+
     context 'when using a reserved type name' do
       let(:type) { 'rack' }
 

--- a/spec/records/asset_spec.rb
+++ b/spec/records/asset_spec.rb
@@ -82,11 +82,7 @@ RSpec.describe Metalware::Records::Asset do
       expect(described_class.available?(name)).to eq(false)
     end
 
-    asset_array = Metalware::Namespaces::AssetArray
-    {
-      'public' => asset_array.instance_methods.sort.first,
-      'private' => asset_array.private_instance_methods.sort.first
-    }.each do |type, method|
+    { 'public' => 'each', 'private' => 'alces' }.each do |type, method|
       it "returns false for #{type} methods on AssetArray" do
         expect(described_class.available?(method)).to eq(false)
       end

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -21,7 +21,7 @@ module Metalware
 
         def run
           error_if_type_is_missing
-          error_if_asset_exists
+          ensure_asset_name_is_available
           FileUtils.mkdir_p File.dirname(destination)
           copy_and_edit_record_file
           assign_asset_to_node_if_given(asset_name)
@@ -38,12 +38,17 @@ module Metalware
           EOF
         end
 
-        def error_if_asset_exists
+        def ensure_asset_name_is_available
           return if Records::Asset.available?(asset_name)
-          raise InvalidInput, <<-EOF.squish
-            The "#{asset_name}" asset already exists. Please use `metal
-            asset edit` instead
-          EOF
+          msg = if Records::Asset.path(asset_name)
+                  <<-EOF.squish
+                    The "#{asset_name}" asset already exists. Please use
+                    `metal asset edit` instead
+                  EOF
+                else
+                  "\"#{asset_name}\" is not a valid asset name"
+                end
+          raise InvalidInput, msg
         end
       end
     end

--- a/src/records/asset.rb
+++ b/src/records/asset.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'file_path'
+require 'namespaces/asset_array'
 
 module Metalware
   module Records
@@ -26,7 +27,7 @@ module Metalware
         def available?(name)
           if TYPES.include?(name) || TYPES.map(&:pluralize).include?(name)
             false
-          elsif Namespaces::AssetArray.respond_to?(name, true)
+          elsif reserved_methods.include?(name)
             false
           else
             !path(name)
@@ -39,6 +40,14 @@ module Metalware
           raise MissingRecordError, <<-EOF.squish
             The "#{name}" asset does not exist
           EOF
+        end
+
+        def reserved_methods
+          @reserved_methods ||= begin
+            Namespaces::AssetArray.instance_methods.concat(
+              Namespaces::AssetArray.private_instance_methods
+            ).uniq.map(&:to_s)
+          end
         end
       end
     end

--- a/src/records/asset.rb
+++ b/src/records/asset.rb
@@ -5,6 +5,12 @@ require 'file_path'
 module Metalware
   module Records
     class Asset
+      TYPES = begin
+        Dir.glob(Metalware::FilePath.asset_type('*')).map do |path|
+          File.basename(path, '.yaml')
+        end
+      end.freeze
+
       class << self
         def path(name, missing_error: false)
           paths.find { |path| name == File.basename(path, '.yaml') }

--- a/src/records/asset.rb
+++ b/src/records/asset.rb
@@ -24,7 +24,11 @@ module Metalware
         end
 
         def available?(name)
-          !path(name)
+          if TYPES.include?(name) || TYPES.map(&:pluralize).include?(name)
+            false
+          else
+            !path(name)
+          end
         end
 
         private

--- a/src/records/asset.rb
+++ b/src/records/asset.rb
@@ -26,6 +26,8 @@ module Metalware
         def available?(name)
           if TYPES.include?(name) || TYPES.map(&:pluralize).include?(name)
             false
+          elsif Namespaces::AssetArray.respond_to?(name, true)
+            false
           else
             !path(name)
           end


### PR DESCRIPTION
To prevent confusion in the future, assets can not have the same name as types or there plural. Also because the assets are going to be loaded into `Namespaces::AssetArray`, they can not share the name with any of its methods.

To do this, the `Record::Asset.avaliable?` method now checks for these reserved terms. This means that `Asset.avaliable?` can no longer tell if an asset exists or not. To check for an assets existence, `Asset.path` should be used.