### PR TITLE
Switch NetworkAdapter asset to use new format

### DIFF
--- a/data/asset_types/network_adapter.yaml
+++ b/data/asset_types/network_adapter.yaml
@@ -5,16 +5,12 @@ ports:
   - network: null
     mac: null
     switch: null
-    port: null
   - network: null
     mac: null
     switch: null
-    port: null
   - network: null
     mac: null
     switch: null
-    port: null
   - network: null
     mac: null
     switch: null
-    port: null

--- a/data/asset_types/network_adapter.yaml
+++ b/data/asset_types/network_adapter.yaml
@@ -2,23 +2,19 @@ manufacturer: null
 model: null
 serial: null
 ports:
-  em1:
-    network: null
+  - network: null
     mac: null
     switch: null
     port: null
-  em2:
-    network: null
+  - network: null
     mac: null
     switch: null
     port: null
-  em3:
-    network: null
+  - network: null
     mac: null
     switch: null
     port: null
-  em4:
-    network: null
+  - network: null
     mac: null
     switch: null
     port: null


### PR DESCRIPTION
As discussed earlier @ColonelPanicks:

> The interface is a property of a particular node's connection to a network, via a network adapter port, rather than a property of the port itself.
> 
> Therefore we have decided to store network adapter ports as an array rather than a hash including the interface, and the canonical source for interface names will be in each node's network configs.

A pretty trivial change but couple of minor things to consider before merging:

1. Are the `port` keys in this file relevant any more? They aren't used in any of the clusters I have access to, and I'm guessing this is the same information that we now have from the (1-based) index of the port in the `ports` array.

2. Do we need to make any corresponding repo changes following this change?