### PR TITLE
Define method for getting the next asset

### DIFF
--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -6,6 +6,14 @@ require 'asset_builder'
 RSpec.describe Metalware::AssetBuilder do
   subject { described_class.new }
 
+  let(:type_asset) { 'type-asset-name' }
+  let(:type) { 'rack' }
+  let(:type_path) { Metalware::FilePath.asset_type(type) }
+
+  def push_type_asset
+    subject.push_asset(type_asset, type)
+  end
+
   describe '#queue' do
     it 'initially returns an empty array' do
       expect(subject.queue).to eq([])
@@ -13,13 +21,9 @@ RSpec.describe Metalware::AssetBuilder do
   end
 
   describe '#push_asset' do
-    let(:type_asset) { 'type-asset-name' }
-    let(:type) { 'rack' }
-    let(:type_path) { Metalware::FilePath.asset_type(type) }
-
     before do
       SpecUtils.enable_output_to_stderr
-      subject.push_asset(type_asset, type)
+      push_type_asset
     end
 
     context 'when adding an asset from a type' do
@@ -62,6 +66,17 @@ RSpec.describe Metalware::AssetBuilder do
         end.to output(/Failed to add asset: "#{layout_asset}"/).to_stderr
         expect(subject.queue).to eq(original_queue)
       end
+    end
+  end
+
+  describe '#empty?' do
+    it 'returns true when the queue is empty' do
+      expect(subject.empty?).to be true
+    end
+
+    it 'returns false when there is an asset on the queue' do
+      push_type_asset
+      expect(subject.empty?).to be false
     end
   end
 end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -3,6 +3,14 @@
 require 'spec_utils'
 require 'asset_builder'
 
+RSpec.shared_examples 'pushes the asset' do
+  it 'pushes the asset onto the stack' do
+    expect(subject.stack.last.name).to eq(pushed_asset_name)
+    expect(subject.stack.last.source_path).to eq(pushed_source_path)
+    expect(subject.stack.last.type).to eq(type)
+  end
+end
+
 RSpec.describe Metalware::AssetBuilder do
   subject { described_class.new }
 
@@ -27,11 +35,10 @@ RSpec.describe Metalware::AssetBuilder do
     end
 
     context 'when adding an asset from a type' do
-      it 'pushes the asset onto the stack' do
-        expect(subject.stack.last.name).to eq(test_asset)
-        expect(subject.stack.last.source_path).to eq(type_path)
-        expect(subject.stack.last.type).to eq(type)
-      end
+      let(:pushed_asset_name) { test_asset }
+      let(:pushed_source_path) { type_path }
+
+      include_examples 'pushes the asset'
     end
 
     context 'when adding an asset from a layout' do
@@ -52,11 +59,10 @@ RSpec.describe Metalware::AssetBuilder do
           push_layout_asset
         end
 
-        it 'pushes the asset if the layout exists' do
-          expect(subject.stack.last.name).to eq(layout_asset)
-          expect(subject.stack.last.source_path).to eq(layout_path)
-          expect(subject.stack.last.type).to eq(type)
-        end
+        let(:pushed_asset_name) { layout_asset }
+        let(:pushed_source_path) { layout_path }
+
+        include_examples 'pushes the asset'
       end
 
       it 'warns and does nothing if the layout does not exist' do

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_utils'
 require 'asset_builder'
+require 'alces_utils'
 
 RSpec.shared_examples 'pushes the asset' do
   it 'pushes the asset onto the stack' do
@@ -12,6 +13,8 @@ RSpec.shared_examples 'pushes the asset' do
 end
 
 RSpec.describe Metalware::AssetBuilder do
+  include AlcesUtils
+
   subject { described_class.new }
 
   let(:test_asset) { 'type-asset-name' }
@@ -96,6 +99,12 @@ RSpec.describe Metalware::AssetBuilder do
       subject.push_asset(type, 'some-random-other-asset')
       push_test_asset
       expect(subject.pop_asset.name).to eq(test_asset)
+    end
+
+    it 'does not return assets that already exist' do
+      push_test_asset
+      AlcesUtils.mock(self) { create_asset(test_asset, {}, type: type) }
+      expect(subject.pop_asset).to be_nil
     end
   end
 end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -84,5 +84,17 @@ RSpec.describe Metalware::AssetBuilder do
     it 'returns nil if there are no more assets' do
       expect(subject.pop_asset).to eq(nil)
     end
+
+    it 'returns the asset to be built' do
+      push_test_asset
+      expect(subject.pop_asset.name).to eq(test_asset)
+    end
+
+    it 'removes the asset from the queue' do
+      length = subject.queue.length
+      push_test_asset
+      subject.pop_asset
+      expect(subject.queue.length).to eq(length)
+    end
   end
 end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Metalware::AssetBuilder do
     subject.push_asset(test_asset, type)
   end
 
-  describe '#queue' do
+  describe '#stack' do
     it 'initially returns an empty array' do
-      expect(subject.queue).to eq([])
+      expect(subject.stack).to eq([])
     end
   end
 
@@ -27,10 +27,10 @@ RSpec.describe Metalware::AssetBuilder do
     end
 
     context 'when adding an asset from a type' do
-      it 'pushes the asset onto the queue' do
-        expect(subject.queue.last.name).to eq(test_asset)
-        expect(subject.queue.last.source_path).to eq(type_path)
-        expect(subject.queue.last.type).to eq(type)
+      it 'pushes the asset onto the stack' do
+        expect(subject.stack.last.name).to eq(test_asset)
+        expect(subject.stack.last.source_path).to eq(type_path)
+        expect(subject.stack.last.type).to eq(type)
       end
     end
 
@@ -53,28 +53,28 @@ RSpec.describe Metalware::AssetBuilder do
         end
 
         it 'pushes the asset if the layout exists' do
-          expect(subject.queue.last.name).to eq(layout_asset)
-          expect(subject.queue.last.source_path).to eq(layout_path)
-          expect(subject.queue.last.type).to eq(type)
+          expect(subject.stack.last.name).to eq(layout_asset)
+          expect(subject.stack.last.source_path).to eq(layout_path)
+          expect(subject.stack.last.type).to eq(type)
         end
       end
 
       it 'warns and does nothing if the layout does not exist' do
-        original_queue = subject.queue.dup
+        original_stack = subject.stack.dup
         expect do
           push_layout_asset
         end.to output(/Failed to add asset: "#{layout_asset}"/).to_stderr
-        expect(subject.queue).to eq(original_queue)
+        expect(subject.stack).to eq(original_stack)
       end
     end
   end
 
   describe '#empty?' do
-    it 'returns true when the queue is empty' do
+    it 'returns true when the stack is empty' do
       expect(subject.empty?).to be true
     end
 
-    it 'returns false when there is an asset on the queue' do
+    it 'returns false when there is an asset on the stack' do
       push_test_asset
       expect(subject.empty?).to be false
     end
@@ -90,11 +90,17 @@ RSpec.describe Metalware::AssetBuilder do
       expect(subject.pop_asset.name).to eq(test_asset)
     end
 
-    it 'removes the asset from the queue' do
-      length = subject.queue.length
+    it 'removes the asset from the stack' do
+      length = subject.stack.length
       push_test_asset
       subject.pop_asset
-      expect(subject.queue.length).to eq(length)
+      expect(subject.stack.length).to eq(length)
+    end
+
+    it 'removes assets in a FIFO order' do
+      subject.push_asset(type, 'some-random-other-asset')
+      push_test_asset
+      expect(subject.pop_asset.name).to eq(test_asset)
     end
   end
 end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -79,4 +79,10 @@ RSpec.describe Metalware::AssetBuilder do
       expect(subject.empty?).to be false
     end
   end
+
+  describe '#pop_asset' do
+    it 'returns nil if there are no more assets' do
+      expect(subject.pop_asset).to eq(nil)
+    end
+  end
 end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -6,12 +6,12 @@ require 'asset_builder'
 RSpec.describe Metalware::AssetBuilder do
   subject { described_class.new }
 
-  let(:type_asset) { 'type-asset-name' }
+  let(:test_asset) { 'type-asset-name' }
   let(:type) { 'rack' }
   let(:type_path) { Metalware::FilePath.asset_type(type) }
 
-  def push_type_asset
-    subject.push_asset(type_asset, type)
+  def push_test_asset
+    subject.push_asset(test_asset, type)
   end
 
   describe '#queue' do
@@ -23,12 +23,12 @@ RSpec.describe Metalware::AssetBuilder do
   describe '#push_asset' do
     before do
       SpecUtils.enable_output_to_stderr
-      push_type_asset
+      push_test_asset
     end
 
     context 'when adding an asset from a type' do
       it 'pushes the asset onto the queue' do
-        expect(subject.queue.last.name).to eq(type_asset)
+        expect(subject.queue.last.name).to eq(test_asset)
         expect(subject.queue.last.source_path).to eq(type_path)
         expect(subject.queue.last.type).to eq(type)
       end
@@ -75,7 +75,7 @@ RSpec.describe Metalware::AssetBuilder do
     end
 
     it 'returns false when there is an asset on the queue' do
-      push_type_asset
+      push_test_asset
       expect(subject.empty?).to be false
     end
   end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -75,17 +75,6 @@ RSpec.describe Metalware::AssetBuilder do
     end
   end
 
-  describe '#empty?' do
-    it 'returns true when the stack is empty' do
-      expect(subject.empty?).to be true
-    end
-
-    it 'returns false when there is an asset on the stack' do
-      push_test_asset
-      expect(subject.empty?).to be false
-    end
-  end
-
   describe '#pop_asset' do
     it 'returns nil if there are no more assets' do
       expect(subject.pop_asset).to eq(nil)

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -7,6 +7,8 @@ module Metalware
   class AssetBuilder
     attr_reader :queue
 
+    delegate :empty?, to: :queue
+
     def initialize
       @queue ||= []
     end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -23,7 +23,14 @@ module Metalware
     end
 
     def pop_asset
-      stack.pop
+      asset = stack.pop
+      if asset.nil?
+        nil
+      elsif Records::Asset.available?(asset.name)
+        asset
+      else
+        pop_asset
+      end
     end
 
     private

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -25,6 +25,7 @@ module Metalware
     end
 
     def pop_asset
+      queue.pop
     end
 
     private

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -7,8 +7,6 @@ module Metalware
   class AssetBuilder
     attr_reader :stack
 
-    delegate :empty?, to: :stack
-
     def initialize
       @stack ||= []
     end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -5,17 +5,17 @@ require 'records/asset'
 
 module Metalware
   class AssetBuilder
-    attr_reader :queue
+    attr_reader :stack
 
-    delegate :empty?, to: :queue
+    delegate :empty?, to: :stack
 
     def initialize
-      @queue ||= []
+      @stack ||= []
     end
 
     def push_asset(name, layout_or_type)
       if (details = source_file_details(layout_or_type))
-        queue.push(Asset.new(name, details.path, details.type))
+        stack.push(Asset.new(name, details.path, details.type))
       else
         MetalLog.warn <<-EOF.squish
           Failed to add asset: "#{name}". Could not find layout:
@@ -25,7 +25,7 @@ module Metalware
     end
 
     def pop_asset
-      queue.pop
+      stack.pop
     end
 
     private

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -24,6 +24,9 @@ module Metalware
       end
     end
 
+    def pop_asset
+    end
+
     private
 
     Asset = Struct.new(:name, :source_path, :type)


### PR DESCRIPTION
Now that `push_asset` has been defined, its corresponding `pop_asset` method is required.

It will return the next asset to be built. As it returns a struct, the edit and save methods will be defined on it directly. If however there are no more assets, it returns nil. This means the `empty?` method is not required as `pop_asset` can be performed in a loop until it returns nil.

`pop_asset` is also responsible for checking if the asset already exists. If it does, it skips the asset and returns the next one on the stack (or `nil`). It is assumed that if the asset already exists, the user has intentionally made it and thus no warning should be issued.