### PR TITLE
Ask user if they want to save or edit sub assets

### DIFF
--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Metalware::AssetBuilder do
         end
       end
       let(:sub_asset_names) do
-        ["#{asset_name}_server1", "#{asset_name}_pdu1"]
+        ["#{asset_name}-server1", "#{asset_name}-pdu1"]
       end
       let(:expected_asset_content) do
         links = sub_asset_names.map { |n| '^' + n }

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Metalware::Commands::Asset::Add do
     let(:parent_asset_name) { 'parent-asset' }
     let(:sub_asset_name_fragment) { 'pdu1' }
     let(:sub_asset_name) do
-      "#{parent_asset_name}_#{sub_asset_name_fragment}"
+      "#{parent_asset_name}-#{sub_asset_name_fragment}"
     end
 
     AlcesUtils.mock(self, :each) do

--- a/src/asset_builder.rb
+++ b/src/asset_builder.rb
@@ -106,7 +106,7 @@ module Metalware
         return str unless str.match?(/\A[^\^]+\^[^\^]+\Z/)
         sub_type_layout = str.match(/\A.+(?=\^)/).to_s
         append_name = str.match(/(?<=\^).+\Z/).to_s
-        sub_asset_name = "#{name}_#{append_name}"
+        sub_asset_name = "#{name}-#{append_name}"
         builder.push_asset(sub_asset_name, sub_type_layout)
         '^' + sub_asset_name
       end

--- a/src/command_helpers/asset_editor.rb
+++ b/src/command_helpers/asset_editor.rb
@@ -21,12 +21,22 @@ module Metalware
 
       def build_sub_assets
         while (asset = asset_builder.pop_asset)
-          asset.save
+          ask_edit_asset(asset.name) ? asset.edit_and_save : asset.save
         end
+      end
+
+      def ask_edit_asset(name)
+        highline.agree <<-EOF
+          Do you wish to edit asset "#{name}"?
+        EOF
       end
 
       def asset_builder
         @asset_builder ||= AssetBuilder.new
+      end
+
+      def highline
+        @highline ||= HighLine.new
       end
 
       def node

--- a/src/command_helpers/asset_editor.rb
+++ b/src/command_helpers/asset_editor.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'command_helpers/layout_editor'
 require 'asset_builder'
 
 module Metalware
@@ -10,13 +9,17 @@ module Metalware
 
       attr_reader :asset_name
 
+      def run
+        edit_first_asset
+        build_sub_assets
+        assign_asset_to_node_if_given
+      end
+
       def edit_first_asset
         raise NotImplementedError
       end
 
-      def run
-        edit_first_asset
-        assign_asset_to_node_if_given
+      def build_sub_assets
       end
 
       def asset_builder

--- a/src/command_helpers/asset_editor.rb
+++ b/src/command_helpers/asset_editor.rb
@@ -26,8 +26,8 @@ module Metalware
       end
 
       def ask_edit_asset(name)
-        highline.agree <<-EOF
-          Do you wish to edit asset "#{name}"?
+        highline.agree <<-EOF.squish
+          Do you wish to edit asset "#{name}"? [yes/no]
         EOF
       end
 

--- a/src/command_helpers/asset_editor.rb
+++ b/src/command_helpers/asset_editor.rb
@@ -20,6 +20,9 @@ module Metalware
       end
 
       def build_sub_assets
+        while (asset = asset_builder.pop_asset)
+          asset.save
+        end
       end
 
       def asset_builder

--- a/src/commands/asset/add.rb
+++ b/src/commands/asset/add.rb
@@ -18,7 +18,7 @@ module Metalware
 
         def edit_first_asset
           asset_builder.push_asset(asset_name, type_name)
-          asset_builder.pop_asset.edit_and_save
+          asset_builder.pop_asset&.edit_and_save
         end
       end
     end


### PR DESCRIPTION
Previously only the first asset would be edited but it sub assets would be skipped. This PR implements looping through the sub assets until asset generation has finished.

After the first asset is added, the user has the option to either `save` or `edit` the sub assets. They are asked this question before adding each sub asset.