### PR TITLE
Split RecordEditor into AssetEditor and LayoutEditor

### DIFF
--- a/src/command_helpers/asset_editor.rb
+++ b/src/command_helpers/asset_editor.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'command_helpers/layout_editor'
+
+module Metalware
+  module CommandHelpers
+    class AssetEditor < LayoutEditor
+      private
+    end
+  end
+end

--- a/src/command_helpers/asset_editor.rb
+++ b/src/command_helpers/asset_editor.rb
@@ -9,6 +9,11 @@ module Metalware
 
       attr_accessor :node
 
+      def run
+        copy_and_edit_record_file
+        assign_asset_to_node_if_given(asset_name)
+      end
+
       def unpack_node_from_options
         return unless options.node
         self.node = alces.nodes.find_by_name(options.node)

--- a/src/command_helpers/asset_editor.rb
+++ b/src/command_helpers/asset_editor.rb
@@ -6,6 +6,28 @@ module Metalware
   module CommandHelpers
     class AssetEditor < LayoutEditor
       private
+
+      attr_accessor :node
+
+      def unpack_node_from_options
+        return unless options.node
+        self.node = alces.nodes.find_by_name(options.node)
+        raise_error_if_node_is_missing
+      end
+
+      def assign_asset_to_node_if_given(asset_name)
+        return unless node
+        Cache::Asset.update do |cache|
+          cache.assign_asset_to_node(asset_name, node)
+        end
+      end
+
+      def raise_error_if_node_is_missing
+        return if node
+        raise InvalidInput, <<-EOF
+          Unable to find node: #{options.node}
+        EOF
+      end
     end
   end
 end

--- a/src/command_helpers/layout_editor.rb
+++ b/src/command_helpers/layout_editor.rb
@@ -4,7 +4,7 @@ require 'validation/asset'
 
 module Metalware
   module CommandHelpers
-    class RecordEditor < BaseCommand
+    class LayoutEditor < BaseCommand
       private
 
       attr_accessor :node

--- a/src/command_helpers/layout_editor.rb
+++ b/src/command_helpers/layout_editor.rb
@@ -7,6 +7,10 @@ module Metalware
     class LayoutEditor < BaseCommand
       private
 
+      def run
+        copy_and_edit_record_file
+      end
+
       def copy_and_edit_record_file
         Utils::Editor.open_copy(source, destination) do |edited_path|
           Validation::Asset.valid_file?(edited_path)

--- a/src/command_helpers/layout_editor.rb
+++ b/src/command_helpers/layout_editor.rb
@@ -7,32 +7,10 @@ module Metalware
     class LayoutEditor < BaseCommand
       private
 
-      attr_accessor :node
-
-      def unpack_node_from_options
-        return unless options.node
-        self.node = alces.nodes.find_by_name(options.node)
-        raise_error_if_node_is_missing
-      end
-
-      def assign_asset_to_node_if_given(asset_name)
-        return unless node
-        Cache::Asset.update do |cache|
-          cache.assign_asset_to_node(asset_name, node)
-        end
-      end
-
       def copy_and_edit_record_file
         Utils::Editor.open_copy(source, destination) do |edited_path|
           Validation::Asset.valid_file?(edited_path)
         end
-      end
-
-      def raise_error_if_node_is_missing
-        return if node
-        raise InvalidInput, <<-EOF
-          Can not find node: #{options.node}
-        EOF
       end
 
       def source

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -5,7 +5,7 @@ require 'utils/editor'
 module Metalware
   module Commands
     module Asset
-      class Add < CommandHelpers::LayoutEditor
+      class Add < CommandHelpers::AssetEditor
         private
 
         attr_reader :type_name, :type_path, :asset_name

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -5,7 +5,7 @@ require 'utils/editor'
 module Metalware
   module Commands
     module Asset
-      class Add < CommandHelpers::RecordEditor
+      class Add < CommandHelpers::LayoutEditor
         private
 
         attr_reader :type_name, :type_path, :asset_name

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -17,14 +17,9 @@ module Metalware
           @type_path = FilePath.asset_type(type_name)
           @asset_name = args[1]
           unpack_node_from_options
-        end
-
-        def run
           error_if_type_is_missing
           Records::Asset.error_if_unavailable(asset_name)
           FileUtils.mkdir_p File.dirname(destination)
-          copy_and_edit_record_file
-          assign_asset_to_node_if_given(asset_name)
         end
 
         def destination

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -17,11 +17,6 @@ module Metalware
                                             missing_error: true)
           unpack_node_from_options
         end
-
-        def run
-          copy_and_edit_record_file
-          assign_asset_to_node_if_given(asset_name)
-        end
       end
     end
   end

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -3,7 +3,7 @@
 module Metalware
   module Commands
     module Asset
-      class Edit < CommandHelpers::LayoutEditor
+      class Edit < CommandHelpers::AssetEditor
         private
 
         attr_reader :asset_name, :asset_path

--- a/src/commands/asset/edit.rb
+++ b/src/commands/asset/edit.rb
@@ -3,7 +3,7 @@
 module Metalware
   module Commands
     module Asset
-      class Edit < CommandHelpers::RecordEditor
+      class Edit < CommandHelpers::LayoutEditor
         private
 
         attr_reader :asset_name, :asset_path

--- a/src/commands/layout/add.rb
+++ b/src/commands/layout/add.rb
@@ -6,7 +6,7 @@ require 'records/layout'
 module Metalware
   module Commands
     module Layout
-      class Add < CommandHelpers::RecordEditor
+      class Add < CommandHelpers::LayoutEditor
         private
 
         attr_reader :type_name, :layout_name

--- a/src/commands/layout/add.rb
+++ b/src/commands/layout/add.rb
@@ -14,7 +14,7 @@ module Metalware
         def setup
           @type_name = args[0]
           @layout_name = args[1]
-          source # This ensure that the source type is valid
+          source # This ensures that the source type is valid
           Records::Layout.error_if_unavailable(layout_name)
           FileUtils.mkdir_p File.dirname(destination)
         end

--- a/src/commands/layout/add.rb
+++ b/src/commands/layout/add.rb
@@ -14,13 +14,9 @@ module Metalware
         def setup
           @type_name = args[0]
           @layout_name = args[1]
-        end
-
-        def run
-          source # This ensures that the source type is valid
+          source # This ensure that the source type is valid
           Records::Layout.error_if_unavailable(layout_name)
           FileUtils.mkdir_p File.dirname(destination)
-          copy_and_edit_record_file
         end
 
         def destination

--- a/src/commands/layout/edit.rb
+++ b/src/commands/layout/edit.rb
@@ -15,10 +15,6 @@ module Metalware
           @layout_name = args[0]
           @layout_path = Records::Layout.path(layout_name, missing_error: true)
         end
-
-        def run
-          copy_and_edit_record_file
-        end
       end
     end
   end

--- a/src/commands/layout/edit.rb
+++ b/src/commands/layout/edit.rb
@@ -3,7 +3,7 @@
 module Metalware
   module Commands
     module Layout
-      class Edit < CommandHelpers::RecordEditor
+      class Edit < CommandHelpers::LayoutEditor
         private
 
         attr_reader :layout_name, :layout_path


### PR DESCRIPTION
With the addition of sub asseting the asset and layout commands are going to diverge fairly significantly. Therefore it is easier to use a different editor class to separate the logic and keep all code relevant to the same set of commands.

This PR splits `RecordEditor` into `AssetEditor` and `LayoutEditor`, moving methods to their relevant class and generalising the `run` methods for their respective commands.