### PR TITLE
Fix invalid named zone file comments

### DIFF
--- a/spec/managed_file_spec.rb
+++ b/spec/managed_file_spec.rb
@@ -37,5 +37,17 @@ RSpec.describe Metalware::ManagedFile do
 
       it_behaves_like 'includes managed file markers', '#'
     end
+
+    context "when `comment_char: ';'` option passed" do
+      subject do
+        described_class.content(
+          managed_file,
+          rendered_content,
+          comment_char: ';'
+        )
+      end
+
+      it_behaves_like 'includes managed file markers', ';'
+    end
   end
 end

--- a/spec/managed_file_spec.rb
+++ b/spec/managed_file_spec.rb
@@ -1,0 +1,41 @@
+
+# frozen_string_literal: true
+
+require 'managed_file'
+
+RSpec.describe Metalware::ManagedFile do
+  describe '#content' do
+    let :managed_file { Tempfile.new }
+    let :rendered_content { 'content' }
+
+    RSpec.shared_examples 'includes managed file markers' do |comment_char|
+      marker_comment_regex = /#{comment_char}{3,}/
+
+      it "includes start marker with `#{comment_char}` as comment character" do
+        expect(subject).to match(
+          /#{marker_comment_regex} METALWARE_START #{marker_comment_regex}/
+        )
+      end
+
+      it "includes end marker with `#{comment_char}` as comment character" do
+        expect(subject).to match(
+          /#{marker_comment_regex} METALWARE_END #{marker_comment_regex}/
+        )
+      end
+
+      it "includes managed file info with `#{comment_char}` as comment character" do
+        expect(subject).to include(
+          "#{comment_char} This section of this file is managed by Alces Metalware"
+        )
+      end
+    end
+
+    context 'when no `comment_char` option passed' do
+      subject do
+        described_class.content(managed_file, rendered_content)
+      end
+
+      it_behaves_like 'includes managed file markers', '#'
+    end
+  end
+end

--- a/spec/staging_spec.rb
+++ b/spec/staging_spec.rb
@@ -133,16 +133,16 @@ RSpec.describe Metalware::Staging do
         expected_start_marker = [
           comment_char,
           Metalware::ManagedFile::MANAGED_START_MARKER,
-          comment_char
+          comment_char,
         ].join(' ')
 
         expected_end_marker = [
           comment_char,
           Metalware::ManagedFile::MANAGED_END_MARKER,
-          comment_char
+          comment_char,
         ].join(' ')
 
-        it "writes the managed file content with `#{comment_char}` as comment character" do
+        it "writes the managed file content with `#{comment_char}` as comment char" do
           content = read_managed_content
           expect(content.first).to include(expected_start_marker)
           expect(content.last).to include(expected_end_marker)
@@ -186,12 +186,11 @@ RSpec.describe Metalware::Staging do
 
       context "when `comment_char: ';'` option set for file" do
         let(:additional_options) do
-          {comment_char: ';'}
+          { comment_char: ';' }
         end
 
         it_behaves_like 'writes managed file', ';'
       end
-
     end
   end
 end

--- a/spec/staging_spec.rb
+++ b/spec/staging_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe Metalware::Staging do
 
       it 'writes the managed file content and flags' do
         content = read_managed_content
-        expect(content.first).to eq(Metalware::ManagedFile::MANAGED_START)
-        expect(content.last).to eq(Metalware::ManagedFile::MANAGED_END)
+        expect(content.first).to include(Metalware::ManagedFile::MANAGED_START_MARKER)
+        expect(content.last).to include(Metalware::ManagedFile::MANAGED_END_MARKER)
         expect(content).to include(managed_content)
       end
 

--- a/spec/staging_spec.rb
+++ b/spec/staging_spec.rb
@@ -184,6 +184,14 @@ RSpec.describe Metalware::Staging do
         it_behaves_like 'writes managed file', '#'
       end
 
+      context "when `comment_char: ';'` option set for file" do
+        let(:additional_options) do
+          {comment_char: ';'}
+        end
+
+        it_behaves_like 'writes managed file', ';'
+      end
+
     end
   end
 end

--- a/src/dns/named.rb
+++ b/src/dns/named.rb
@@ -90,6 +90,7 @@ module Metalware
           FilePath.template_path("named/#{direction}", node: alces.domain),
           FilePath.named_zone(zone_name),
           dynamic: dynamic_namespace,
+          comment_char: ';',
           **staging_options
         )
       end

--- a/src/managed_file.rb
+++ b/src/managed_file.rb
@@ -4,24 +4,24 @@
 module Metalware
   class ManagedFile
     MANAGED_START_MARKER = 'METALWARE_START'
-    MANAGED_START = "########## #{MANAGED_START_MARKER} ##########"
     MANAGED_END_MARKER = 'METALWARE_END'
-    MANAGED_END = "########## #{MANAGED_END_MARKER} ##########"
-    MANAGED_COMMENT = Utils.commentify(
-      <<-EOF.squish
+    MANAGED_COMMENT_TEXT = <<-EOF.squish
       This section of this file is managed by Alces Metalware. Any changes made
       to this file between the #{MANAGED_START_MARKER} and
       #{MANAGED_END_MARKER} markers may be lost; you should make any changes
       you want to persist outside of this section or to the template directly.
     EOF
-    )
 
     class << self
-      def content(managed_file, rendered_content)
+      def content(managed_file, rendered_content, comment_char: '#')
         pre, post = split_on_managed_section(
-          current_file_contents(managed_file)
+          current_file_contents(managed_file), comment_char: comment_char
         )
-        [pre, managed_section(rendered_content.strip), post].join
+        new_managed_section = managed_section(
+          rendered_content.strip,
+          comment_char: comment_char
+        )
+        [pre, new_managed_section, post].join
       end
 
       private
@@ -30,23 +30,34 @@ module Metalware
         File.exist?(file) ? File.read(file).strip : ''
       end
 
-      def split_on_managed_section(file_contents)
-        if file_contents.include? MANAGED_START
-          pre, rest = file_contents.split(MANAGED_START)
-          _, post = rest.split(MANAGED_END)
+      def split_on_managed_section(file_contents, comment_char:)
+        managed_start = comment_wrapped(MANAGED_START_MARKER, comment_char: comment_char)
+        managed_end = comment_wrapped(MANAGED_END_MARKER, comment_char: comment_char)
+        if file_contents.include? managed_start
+          pre, rest = file_contents.split(managed_start)
+          _, post = rest.split(managed_end)
           [pre, post]
         else
           [file_contents + "\n\n", nil]
         end
       end
 
-      def managed_section(rendered_template)
+      def managed_section(rendered_template, comment_char:)
         [
-          MANAGED_START,
-          MANAGED_COMMENT,
+          comment_wrapped(MANAGED_START_MARKER, comment_char: comment_char),
+          managed_comment(comment_char: comment_char),
           rendered_template,
-          MANAGED_END,
+          comment_wrapped(MANAGED_END_MARKER, comment_char: comment_char),
         ].join("\n") + "\n"
+      end
+
+      def comment_wrapped(marker, comment_char:)
+        comment_chars = comment_char * 10
+        [comment_chars, marker, comment_chars].join(' ')
+      end
+
+      def managed_comment(comment_char:)
+        Utils.commentify(MANAGED_COMMENT_TEXT, comment_char: comment_char)
       end
     end
   end

--- a/src/managed_file.rb
+++ b/src/managed_file.rb
@@ -24,7 +24,7 @@ module Metalware
           @managed_file = managed_file
           @rendered_content = rendered_content
           @comment_char = comment_char
-	end
+        end
 
         def create
           pre, post = split_on_managed_section(current_file_contents)
@@ -34,7 +34,8 @@ module Metalware
 
         private
 
-        attr_reader :managed_file,
+        attr_reader \
+          :managed_file,
           :rendered_content,
           :comment_char
 
@@ -78,7 +79,6 @@ module Metalware
           Utils.commentify(MANAGED_COMMENT_TEXT, comment_char: comment_char)
         end
       end
-
     end
   end
 end

--- a/src/managed_file.rb
+++ b/src/managed_file.rb
@@ -13,52 +13,72 @@ module Metalware
     EOF
 
     class << self
-      def content(managed_file, rendered_content, comment_char: '#')
-        pre, post = split_on_managed_section(
-          current_file_contents(managed_file), comment_char: comment_char
-        )
-        new_managed_section = managed_section(
-          rendered_content.strip,
-          comment_char: comment_char
-        )
-        [pre, new_managed_section, post].join
+      def content(*args)
+        NewContent.new(*args).create
       end
 
       private
 
-      def current_file_contents(file)
-        File.exist?(file) ? File.read(file).strip : ''
-      end
+      class NewContent
+        def initialize(managed_file, rendered_content, comment_char: '#')
+          @managed_file = managed_file
+          @rendered_content = rendered_content
+          @comment_char = comment_char
+	end
 
-      def split_on_managed_section(file_contents, comment_char:)
-        managed_start = comment_wrapped(MANAGED_START_MARKER, comment_char: comment_char)
-        managed_end = comment_wrapped(MANAGED_END_MARKER, comment_char: comment_char)
-        if file_contents.include? managed_start
-          pre, rest = file_contents.split(managed_start)
-          _, post = rest.split(managed_end)
-          [pre, post]
-        else
-          [file_contents + "\n\n", nil]
+        def create
+          pre, post = split_on_managed_section(current_file_contents)
+          new_managed_section = managed_section(rendered_content.strip)
+          [pre, new_managed_section, post].join
+        end
+
+        private
+
+        attr_reader :managed_file,
+          :rendered_content,
+          :comment_char
+
+        def current_file_contents
+          File.exist?(managed_file) ? File.read(managed_file).strip : ''
+        end
+
+        def split_on_managed_section(file_contents)
+          if file_contents.include? managed_start
+            pre, rest = file_contents.split(managed_start)
+            _, post = rest.split(managed_end)
+            [pre, post]
+          else
+            [file_contents + "\n\n", nil]
+          end
+        end
+
+        def managed_section(rendered_template)
+          [
+            managed_start,
+            managed_comment,
+            rendered_template,
+            managed_end,
+          ].join("\n") + "\n"
+        end
+
+        def managed_start
+          comment_wrapped(MANAGED_START_MARKER)
+        end
+
+        def managed_end
+          comment_wrapped(MANAGED_END_MARKER)
+        end
+
+        def comment_wrapped(marker)
+          comment_chars = comment_char * 10
+          [comment_chars, marker, comment_chars].join(' ')
+        end
+
+        def managed_comment
+          Utils.commentify(MANAGED_COMMENT_TEXT, comment_char: comment_char)
         end
       end
 
-      def managed_section(rendered_template, comment_char:)
-        [
-          comment_wrapped(MANAGED_START_MARKER, comment_char: comment_char),
-          managed_comment(comment_char: comment_char),
-          rendered_template,
-          comment_wrapped(MANAGED_END_MARKER, comment_char: comment_char),
-        ].join("\n") + "\n"
-      end
-
-      def comment_wrapped(marker, comment_char:)
-        comment_chars = comment_char * 10
-        [comment_chars, marker, comment_chars].join(' ')
-      end
-
-      def managed_comment(comment_char:)
-        Utils.commentify(MANAGED_COMMENT_TEXT, comment_char: comment_char)
-      end
     end
   end
 end

--- a/src/staging.rb
+++ b/src/staging.rb
@@ -99,9 +99,7 @@ module Metalware
     def managed_file_content(data, rendered_content)
       managed_file_content_args = [data.sync, rendered_content]
       if data.comment_char
-        managed_file_content_args.push({
-          comment_char: data.comment_char
-        })
+        managed_file_content_args.push(comment_char: data.comment_char)
       end
       ManagedFile.content(*managed_file_content_args)
     end

--- a/src/staging.rb
+++ b/src/staging.rb
@@ -93,7 +93,17 @@ module Metalware
 
     def file_content(data)
       raw = File.read(FilePath.staging(data.sync))
-      data.managed ? ManagedFile.content(data.sync, raw) : raw
+      data.managed ? managed_file_content(data, raw) : raw
+    end
+
+    def managed_file_content(data, rendered_content)
+      managed_file_content_args = [data.sync, rendered_content]
+      if data.comment_char
+        managed_file_content_args.push({
+          comment_char: data.comment_char
+        })
+      end
+      ManagedFile.content(*managed_file_content_args)
     end
   end
 end


### PR DESCRIPTION
- Add test coverage for existing `ManagedFile.content` behaviour.

- Add ability to specify different `comment_char` to use when rendering `ManagedFile.content` markers and info.

- Refactor `ManagedFile` to reduce duplication following this addition.

- Allow specifying `comment_char` to use when rendering managed files, which will then be passed through to above.

- Use this new functionality to fix #433 by specifying correct comment character (`;`) when rendering these files.