### PR TITLE
Ensure the source type is valid before making a directory

### DIFF
--- a/src/commands/layout/add.rb
+++ b/src/commands/layout/add.rb
@@ -17,6 +17,7 @@ module Metalware
         end
 
         def run
+          source # This ensures that the source type is valid
           Records::Layout.error_if_unavailable(layout_name)
           FileUtils.mkdir_p File.dirname(destination)
           copy_and_edit_record_file


### PR DESCRIPTION
This implements a fix that ensures the input `ASSET_TYPE` for `metal layout add` is valid before the directory is made. Currently the validity check happens after the directory for the type is made, before it even knows whether or not the type exists.