### PR TITLE
Implement the sub asseting within `AssetBuilder`

### DIFF
--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -112,22 +112,25 @@ RSpec.describe Metalware::AssetBuilder do
     let(:asset) { subject.pop_asset }
     let(:source_content) { Metalware::Data.load(asset.source_path) }
 
-    before do
-      FileSystem.root_setup(&:with_asset_types)
-      push_test_asset
-    end
+    before { FileSystem.root_setup(&:with_asset_types) }
 
-    it 'saves the asset' do
-      run_save.call
-      content = alces.assets.find_by_name(test_asset).to_h.tap do |c|
-        c.delete(:metadata)
+    context 'with the test asset' do
+      before { push_test_asset }
+
+      it 'saves the asset' do
+        run_save.call
+        content = alces.assets.find_by_name(test_asset).to_h.tap do |c|
+          c.delete(:metadata)
+        end
+        expect(content).to eq(source_content)
       end
-      expect(content).to eq(source_content)
-    end
 
-    it 'errors if the file is invalid' do
-      allow(Metalware::Data).to receive(:load).and_return([])
-      expect { run_save.call }.to raise_error(Metalware::ValidationFailure)
+      it 'errors if the file is invalid' do
+        allow(Metalware::Data).to receive(:load).and_return([])
+        expect do
+          run_save.call
+        end.to raise_error(Metalware::ValidationFailure)
+      end
     end
 
     context 'with a sub asset layout' do
@@ -142,8 +145,12 @@ RSpec.describe Metalware::AssetBuilder do
           data.delete(:metadata)
         end
       end
+      let(:sub_asset_names) do
+        ["#{asset_name}_server1", "#{asset_name}_pdu1"]
+      end
       let(:expected_asset_content) do
-        content_generator("^#{asset_name}_server1", "^#{asset_name}_pdu1")
+        links = sub_asset_names.map { |n| '^' + n }
+        content_generator(links[0], links[1])
       end
 
       def content_generator(server_value, pdu_value)
@@ -164,6 +171,11 @@ RSpec.describe Metalware::AssetBuilder do
 
       it 'transforms the sub asset notation to asset names' do
         expect(asset_content).to eq(expected_asset_content)
+      end
+
+      it 'adds the sub assets to stack' do
+        stacked_assets = subject.stack.map(&:name)
+        expect(stacked_assets).to contain_exactly(*sub_asset_names)
       end
     end
   end

--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -155,11 +155,11 @@ RSpec.describe Metalware::AssetBuilder do
 
       def content_generator(server_value, pdu_value)
         {
-          :'no_double_^' => 'does-not^replace-double^chevron',
+          'no_double_^': 'does-not^replace-double^chevron',
           server: server_value,
           some_key: {
-            pdus: ['^pdu-existing-asset-do-not-touch', pdu_value]
-          }
+            pdus: ['^pdu-existing-asset-do-not-touch', pdu_value],
+          },
         }
       end
 

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -13,7 +13,7 @@ module Metalware
 
     def push_asset(name, layout_or_type)
       if (details = source_file_details(layout_or_type))
-        stack.push(Asset.new(name, details.path, details.type))
+        stack.push(Asset.new(self, name, details.path, details.type))
       else
         MetalLog.warn <<-EOF.squish
           Failed to add asset: "#{name}". Could not find layout:
@@ -49,7 +49,7 @@ module Metalware
       end
     end
 
-    Asset = Struct.new(:name, :source_path, :type) do
+    Asset = Struct.new(:builder, :name, :source_path, :type) do
       def edit_and_save
         Utils::Editor.open_copy(source_path, asset_path) do |temp_path|
           validate_and_generate_sub_assets(temp_path)
@@ -99,9 +99,11 @@ module Metalware
 
       def convert_sub_asset_string(str)
         return str unless str.match?(/\A[^\^]+\^[^\^]+\Z/)
-        # type = str.match(/\A.+(?=\^)/).to_s
+        sub_type_layout = str.match(/\A.+(?=\^)/).to_s
         append_name = str.match(/(?<=\^).+\Z/).to_s
-        "^#{name}_#{append_name}"
+        sub_asset_name = "#{name}_#{append_name}"
+        builder.push_asset(sub_asset_name, sub_type_layout)
+        '^' +  sub_asset_name
       end
     end
   end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -76,10 +76,9 @@ module Metalware
       end
 
       def validate_and_generate_sub_assets(path)
-        if (data = Validation::Asset.valid_file?(path))
-          new_data = convert_sub_assets(data)
-          Metalware::Data.dump(path, new_data)
-        end
+        return false unless (data = Validation::Asset.valid_file?(path))
+        new_data = convert_sub_assets(data)
+        Metalware::Data.dump(path, new_data)
       end
 
       def convert_sub_assets(value)

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -52,13 +52,16 @@ module Metalware
     Asset = Struct.new(:name, :source_path, :type) do
       def edit_and_save
         Utils::Editor.open_copy(source_path, asset_path) do |temp_path|
-          Validation::Asset.valid_file?(temp_path)
+          validate_and_generate_sub_assets(temp_path)
         end
       end
 
       def save
-        raise_if_source_invalid(source_path)
-        Utils.copy_via_temp_file(source_path, asset_path) {}
+        Utils.copy_via_temp_file(source_path, asset_path) do |path|
+          unless validate_and_generate_sub_assets(path)
+            raise_invalid_source
+          end
+        end
       end
 
       def asset_path
@@ -67,12 +70,38 @@ module Metalware
 
       private
 
-      def raise_if_source_invalid(source_path)
-        return if Validation::Asset.valid_file?(source_path)
+      def raise_invalid_source
         raise ValidationFailure, <<-EOF.squish
           Failed to add asset: "#{name}". Please check the layout is valid:
           "#{source_path}"
         EOF
+      end
+
+      def validate_and_generate_sub_assets(path)
+        if (data = Validation::Asset.valid_file?(path))
+          new_data = convert_sub_assets(data)
+          Metalware::Data.dump(path, new_data)
+        end
+      end
+
+      def convert_sub_assets(value)
+        case value
+        when String
+          convert_sub_asset_string(value)
+        when Array
+          value.map { |v| convert_sub_assets(v) }
+        when Hash
+          value.deep_merge(value) { |_,_, v| convert_sub_assets(v) }
+        else
+          value
+        end
+      end
+
+      def convert_sub_asset_string(str)
+        return str unless str.match?(/\A[^\^]+\^[^\^]+\Z/)
+        # type = str.match(/\A.+(?=\^)/).to_s
+        append_name = str.match(/(?<=\^).+\Z/).to_s
+        "^#{name}_#{append_name}"
       end
     end
   end

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -58,9 +58,7 @@ module Metalware
 
       def save
         Utils.copy_via_temp_file(source_path, asset_path) do |path|
-          unless validate_and_generate_sub_assets(path)
-            raise_invalid_source
-          end
+          raise_invalid_source unless validate_and_generate_sub_assets(path)
         end
       end
 
@@ -91,7 +89,7 @@ module Metalware
         when Array
           value.map { |v| convert_sub_assets(v) }
         when Hash
-          value.deep_merge(value) { |_,_, v| convert_sub_assets(v) }
+          value.deep_merge(value) { |_, _, v| convert_sub_assets(v) }
         else
           value
         end
@@ -103,7 +101,7 @@ module Metalware
         append_name = str.match(/(?<=\^).+\Z/).to_s
         sub_asset_name = "#{name}_#{append_name}"
         builder.push_asset(sub_asset_name, sub_type_layout)
-        '^' +  sub_asset_name
+        '^' + sub_asset_name
       end
     end
   end

--- a/src/validation/asset.rb
+++ b/src/validation/asset.rb
@@ -4,7 +4,8 @@ module Metalware
   module Validation
     class Asset
       def self.valid_file?(path)
-        Data.load(path).is_a?(Hash)
+        data = Data.load(path)
+        data.is_a?(Hash) ? data : false
       rescue StandardError
         false
       end


### PR DESCRIPTION
Sorry for the big commits. I got a bit carried away.

Before an asset is saved, it needs to look for the sub asset syntax (`type^asset_name`). When this occurs, the string needs to be translated to its final name: `^#{parent_asset_name}_#{sub_asset_name}`. It also needs to schedule the sub assets to be built.