### PR TITLE
Add a method to error if no arguments are provided

### DIFF
--- a/src/commands/view.rb
+++ b/src/commands/view.rb
@@ -14,6 +14,7 @@ module Metalware
       ARRAY_TYPES = [Array, Namespaces::AssetArray].freeze
 
       def run
+        error_if_no_arguments_provided
         pretty_print_json(cli_input_object.to_json)
       end
 
@@ -44,6 +45,14 @@ module Metalware
         # Should colourize the output if we have been forced to do so or we are
         # outputting to a terminal.
         options.color_output || STDOUT.isatty
+      end
+
+      def error_if_no_arguments_provided
+        return unless args.empty?
+        raise InvalidInput, <<-EOF.squish
+          No arguments provided, expected syntax:
+          metal view [ALCES_COMMAND] [options]. See --help for more info
+        EOF
       end
     end
   end


### PR DESCRIPTION
Currently running `metal view` with no arguments throws out the error message for an incorrect input for `[ALCES_COMMAND]`. However this isn't particularly helpful when no argument has been provided.

This PR implements a method within `View` that raises an error in this case. 

See #285 for full details on the issue