### PR TITLE
Reduce the warnings that are causing screen noise

### DIFF
--- a/spec/metal_log_spec.rb
+++ b/spec/metal_log_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Metalware::MetalLog do
       class_spy(Metalware::Output).as_stubbed_const
     end
 
+    let(:test_warning) { 'warning: message' }
+
     after do
       # Reset global options passed to MetalLog by command.
       described_class.strict = false
@@ -36,7 +38,7 @@ RSpec.describe Metalware::MetalLog do
     it 'gives warning output by default' do
       run_test_command
       expect(output).to \
-        have_received(:warning).with('warning: message')
+        have_received(:warning).with(test_warning)
     end
 
     it 'does not give warning and raises when --strict passed' do
@@ -46,13 +48,13 @@ RSpec.describe Metalware::MetalLog do
       end.to raise_error(Metalware::StrictWarningError)
 
       expect(output).not_to \
-        have_received(:warning).with('warning: message')
+        have_received(:warning).with(test_warning)
     end
 
     it 'does not give warning output when --quiet passed' do
       run_test_command(quiet: true)
       expect(output).not_to \
-        have_received(:warning).with('warning: message')
+        have_received(:warning).with(test_warning)
     end
 
     [true, false].each do |quiet|

--- a/spec/metal_log_spec.rb
+++ b/spec/metal_log_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe Metalware::MetalLog do
         have_received(:warning).with(test_warning)
     end
 
+    it 'only issues the warning once' do
+      run_test_command
+      run_test_command
+      expect(output).to have_received(:warning).once
+    end
+
     it 'does not give warning and raises when --strict passed' do
       expect_any_instance_of(Logger).not_to receive(:warn)
       expect do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,7 +138,10 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
   # Do not print stderr Output in rspec by default
-  config.before { $rspec_suppress_output_to_stderr = true }
+  config.before do
+    $rspec_suppress_output_to_stderr = true
+    Metalware::MetalLog.instance_variable_set(:@metal_log, nil)
+  end
 
   config.around do |example|
     # Run every test using `FakeFS`, this prevents us polluting the real file

--- a/src/metal_log.rb
+++ b/src/metal_log.rb
@@ -73,7 +73,14 @@ module Metalware
 
     def print_warning(msg)
       return if quiet?
+      message_cache[msg] ||= 0
+      message_cache[msg] += 1
+      return if message_cache[msg] > 1
       Output.warning "warning: #{msg}"
+    end
+
+    def message_cache
+      @message_cache ||= {}
     end
   end
 end

--- a/src/metal_log.rb
+++ b/src/metal_log.rb
@@ -56,11 +56,8 @@ module Metalware
     end
 
     def warn(msg)
-      if strict?
-        raise StrictWarningError, msg
-      elsif !quiet?
-        Output.warning "warning: #{msg}" unless quiet?
-      end
+      raise StrictWarningError, msg if strict?
+      print_warning(msg)
       super(msg)
     end
 
@@ -72,6 +69,11 @@ module Metalware
 
     def quiet?
       self.class.quiet
+    end
+
+    def print_warning(msg)
+      return if quiet?
+      Output.warning "warning: #{msg}"
     end
   end
 end


### PR DESCRIPTION
Based on #421, please merge it first.

To reduces the screen noise, warnings are now only printed to the screen the first time they occur. After this, they are still logged to the file but will not be shown to the user.

This provides a happy median of recording how often a warning is being issued but only showing the relevant information to the user.

Fixes #182 