### PR TITLE
Implement methods for saving asset files

### DIFF
--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Metalware::AssetBuilder do
   describe '#edit_and_save' do
     let(:run_save) { proc { asset.edit_and_save } }
     let(:mock_highline) do
-      double(HighLine).tap do |h|
+      instance_double(HighLine).tap do |h|
         allow(h).to receive(:agree).and_return(false)
       end
     end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -107,4 +107,27 @@ RSpec.describe Metalware::AssetBuilder do
       expect(subject.pop_asset).to be_nil
     end
   end
+
+  describe '#save' do
+    let(:asset) { subject.pop_asset }
+    let(:source_content) { Metalware::Data.load(asset.source_path) }
+
+    before do
+      FileSystem.root_setup(&:with_asset_types)
+      push_test_asset
+    end
+
+    it 'saves the asset' do
+      asset.save
+      content = alces.assets.find_by_name(test_asset).to_h.tap do |c|
+        c.delete(:metadata)
+      end
+      expect(content).to eq(source_content)
+    end
+
+    it 'errors if the source file is invalid' do
+      allow(Metalware::Data).to receive(:load).and_return([])
+      expect { asset.save }.to raise_error(Metalware::InvalidInput)
+    end
+  end
 end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -50,17 +50,26 @@ module Metalware
     end
 
     Asset = Struct.new(:name, :source_path, :type) do
+      def edit_and_save
+        Utils::Editor.open_copy(source_path, asset_path) do |temp_path|
+          Validation::Asset.valid_file?(temp_path)
+        end
+      end
+
       def save
         raise_if_source_invalid(source_path)
-        asset_path = FilePath.asset(type.pluralize, name)
         Utils.copy_via_temp_file(source_path, asset_path) {}
+      end
+
+      def asset_path
+        FilePath.asset(type.pluralize, name)
       end
 
       private
 
       def raise_if_source_invalid(source_path)
         return if Validation::Asset.valid_file?(source_path)
-        raise InvalidInput, <<-EOF
+        raise ValidationFailure, <<-EOF.squish
           Failed to add asset: "#{name}". Please check the layout is valid:
           "#{source_path}"
         EOF

--- a/src/command_helpers/record_editor.rb
+++ b/src/command_helpers/record_editor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'validation/asset'
+
 module Metalware
   module CommandHelpers
     class RecordEditor < BaseCommand
@@ -22,11 +24,7 @@ module Metalware
 
       def copy_and_edit_record_file
         Utils::Editor.open_copy(source, destination) do |edited_path|
-          begin
-            Metalware::Data.load(edited_path).is_a?(Hash)
-          rescue StandardError
-            false
-          end
+          Validation::Asset.valid_file?(edited_path)
         end
       end
 

--- a/src/utils.rb
+++ b/src/utils.rb
@@ -36,12 +36,31 @@ module Metalware
         defined? Rails
       end
 
+      def copy_via_temp_file(source, destination)
+        temp_name = File.basename(destination, '.*')
+        content = File.read(source)
+        create_temp_file(temp_name, content) do |path|
+          yield path
+          FileUtils.cp(path, destination)
+        end
+      end
+
       private
 
       # From
       # https://www.safaribooksonline.com/library/view/ruby-cookbook/0596523696/ch01s15.html.
       def wrap(string, width)
         string.gsub(/(.{1,#{width}})(\s+|\Z)/, "\\1\n")
+      end
+
+      def create_temp_file(name, content)
+        file = Tempfile.new(name)
+        file.write(content)
+        file.flush
+        yield file.path
+      ensure
+        file.close
+        file.unlink
       end
     end
   end

--- a/src/utils/editor.rb
+++ b/src/utils/editor.rb
@@ -20,25 +20,13 @@ module Metalware
         end
 
         def open_copy(source, destination, &validator)
-          name = File.basename(source, '.*')
-          create_temp_file(name, File.read(source)) do |path|
+          Utils.copy_via_temp_file(source, destination) do |path|
             open(path)
             raise_if_validation_fails(path, &validator) if validator
-            FileUtils.cp(path, destination)
           end
         end
 
         private
-
-        def create_temp_file(name, content)
-          file = Tempfile.new(name)
-          file.write(content)
-          file.flush
-          yield file.path
-        ensure
-          file.close
-          file.unlink
-        end
 
         def raise_if_validation_fails(path, &validator)
           return if yield path

--- a/src/validation/asset.rb
+++ b/src/validation/asset.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Metalware
+  module Validation
+    class Asset
+      def self.valid_file?(path)
+        Data.load(path).is_a?(Hash)
+      rescue StandardError
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the methods require to save an asset file. There are two version of how this can be done:
1. `asset.save` which will trigger the asset to be directly saved
1. `asset.edit_and_save` which will open the asset in an editor before saving it

The `edit_and_save` uses the same prompts as before if the asset is invalid. The `save` does not however as this indicates an issue with the `layout` file. If the `layout` is invalid, than it will just error.

Finally both the `edit_and_save` and `save` methods will copy the asset via a temporary file. The code to do this has been extracted to `Utils` so it can be shared. The purpose of doing this is so the name transformation can occur in the temporary file.