### PR TITLE
Create `AssetBuilder` that will be used to create assets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,3 +86,17 @@ RSpec/MessageSpies:
 # doesn't isn't that much clearer IMO.
 RSpec/NamedSubject:
   Enabled: false
+
+# Allow RSpec to suppress Output using a global variable. It already used a global
+# variable previously and it will not be used in the installed version of
+# Metalware. It is however useful to turn the Output off in the specs
+
+# TODO: Remove spec/commander_extensions_spec.rb from this list eventually
+# It needs to be included here as the array is overridding the todo list
+Style/GlobalVars:
+  Exclude:
+    - spec/commander_extensions_spec.rb
+    - spec/spec_helper.rb
+    - spec/spec_utils.rb
+    - src/output.rb
+

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -40,12 +40,17 @@ RSpec.describe Metalware::AssetBuilder do
         subject.push_asset(layout_asset, layout)
       end
 
-      it 'pushes the asset if the layout exists' do
-        FileUtils.mkdir_p(File.dirname(layout_path))
-        Metalware::Data.dump(layout_path, {})
-        push_layout_asset
-        expect(subject.queue.last.name).to eq(layout_asset)
-        expect(subject.queue.last.source_path).to eq(layout_path)
+      context 'when the layout exists' do
+        before do
+          FileUtils.mkdir_p(File.dirname(layout_path))
+          Metalware::Data.dump(layout_path, {})
+          push_layout_asset
+        end
+
+        it 'pushes the asset if the layout exists' do
+          expect(subject.queue.last.name).to eq(layout_asset)
+          expect(subject.queue.last.source_path).to eq(layout_path)
+        end
       end
 
       it 'warns and does nothing if the layout does not exist' do

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe Metalware::AssetBuilder do
     let(:type_asset) { 'type-asset-name' }
     let(:type) { 'rack' }
 
-    before { subject.push_asset(type_asset, type) }
+    before do
+      SpecUtils.enable_output_to_stderr
+      subject.push_asset(type_asset, type)
+    end
 
     context 'when adding an asset from a type' do
       it 'pushes the asset onto the queue' do
@@ -39,6 +42,14 @@ RSpec.describe Metalware::AssetBuilder do
         Metalware::Data.dump(layout_path, {})
         push_layout_asset
         expect(subject.queue.last.name).to eq(layout_asset)
+      end
+
+      it 'warns then does nothing if the layout does not exist' do
+        original_queue = subject.queue.dup
+        expect do
+          push_layout_asset
+        end.to output(/Failed to add "#{layout_asset}"/).to_stderr
+        expect(subject.queue).to eq(original_queue)
       end
     end
   end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Metalware::AssetBuilder do
   describe '#push_asset' do
     let(:type_asset) { 'type-asset-name' }
     let(:type) { 'rack' }
+    let(:type_path) { Metalware::FilePath.asset_type(type) }
 
     before do
       SpecUtils.enable_output_to_stderr
@@ -24,14 +25,16 @@ RSpec.describe Metalware::AssetBuilder do
     context 'when adding an asset from a type' do
       it 'pushes the asset onto the queue' do
         expect(subject.queue.last.name).to eq(type_asset)
-        expect(subject.queue.last.layout).to eq(type)
+        expect(subject.queue.last.source_path).to eq(type_path)
       end
     end
 
     context 'when adding an asset from a layout' do
       let(:layout) { 'new-layout' }
       let(:layout_asset) { 'layout-asset-name' }
-      let(:layout_path) { Metalware::FilePath.layout(type, layout) }
+      let(:layout_path) do
+        Metalware::FilePath.layout(type.pluralize, layout)
+      end
 
       def push_layout_asset
         subject.push_asset(layout_asset, layout)
@@ -42,9 +45,10 @@ RSpec.describe Metalware::AssetBuilder do
         Metalware::Data.dump(layout_path, {})
         push_layout_asset
         expect(subject.queue.last.name).to eq(layout_asset)
+        expect(subject.queue.last.source_path).to eq(layout_path)
       end
 
-      it 'warns then does nothing if the layout does not exist' do
+      it 'warns and does nothing if the layout does not exist' do
         original_queue = subject.queue.dup
         expect do
           push_layout_asset

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -4,4 +4,11 @@ require 'spec_utils'
 require 'asset_builder'
 
 RSpec.describe Metalware::AssetBuilder do
+  subject { described_class.new }
+
+  describe '#queue' do
+    it 'initially returns an empty array' do
+      expect(subject.queue).to eq([])
+    end
+  end
 end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -11,4 +11,35 @@ RSpec.describe Metalware::AssetBuilder do
       expect(subject.queue).to eq([])
     end
   end
+
+  describe '#push_asset' do
+    let(:type_asset) { 'type-asset-name' }
+    let(:type) { 'rack' }
+
+    before { subject.push_asset(type_asset, type) }
+
+    context 'when adding an asset from a type' do
+      it 'pushes the asset onto the queue' do
+        expect(subject.queue.last.name).to eq(type_asset)
+        expect(subject.queue.last.layout).to eq(type)
+      end
+    end
+
+    context 'when adding an asset from a layout' do
+      let(:layout) { 'new-layout' }
+      let(:layout_asset) { 'layout-asset-name' }
+      let(:layout_path) { Metalware::FilePath.layout(type, layout) }
+
+      def push_layout_asset
+        subject.push_asset(layout_asset, layout)
+      end
+
+      it 'pushes the asset if the layout exists' do
+        FileUtils.mkdir_p(File.dirname(layout_path))
+        Metalware::Data.dump(layout_path, {})
+        push_layout_asset
+        expect(subject.queue.last.name).to eq(layout_asset)
+      end
+    end
+  end
 end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'spec_utils'
+require 'asset_builder'
+
+RSpec.describe Metalware::AssetBuilder do
+end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Metalware::AssetBuilder do
         original_queue = subject.queue.dup
         expect do
           push_layout_asset
-        end.to output(/Failed to add "#{layout_asset}"/).to_stderr
+        end.to output(/Failed to add asset: "#{layout_asset}"/).to_stderr
         expect(subject.queue).to eq(original_queue)
       end
     end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Metalware::AssetBuilder do
       it 'pushes the asset onto the queue' do
         expect(subject.queue.last.name).to eq(type_asset)
         expect(subject.queue.last.source_path).to eq(type_path)
+        expect(subject.queue.last.type).to eq(type)
       end
     end
 
@@ -50,6 +51,7 @@ RSpec.describe Metalware::AssetBuilder do
         it 'pushes the asset if the layout exists' do
           expect(subject.queue.last.name).to eq(layout_asset)
           expect(subject.queue.last.source_path).to eq(layout_path)
+          expect(subject.queue.last.type).to eq(type)
         end
       end
 

--- a/spec/records/layout_spec.rb
+++ b/spec/records/layout_spec.rb
@@ -15,43 +15,5 @@ RSpec.describe Metalware::Records::Layout do
   let(:valid_path) { Metalware::FilePath.layout('rack', 'saved-layout') }
   let(:invalid_path) { Metalware::FilePath.asset('server', 'saved-asset') }
 
-  describe '#path_with_types' do
-    let(:type) { 'rack' }
-    let(:type_path) { Metalware::FilePath.asset_type(type) }
-
-    it 'errors when given an invalid type or layout' do
-      expect do
-        described_class.path_with_types('clown-fiesta')
-      end.to raise_error(Metalware::InvalidInput)
-    end
-
-    it 'returns a type path' do
-      expect(described_class.path_with_types(type))
-        .to eq(type_path)
-    end
-
-    context 'with a saved layout' do
-      let(:layout) { 'test-layout' }
-      let(:layout_path) { Metalware::FilePath.layout(type.pluralize, layout) }
-
-      AlcesUtils.mock(self, :each) do
-        FileSystem.root_setup(&:with_asset_types)
-        create_layout
-      end
-
-      def create_layout
-        Metalware::Utils.run_command(Metalware::Commands::Layout::Add,
-                                     type,
-                                     layout,
-                                     stderr: StringIO.new)
-      end
-
-      it 'returns a layout path' do
-        expect(described_class.path_with_types(layout))
-          .to eq(layout_path)
-      end
-    end
-  end
-
   it_behaves_like 'record', file_path_proc
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,6 +137,8 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+  # Do not print stderr Output in rspec by default
+  config.before { $rspec_suppress_output_to_stderr = true }
 
   config.around do |example|
     # Run every test using `FakeFS`, this prevents us polluting the real file

--- a/spec/spec_utils.rb
+++ b/spec/spec_utils.rb
@@ -91,6 +91,10 @@ module SpecUtils
       File.join(FIXTURES_PATH, 'configs', config_file)
     end
 
+    def enable_output_to_stderr
+      $rspec_suppress_output_to_stderr = false
+    end
+
     private
 
     def mock_validate_genders(example_group, valid, error)

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -12,20 +12,24 @@ module Metalware
     end
 
     def push_asset(name, layout)
-      queue.push(Asset.new(name, layout))
+      if layout_or_type_path(layout)
+        queue.push(Asset.new(name, layout))
+      else
+        MetalLog.warn <<-EOF.squish
+          Failed to add "#{name}". Could not find layout: "#{layout}"
+        EOF
+      end
     end
 
     private
 
     Asset = Struct.new(:name, :layout)
 
-    def layout_path_with_types(base_name)
-      if Records::Asset::TYPES.include?(base_name)
-        FilePath.asset_type(base_name)
-      elsif (layout_path = Records::Layout.path(base_name))
-        layout_path
+    def layout_or_type_path(layout_or_type)
+      if Records::Asset::TYPES.include?(layout_or_type)
+        FilePath.asset_type(layout_or_type)
       else
-        nil
+        Records::Layout.path(layout_or_type)
       end
     end
   end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -18,5 +18,15 @@ module Metalware
     private
 
     Asset = Struct.new(:name, :layout)
+
+    def layout_path_with_types(base_name)
+      if Records::Asset::TYPES.include?(base_name)
+        FilePath.asset_type(base_name)
+      elsif (layout_path = Records::Layout.path(base_name))
+        layout_path
+      else
+        nil
+      end
+    end
   end
 end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -37,8 +37,6 @@ module Metalware
           type: Records::Layout.type_from_path(path),
           path: path
         )
-      else
-        nil
       end
     end
   end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -12,8 +12,8 @@ module Metalware
     end
 
     def push_asset(name, layout)
-      if layout_or_type_path(layout)
-        queue.push(Asset.new(name, layout))
+      if (path = layout_or_type_path(layout))
+        queue.push(Asset.new(name, path))
       else
         MetalLog.warn <<-EOF.squish
           Failed to add "#{name}". Could not find layout: "#{layout}"
@@ -23,7 +23,7 @@ module Metalware
 
     private
 
-    Asset = Struct.new(:name, :layout)
+    Asset = Struct.new(:name, :source_path)
 
     def layout_or_type_path(layout_or_type)
       if Records::Asset::TYPES.include?(layout_or_type)

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -13,7 +13,8 @@ module Metalware
 
     def push_asset(name, layout)
       if (path = layout_or_type_path(layout))
-        queue.push(Asset.new(name, path))
+        # TODO: Store the type in the Struct
+        queue.push(Asset.new(name, path, 'type - TBD'))
       else
         MetalLog.warn <<-EOF.squish
           Failed to add "#{name}". Could not find layout: "#{layout}"
@@ -23,7 +24,7 @@ module Metalware
 
     private
 
-    Asset = Struct.new(:name, :source_path)
+    Asset = Struct.new(:name, :source_path, :type)
 
     def layout_or_type_path(layout_or_type)
       if Records::Asset::TYPES.include?(layout_or_type)

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'records/layout'
+require 'records/asset'
+
+module Metalware
+  class AssetBuilder
+    
+  end
+end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -11,13 +11,14 @@ module Metalware
       @queue ||= []
     end
 
-    def push_asset(name, layout)
-      if (path = layout_or_type_path(layout))
+    def push_asset(name, layout_or_type)
+      if (path = layout_or_type_path(layout_or_type))
         # TODO: Store the type in the Struct
         queue.push(Asset.new(name, path, 'type - TBD'))
       else
         MetalLog.warn <<-EOF.squish
-          Failed to add "#{name}". Could not find layout: "#{layout}"
+          Failed to add asset: "#{name}". Could not find layout:
+          "#{layout_or_type}"
         EOF
       end
     end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -10,5 +10,13 @@ module Metalware
     def initialize
       @queue ||= []
     end
+
+    def push_asset(name, layout)
+      queue.push(Asset.new(name, layout))
+    end
+
+    private
+
+    Asset = Struct.new(:name, :layout)
   end
 end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -5,6 +5,10 @@ require 'records/asset'
 
 module Metalware
   class AssetBuilder
-    
+    attr_reader :queue
+
+    def initialize
+      @queue ||= []
+    end
   end
 end

--- a/src/output.rb
+++ b/src/output.rb
@@ -34,7 +34,7 @@ module Metalware
     class << self
       def stderr(*lines)
         # Don't output anything in unit tests to prevent noise.
-        warn(*lines) if $PROGRAM_NAME !~ /rspec$/
+        warn(*lines) unless $rspec_suppress_output_to_stderr
       end
 
       def stderr_indented_error_message(text)

--- a/src/records/layout.rb
+++ b/src/records/layout.rb
@@ -13,19 +13,6 @@ module Metalware
         def record_dir
           FilePath.layout_dir
         end
-
-        def path_with_types(base_name)
-          if self::TYPES.include?(base_name)
-            FilePath.asset_type(base_name)
-          elsif path(base_name)
-            type = File.basename(File.dirname(path(base_name))).pluralize
-            FilePath.layout(type, base_name)
-          else
-            raise InvalidInput, <<-EOF.squish
-              There is no '#{base_name}' type or layout
-            EOF
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
A new `AssetBuilder` class has been added to manege the creation of assets and sub assets. The key feature of the class is an internal `queue` that will store the assets that need to be created.

By using this `queue`, each asset can be created in order as well as scheduling new assets to be made.

A new asset can be scheduled using the `push_asset` method. It takes a `layout` (or type) and a asset `name`. It then stores this information in the queue. The method for finding an layout or type path has been moved out of `Records::Layout` and into `AssetBuilder` as this is where it is used.

Note: AssetBuilder will store the `type` of an asset in the struct as well. However the code to do this has not been implemented yet. Hence there is a place holder atm.