### PR TITLE
Method for checking if a node is local

### DIFF
--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -164,6 +164,10 @@ RSpec.describe Metalware::Namespaces::Node do
             node.build_method
           end.to raise_error(Metalware::InvalidLocalBuild)
         end
+
+        it 'returns false when local? is called' do
+          expect(node.local?).to eq(false)
+        end
       end
 
       context "with the 'local' node" do
@@ -190,6 +194,10 @@ RSpec.describe Metalware::Namespaces::Node do
         # Instead, always force the local node to use the local build
         it 'ignores incorrect config values' do
           local_node_uses_local_build?(:pxelinux)
+        end
+
+        it 'returns true when local? is called' do
+          expect(local.local?).to eq(true)
         end
       end
     end

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -94,6 +94,10 @@ module Metalware
         end
       end
 
+      def local?
+        name == 'local'
+      end
+
       private
 
       def white_list_for_hasher


### PR DESCRIPTION
It is common to check if a node is local and the way to do so currently is to call `alces.node.name == 'local'`. This PR implements a `local?` method that allows for calling `alces.node.local?` that returns a boolean for whether or not the node is local. 