### PR TITLE
Edit asset within AssetBuilder

### DIFF
--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -201,4 +201,22 @@ RSpec.describe Metalware::AssetBuilder do
 
     include_examples 'save asset methods'
   end
+
+  describe '#edit_asset' do
+    let(:path) { Metalware::Records::Asset.path(test_asset) }
+    let(:expected_content) { { key: 'content' } }
+
+    AlcesUtils.mock(self, :each) do
+      FileSystem.root_setup(&:with_minimal_repo)
+      create_asset(test_asset, {}, type: type)
+    end
+
+    it 'calls the asset to edited and saved' do
+      allow(Metalware::Utils::Editor).to receive(:open).and_wrap_original do |_, path|
+        Metalware::Data.dump(path, expected_content)
+      end
+      subject.edit_asset(test_asset)
+      expect(alces.assets.find_by_name(test_asset).to_h).to include(expected_content)
+    end
+  end
 end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -33,6 +33,13 @@ module Metalware
       end
     end
 
+    def edit_asset(name)
+      path = Records::Asset.path(name)
+      type = Records::Asset.type_from_path(path)
+      asset = Asset.new(name, path, type)
+      asset.edit_and_save
+    end
+
     private
 
     def source_file_details(layout_or_type)

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -36,7 +36,7 @@ module Metalware
     def edit_asset(name)
       path = Records::Asset.path(name)
       type = Records::Asset.type_from_path(path)
-      asset = Asset.new(name, path, type)
+      asset = Asset.new(self, name, path, type)
       asset.edit_and_save
     end
 

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -36,8 +36,7 @@ module Metalware
     def edit_asset(name)
       path = Records::Asset.path(name)
       type = Records::Asset.type_from_path(path)
-      asset = Asset.new(self, name, path, type)
-      asset.edit_and_save
+      Asset.new(self, name, path, type).edit_and_save
     end
 
     private


### PR DESCRIPTION
This PR implements an `edit_asset` method within `AssetBuilder`. This first creates an internal `Asset` before calling the `edit_and_save` method.