### PR TITLE
Load the assets by type into the namespace

### DIFF
--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
   # DO NOT use AlcesUtils in the section. It tests features required
   # by the namespace itself.
   let(:alces) { Metalware::Namespaces::Alces.new }
-  let(:assets) do
+  let(:pdu_assets) do
     [
       {
         name: 'pdu1',
@@ -21,12 +21,22 @@ RSpec.describe Metalware::Namespaces::AssetArray do
         types_dir: 'pdus',
         data: { key: 'value2' },
       },
+    ]
+  end
+  let(:rack_assets) do
+    [
       {
         name: 'rack1',
         types_dir: 'racks',
         data: { key: 'value3' },
       },
     ]
+  end
+  let(:assets) do
+    [].tap do |arr|
+      arr.concat pdu_assets
+      arr.concat rack_assets
+    end
   end
 
   let(:assets_data) do

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -183,8 +183,9 @@ RSpec.describe Metalware::Namespaces::AssetArray do
 
   describe 'asset types methods' do
     it 'defines all the type methods as the plural' do
-      Metalware::Records::Asset::TYPES.each do |type|
-        expect(subject).to respond_to(type.pluralize)
+      Metalware::Records::Asset::TYPES.map(&:pluralize).each do |type|
+        expect(subject).to respond_to(type)
+        expect(subject.send(type)).to be_a(subject.class)
       end
     end
   end

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe Metalware::Namespaces::AssetArray do
       it 'does not glob the file system' do
         expect(dir).not_to have_received(:glob)
       end
+
+      it 'has the correct number of assets' do
+        expect(subject.count).to eq(loaders.length)
+      end
+
+      it 'has defined the asset methods' do
+        asset_names.each do |name|
+          expect(subject).to respond_to(name)
+        end
+      end
     end
   end
 

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe Metalware::Namespaces::AssetArray do
       expect(Metalware::Data).not_to receive(:load)
       described_class.new(alces_copy)
     end
+
+    context 'with a loaders input' do
+      it 'does not glob the file system' do
+        expect(Dir).not_to receive(:glob)
+        described_class.new(alces_copy, loaders: [])
+      end
+    end
   end
 
   context 'when loading the second asset' do

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -166,6 +166,14 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     end
   end
 
+  describe 'asset types methods' do
+    it 'defines all the type methods as the plural' do
+      Metalware::Records::Asset::TYPES.each do |type|
+        expect(subject).to respond_to(type.pluralize)
+      end
+    end
+  end
+
   context 'when referencing other asset ("^<asset_name>")' do
     include AlcesUtils
 

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -188,6 +188,14 @@ RSpec.describe Metalware::Namespaces::AssetArray do
         expect(subject.send(type)).to be_a(subject.class)
       end
     end
+
+    it 'can find the assets under its type' do
+      pdu_assets.each do |asset|
+        name = asset[:name]
+        data = asset[:data]
+        expect(subject.pdus.find_by_name(name).to_h).to include(data)
+      end
+    end
   end
 
   context 'when referencing other asset ("^<asset_name>")' do

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -67,9 +67,22 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     end
 
     context 'with a loaders input' do
+      subject { described_class.new(alces, loaders: loaders) }
+
+      let(:type) { Metalware::Records::Asset::TYPES.first }
+      let(:asset_names) { ['asset1', 'asset2'] }
+      let(:loaders) do
+        asset_names.map do |name|
+          path = Metalware::FilePath.asset(type.pluralize, name)
+          Metalware::Namespaces::AssetArray::AssetLoader.new(alces, path)
+        end
+      end
+      let!(:dir) { class_spy(Dir).as_stubbed_const }
+
+      before { subject }
+
       it 'does not glob the file system' do
-        expect(Dir).not_to receive(:glob)
-        described_class.new(alces, loaders: [])
+        expect(dir).not_to have_received(:glob)
       end
     end
   end

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -12,14 +12,19 @@ RSpec.describe Metalware::Namespaces::AssetArray do
   let(:assets) do
     [
       {
-        name: 'asset1',
+        name: 'pdu1',
         types_dir: 'pdus',
         data: { key: 'value1' },
       },
       {
-        name: 'asset2',
-        types_dir: 'racks',
+        name: 'pdu2',
+        types_dir: 'pdus',
         data: { key: 'value2' },
+      },
+      {
+        name: 'rack1',
+        types_dir: 'racks',
+        data: { key: 'value3' },
       },
     ]
   end

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe Metalware::Namespaces::AssetArray do
           expect(subject).to respond_to(name)
         end
       end
+
+      it 'does not respond to the asset type methods' do
+        Metalware::Records::Asset::TYPES.map(&:pluralize).each do |type|
+          expect(subject).not_to respond_to(type)
+        end
+      end
     end
   end
 

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Metalware::Namespaces::AssetArray do
     end
 
     context 'with a loaders input' do
-      subject { described_class.new(alces, loaders: loaders) }
+      subject { described_class.new(alces, loaders_input: loaders) }
 
       let(:type) { Metalware::Records::Asset::TYPES.first }
       let(:asset_names) { ['asset1', 'asset2'] }

--- a/spec/namespaces/asset_array_spec.rb
+++ b/spec/namespaces/asset_array_spec.rb
@@ -4,11 +4,11 @@ require 'alces_utils'
 require 'namespaces/alces'
 
 RSpec.describe Metalware::Namespaces::AssetArray do
-  subject { described_class.new(alces_copy) }
+  subject { described_class.new(alces) }
 
   # DO NOT use AlcesUtils in the section. It tests features required
   # by the namespace itself.
-  let(:alces_copy) { Metalware::Namespaces::Alces.new }
+  let(:alces) { Metalware::Namespaces::Alces.new }
   let(:assets) do
     [
       {
@@ -56,20 +56,20 @@ RSpec.describe Metalware::Namespaces::AssetArray do
 
       it 'errors due to the existing method' do
         expect do
-          described_class.new(alces_copy)
+          described_class.new(alces)
         end.to raise_error(Metalware::DataError)
       end
     end
 
     it 'does not load the files when initially called' do
       expect(Metalware::Data).not_to receive(:load)
-      described_class.new(alces_copy)
+      described_class.new(alces)
     end
 
     context 'with a loaders input' do
       it 'does not glob the file system' do
         expect(Dir).not_to receive(:glob)
-        described_class.new(alces_copy, loaders: [])
+        described_class.new(alces, loaders: [])
       end
     end
   end

--- a/spec/shared_examples/record.rb
+++ b/spec/shared_examples/record.rb
@@ -98,6 +98,11 @@ RSpec.shared_examples 'record' do |file_path_proc|
       it 'is false for the plural' do
         expect(described_class.available?(type.pluralize)).to eq(false)
       end
+
+      # File paths will break how the type is worked out
+      it 'is false for file paths' do
+        expect(described_class.available?('some/path')).to eq(false)
+      end
     end
   end
 end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -48,6 +48,7 @@ module Metalware
         @alces = alces
         @asset_loaders = loaders_input || create_asset_loaders
         asset_loaders.each { |l| define_asset_method_from_loader(l) }
+        define_type_methods unless loaders_input
       end
 
       def [](index)
@@ -84,6 +85,12 @@ module Metalware
       def create_asset_loaders
         Records::Asset.paths.map do |path|
           AssetLoader.new(alces, path)
+        end
+      end
+
+      def define_type_methods
+        Records::Asset::TYPES.map(&:pluralize).each do |type|
+          define_singleton_method(type) {}
         end
       end
     end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -44,9 +44,9 @@ module Metalware
 
       include Enumerable
 
-      def initialize(alces, loaders: nil)
+      def initialize(alces, loaders_input: nil)
         @alces = alces
-        @asset_loaders = loaders || create_asset_loaders
+        @asset_loaders = loaders_input || create_asset_loaders
         asset_loaders.each { |l| define_asset_method_from_loader(l) }
       end
 

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -44,9 +44,9 @@ module Metalware
 
       include Enumerable
 
-      def initialize(alces)
+      def initialize(alces, loaders: nil)
         @alces = alces
-        @asset_loaders = Records::Asset.paths.map do |path|
+        @asset_loaders = loaders || Records::Asset.paths.map do |path|
           AssetLoader.new(alces, path)
         end
         asset_loaders.each { |l| define_asset_method_from_loader(l) }

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -48,7 +48,7 @@ module Metalware
         @alces = alces
         @asset_loaders = loaders_input || create_asset_loaders
         define_type_methods unless loaders_input
-        asset_loaders.each { |l| define_asset_method_from_loader(l) }
+        define_asset_methods
       end
 
       def [](index)
@@ -77,14 +77,16 @@ module Metalware
         EOF
       end
 
-      def define_asset_method_from_loader(loader)
-        raise_error_if_method_is_defined(loader.name)
-        define_singleton_method(loader.name) { loader.data }
-      end
-
       def create_asset_loaders
         Records::Asset.paths.map do |path|
           AssetLoader.new(alces, path)
+        end
+      end
+
+      def define_asset_methods
+        asset_loaders.each do |loader|
+          raise_error_if_method_is_defined(loader.name)
+          define_singleton_method(loader.name) { loader.data }
         end
       end
 

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -91,7 +91,10 @@ module Metalware
       def define_type_methods
         Records::Asset::TYPES.map(&:pluralize).each do |type_plural|
           type_variable = :"@#{type_plural}"
-          sub_array = self.class.new(alces, loaders_input: [])
+          loaders = asset_loaders.select do |loader|
+            loader.type == type_plural.singularize
+          end
+          sub_array = self.class.new(alces, loaders_input: loaders)
           instance_variable_set(type_variable, sub_array)
           define_singleton_method(type_plural) do
             instance_variable_get(type_variable)

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -89,8 +89,13 @@ module Metalware
       end
 
       def define_type_methods
-        Records::Asset::TYPES.map(&:pluralize).each do |type|
-          define_singleton_method(type) {}
+        Records::Asset::TYPES.map(&:pluralize).each do |type_plural|
+          type_variable = :"@#{type_plural}"
+          sub_array = self.class.new(alces, loaders_input: [])
+          instance_variable_set(type_variable, sub_array)
+          define_singleton_method(type_plural) do
+            instance_variable_get(type_variable)
+          end
         end
       end
     end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -47,8 +47,8 @@ module Metalware
       def initialize(alces, loaders_input: nil)
         @alces = alces
         @asset_loaders = loaders_input || create_asset_loaders
-        asset_loaders.each { |l| define_asset_method_from_loader(l) }
         define_type_methods unless loaders_input
+        asset_loaders.each { |l| define_asset_method_from_loader(l) }
       end
 
       def [](index)

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -46,9 +46,7 @@ module Metalware
 
       def initialize(alces, loaders: nil)
         @alces = alces
-        @asset_loaders = loaders || Records::Asset.paths.map do |path|
-          AssetLoader.new(alces, path)
-        end
+        @asset_loaders = loaders || create_asset_loaders
         asset_loaders.each { |l| define_asset_method_from_loader(l) }
       end
 
@@ -81,6 +79,12 @@ module Metalware
       def define_asset_method_from_loader(loader)
         raise_error_if_method_is_defined(loader.name)
         define_singleton_method(loader.name) { loader.data }
+      end
+
+      def create_asset_loaders
+        Records::Asset.paths.map do |path|
+          AssetLoader.new(alces, path)
+        end
       end
     end
   end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -47,11 +47,9 @@ module Metalware
       def initialize(alces)
         @alces = alces
         @asset_loaders = Records::Asset.paths.map do |path|
-          AssetLoader.new(alces, path).tap do |loader|
-            raise_error_if_method_is_defined(loader.name)
-            define_singleton_method(loader.name) { loader.data }
-          end
+          AssetLoader.new(alces, path)
         end
+        asset_loaders.each { |l| define_asset_method_from_loader(l) }
       end
 
       def [](index)
@@ -78,6 +76,11 @@ module Metalware
         raise DataError, <<-EOF.strip_heredoc
           Asset can not be called key word: #{method}
         EOF
+      end
+
+      def define_asset_method_from_loader(loader)
+        raise_error_if_method_is_defined(loader.name)
+        define_singleton_method(loader.name) { loader.data }
       end
     end
   end

--- a/src/namespaces/asset_array.rb
+++ b/src/namespaces/asset_array.rb
@@ -89,14 +89,14 @@ module Metalware
       end
 
       def define_type_methods
-        Records::Asset::TYPES.map(&:pluralize).each do |type_plural|
-          type_variable = :"@#{type_plural}"
+        Records::Asset::TYPES.map.each do |type|
+          type_variable = :"@#{type.pluralize}"
           loaders = asset_loaders.select do |loader|
-            loader.type == type_plural.singularize
+            loader.type == type
           end
           sub_array = self.class.new(alces, loaders_input: loaders)
           instance_variable_set(type_variable, sub_array)
-          define_singleton_method(type_plural) do
+          define_singleton_method(type.pluralize) do
             instance_variable_get(type_variable)
           end
         end

--- a/src/records/record.rb
+++ b/src/records/record.rb
@@ -29,6 +29,8 @@ module Metalware
             false
           elsif reserved_methods.include?(name)
             false
+          elsif name.include?('/')
+            false
           else
             !path(name)
           end


### PR DESCRIPTION
The assets can now be accessed by type within the namespace. When a new `AssetArray` is created, it dynamically creates a new sub `AssetArray's` corresponding to each asset type. This means the following syntax is supported. The asset methods are always defined as the plural of the asset type.
```
alces.assets.pdus.each { ... }
```

The sub asset arrays are also of the `AssetArray` type and share the loader objects from the parent object. This means regardless of how the asset is accessed, the asset file is only loaded once as all objects share the same cache.

As all the assets within a sub `AssetArray` share an asset type, they do not need the asset methods. For this reason, sub `AssetArray's` do not need to define the asset type methods. Thus the following method call will fail:
```
alces.assets.pdus.pdus # Will error
```