### PR TITLE
Add a utility for finding an asset type or layout by name

### DIFF
--- a/spec/records/layout.rb
+++ b/spec/records/layout.rb
@@ -12,18 +12,18 @@ RSpec.describe Metalware::Records::Layout do
     Metalware::FilePath.layout(types_dir, name)
   end
 
-  describe '#base_path' do
+  describe '#path_with_types' do
     let(:type) { 'rack' }
     let(:type_path) { Metalware::FilePath.asset_type(type) }
 
     it 'errors when given an invalid type or layout' do
       expect do
-        described_class.base_path('clown-fiesta')
+        described_class.path_with_types('clown-fiesta')
       end.to raise_error(Metalware::InvalidInput)
     end
 
     it 'returns a type path' do
-      expect(described_class.base_path(type))
+      expect(described_class.path_with_types(type))
         .to eq(type_path)
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Metalware::Records::Layout do
       end
 
       it 'returns a layout path' do
-        expect(described_class.base_path(layout))
+        expect(described_class.path_with_types(layout))
           .to eq(layout_path)
       end
     end

--- a/spec/records/layout.rb
+++ b/spec/records/layout.rb
@@ -5,8 +5,49 @@ require 'shared_examples/record'
 require 'records/layout'
 
 RSpec.describe Metalware::Records::Layout do
+  include AlcesUtils
+  before { allow(Metalware::Utils::Editor).to receive(:open) }
+
   file_path_proc = proc do |types_dir, name|
     Metalware::FilePath.layout(types_dir, name)
+  end
+
+  describe '#base_path' do
+    let(:type) { 'rack' }
+    let(:type_path) { Metalware::FilePath.asset_type(type) }
+
+    it 'errors when given an invalid type or layout' do
+      expect do
+        described_class.base_path('clown-fiesta')
+      end.to raise_error(Metalware::InvalidInput)
+    end 
+
+    it 'returns a type path' do
+      expect(described_class.base_path(type)) 
+        .to eq(type_path)
+    end
+
+    context 'with a saved layout' do
+      let(:layout) { 'test-layout' }
+      let(:layout_path) { Metalware::FilePath.layout(type.pluralize, layout) }
+
+      AlcesUtils.mock(self, :each) do
+        FileSystem.root_setup(&:with_asset_types)
+        create_layout
+      end
+
+      def create_layout
+        Metalware::Utils.run_command(Metalware::Commands::Layout::Add,
+                                     type,
+                                     layout,
+                                     stderr: StringIO.new)
+      end
+
+      it 'returns a layout path' do
+        expect(described_class.base_path(layout))
+          .to eq(layout_path)
+      end
+    end
   end
 
   it_behaves_like 'record', file_path_proc

--- a/spec/records/layout.rb
+++ b/spec/records/layout.rb
@@ -20,10 +20,10 @@ RSpec.describe Metalware::Records::Layout do
       expect do
         described_class.base_path('clown-fiesta')
       end.to raise_error(Metalware::InvalidInput)
-    end 
+    end
 
     it 'returns a type path' do
-      expect(described_class.base_path(type)) 
+      expect(described_class.base_path(type))
         .to eq(type_path)
     end
 

--- a/src/records/layout.rb
+++ b/src/records/layout.rb
@@ -10,7 +10,7 @@ module Metalware
           Dir.glob(FilePath.layout('[a-z]*', '*'))
         end
 
-        def base_path(base_name)
+        def path_with_types(base_name)
           if self::TYPES.include?(base_name)
             FilePath.asset_type(base_name)
           elsif path(base_name)

--- a/src/records/layout.rb
+++ b/src/records/layout.rb
@@ -11,7 +11,7 @@ module Metalware
         end
 
         def base_path(base_name)
-          if types.include?(base_name)
+          if self::TYPES.include?(base_name)
             FilePath.asset_type(base_name)
           elsif path(base_name)
             type = File.basename(File.dirname(path(base_name))).pluralize

--- a/src/records/layout.rb
+++ b/src/records/layout.rb
@@ -9,6 +9,19 @@ module Metalware
         def paths
           Dir.glob(FilePath.layout('[a-z]*', '*'))
         end
+
+        def base_path(base_name)
+          if types.include?(base_name)
+            FilePath.asset_type(base_name)
+          elsif path(base_name)
+            type = File.basename(File.dirname(path(base_name))).pluralize
+            FilePath.layout(type, base_name) 
+          else 
+            raise InvalidInput, <<-EOF.squish
+              There is no '#{base_name}' type or layout
+            EOF
+          end
+        end
       end
     end
   end

--- a/src/records/layout.rb
+++ b/src/records/layout.rb
@@ -15,8 +15,8 @@ module Metalware
             FilePath.asset_type(base_name)
           elsif path(base_name)
             type = File.basename(File.dirname(path(base_name))).pluralize
-            FilePath.layout(type, base_name) 
-          else 
+            FilePath.layout(type, base_name)
+          else
             raise InvalidInput, <<-EOF.squish
               There is no '#{base_name}' type or layout
             EOF


### PR DESCRIPTION
The `base_path` method within `Records::Layout` checks the given input within the list of `types` and existing `layouts`. Returning the respective path if something is found or raising an error if nothing is found in either place.

From there the path can be used as the base of the asset to be created. This utility was made in preparation for the upcoming changes to `asset add` that allow an asset to be created from a layout or a type.