### PR TITLE
Implement the layout add command

### DIFF
--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -1,64 +1,14 @@
 # frozen_string_literal: true
 
-require 'commands'
-require 'utils'
-require 'filesystem'
 require 'shared_examples/asset_command_that_assigns_a_node'
+require 'shared_examples/record_add_command'
 
 RSpec.describe Metalware::Commands::Asset::Add do
-  # Stops the editor from running the bash command
-  before { allow(Metalware::Utils::Editor).to receive(:open) }
-
-  it 'errors if the type does not exist' do
-    expect do
-      Metalware::Utils.run_command(described_class,
-                                   'missing-type',
-                                   'name',
-                                   stderr: StringIO.new)
-    end.to raise_error(Metalware::InvalidInput)
+  let(:record_path) do
+    Metalware::FilePath.asset(type.pluralize, saved_record_name)
   end
 
-  context 'when using the default type' do
-    before do
-      FileSystem.root_setup(&:with_asset_types)
-    end
-
-    let(:type) { 'rack' }
-    let(:save) { 'saved-asset' }
-
-    let(:type_path) { Metalware::FilePath.asset_type(type) }
-    let(:save_path) do
-      Metalware::FilePath.asset(type.pluralize, save)
-    end
-
-    def run_command(asset_name = save)
-      Metalware::Utils.run_command(described_class,
-                                   type,
-                                   asset_name,
-                                   stderr: StringIO.new)
-    end
-
-    it 'calls for the type to be opened and copied' do
-      expect(Metalware::Utils::Editor).to receive(:open_copy)
-        .with(type_path, save_path)
-      run_command
-    end
-
-    it 'errors if the asset already exists' do
-      run_command
-      expect do
-        run_command
-      end.to raise_error(Metalware::InvalidInput)
-        .with_message(/already exists/)
-    end
-
-    it 'errors if the asset name is an asset type' do
-      expect do
-        run_command(type)
-      end.to raise_error(Metalware::InvalidInput)
-        .with_message(/is not a valid/)
-    end
-  end
+  it_behaves_like 'record add command'
 
   context 'with a node argument' do
     before { FileSystem.root_setup(&:with_asset_types) }

--- a/spec/commands/layout/add_spec.rb
+++ b/spec/commands/layout/add_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'shared_examples/record_add_command'
+
+RSpec.describe Metalware::Commands::Layout::Add do
+  let(:record_path) do
+    Metalware::FilePath.layout(type.pluralize, saved_record_name)
+  end
+
+  it_behaves_like 'record add command'
+end

--- a/spec/shared_examples/asset_command_that_assigns_a_node.rb
+++ b/spec/shared_examples/asset_command_that_assigns_a_node.rb
@@ -9,6 +9,9 @@ require 'cache/asset'
 RSpec.shared_examples 'asset command that assigns a node' do
   include AlcesUtils
 
+  # Stops the editor from running the bash command
+  before { allow(Metalware::Utils::Editor).to receive(:open) }
+
   let(:asset_cache) { Metalware::Cache::Asset.new }
   let(:node_name) { 'test-node' }
 

--- a/spec/shared_examples/record_add_command.rb
+++ b/spec/shared_examples/record_add_command.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'record add command' do
+  # Stops the editor from running the bash command
+  before { allow(Metalware::Utils::Editor).to receive(:open) }
+
+  it 'errors if the type does not exist' do
+    expect do
+      Metalware::Utils.run_command(described_class,
+                                   'missing-type',
+                                   'record-name',
+                                   stderr: StringIO.new)
+    end.to raise_error(Metalware::InvalidInput)
+  end
+
+  context 'when using the rack type' do
+    before do
+      FileSystem.root_setup(&:with_asset_types)
+    end
+
+    let(:type) { 'rack' }
+    let(:saved_record_name) { 'saved-record' }
+
+    let(:type_path) { Metalware::FilePath.asset_type(type) }
+
+    def run_command(record_name = saved_record_name)
+      Metalware::Utils.run_command(described_class,
+                                   type,
+                                   record_name,
+                                   stderr: StringIO.new)
+    end
+
+    it 'calls for the record to be opened and copied' do
+      expect(Metalware::Utils::Editor).to receive(:open_copy)
+        .with(type_path, record_path)
+      run_command
+    end
+
+    it 'errors if the record already exists' do
+      run_command
+      expect do
+        run_command
+      end.to raise_error(Metalware::InvalidInput)
+        .with_message(/already exists/)
+    end
+
+    it 'errors if the record name is an asset type' do
+      expect do
+        run_command(type)
+      end.to raise_error(Metalware::InvalidInput)
+        .with_message(/is not a valid/)
+    end
+  end
+end

--- a/spec/shared_examples/record_add_command.rb
+++ b/spec/shared_examples/record_add_command.rb
@@ -14,9 +14,7 @@ RSpec.shared_examples 'record add command' do
   end
 
   context 'when using the rack type' do
-    before do
-      FileSystem.root_setup(&:with_asset_types)
-    end
+    before { FileSystem.root_setup(&:with_asset_types) }
 
     let(:type) { 'rack' }
     let(:saved_record_name) { 'saved-record' }

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -98,7 +98,7 @@ subcommands:
     action: Commands::Configure::Local
 
   layout_add: &layout_add
-    syntax: metal layout add LAYOUT_TYPE LAYOUT_NAME [options]
+    syntax: metal layout add ASSET_TYPE LAYOUT_NAME [options]
     summary: Add a new layout record
     action: Commands::Layout::Add
 

--- a/src/cli_helper/config.yaml
+++ b/src/cli_helper/config.yaml
@@ -97,6 +97,11 @@ subcommands:
       the system environment. This command is intended to only be ran once.
     action: Commands::Configure::Local
 
+  layout_add: &layout_add
+    syntax: metal layout add LAYOUT_TYPE LAYOUT_NAME [options]
+    summary: Add a new layout record
+    action: Commands::Layout::Add
+
   orchestrate_create: &orchestrate_create
     syntax: metal orchestrate create NODE_IDENTIFIER [options]
     summary: Creates a new virtual machine or group of machines
@@ -339,6 +344,12 @@ commands:
         description: >
           Legacy tags used to specify the input. Their use has been
           deprecated by the COMMAND input.
+
+  layout:
+    syntax: metal layout [SUB_COMMAND] [options]
+    summary: Manage the layout record files
+    subcommands:
+      add: *layout_add
 
   orchestrate:
     syntax: metal orchestrate [SUB_COMMAND] [options]

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -21,7 +21,7 @@ module Metalware
 
         def run
           error_if_type_is_missing
-          ensure_asset_name_is_available
+          Records::Asset.error_if_unavailable(asset_name)
           FileUtils.mkdir_p File.dirname(destination)
           copy_and_edit_record_file
           assign_asset_to_node_if_given(asset_name)
@@ -36,19 +36,6 @@ module Metalware
           raise InvalidInput, <<-EOF.squish
             Cannot find asset type: "#{type_name}"
           EOF
-        end
-
-        def ensure_asset_name_is_available
-          return if Records::Asset.available?(asset_name)
-          msg = if Records::Asset.path(asset_name)
-                  <<-EOF.squish
-                    The "#{asset_name}" asset already exists. Please use
-                    `metal asset edit` instead
-                  EOF
-                else
-                  "\"#{asset_name}\" is not a valid asset name"
-                end
-          raise InvalidInput, msg
         end
       end
     end

--- a/src/commands/layout/add.rb
+++ b/src/commands/layout/add.rb
@@ -21,7 +21,7 @@ module Metalware
 
         def run
           error_if_type_is_missing
-          ensure_layout_name_is_available
+          Records::Layout.error_if_unavailable(layout_name)
           FileUtils.mkdir_p File.dirname(destination)
           copy_and_edit_record_file
         end
@@ -35,19 +35,6 @@ module Metalware
           raise InvalidInput, <<-EOF.squish
             Cannot find layout type: "#{type_name}"
           EOF
-        end
-
-        def ensure_layout_name_is_available
-          return if Records::Layout.available?(layout_name)
-          msg = if Records::Layout.path(layout_name)
-                  <<-EOF.squish
-                    The "#{layout_name}" layout already exists. Please use
-                    'metal layout edit' instead
-                  EOF
-                else
-                  "\"#{layout_name}\" is not a valid layout name"
-                end
-          raise InvalidInput, msg
         end
       end
     end

--- a/src/commands/layout/add.rb
+++ b/src/commands/layout/add.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'utils/editor'
+require 'records/layout'
+
+module Metalware
+  module Commands
+    module Layout
+      class Add < CommandHelpers::RecordEditor
+        private
+
+        attr_reader :type_name, :type_path, :layout_name
+
+        alias source type_path
+
+        def setup
+          @type_name = args[0]
+          @type_path = FilePath.asset_type(type_name)
+          @layout_name = args[1]
+        end
+
+        def run
+          error_if_type_is_missing
+          ensure_layout_name_is_available
+          FileUtils.mkdir_p File.dirname(destination)
+          copy_and_edit_record_file
+        end
+
+        def destination
+          FilePath.layout(type_name.pluralize, layout_name)
+        end
+
+        def error_if_type_is_missing
+          return if File.exist?(type_path)
+          raise InvalidInput, <<-EOF.squish
+            Cannot find layout type: "#{type_name}"
+          EOF
+        end
+
+        def ensure_layout_name_is_available
+          return if Records::Layout.available?(layout_name)
+          msg = if Records::Layout.path(layout_name)
+                  <<-EOF.squish
+                    The "#{layout_name}" layout already exists. Please use
+                    'metal layout edit' instead
+                  EOF
+                else
+                  "\"#{layout_name}\" is not a valid layout name"
+                end
+          raise InvalidInput, msg
+        end
+      end
+    end
+  end
+end

--- a/src/records/record.rb
+++ b/src/records/record.rb
@@ -34,12 +34,28 @@ module Metalware
           end
         end
 
+        def error_if_unavailable(name)
+          return if available?(name)
+          msg = if path(name)
+                  <<-EOF.squish
+                    The "#{name}" #{class_name} already exists. Please use
+                    `metal #{class_name} edit` instead
+                  EOF
+                else
+                  "\"#{name}\" is not a valid #{class_name} name"
+                end
+          raise InvalidInput, msg
+        end
+
         private
 
+        def class_name
+          to_s.gsub(/^.*::/, '').downcase
+        end
+
         def raise_missing_record(name)
-          klass = to_s.gsub(/^.*::/, '').downcase
           raise MissingRecordError, <<-EOF.squish
-            The "#{name}" #{klass} does not exist
+            The "#{name}" #{class_name} does not exist
           EOF
         end
 


### PR DESCRIPTION
Using `metal layout add LAYOUT_TYPE LAYOUT_NAME` you can create a new layout from the base of a given `type`. These layouts are stored under `/v/l/m/layouts/<type>/<layout-name>`. 

This command uses the same structure as `asset add` and utilises the same sort of validation thanks to the `Records` class. Therefore you're unable to add from a non-existent type or use a layout name that would cause a conflict, from an existing layout or from any reserved names.

Also within this branch is a new shared example for testing, `record_add_command`, that groups together all tests that are shared between both `asset add` and `layout add`. Because of this changes have been made to the test spec for `asset add` to make use of this new shared example.

