### PR TITLE
Fix build methods

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -27,7 +27,14 @@ IFS=$'\n\t'
 # Install RVM.
 gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 curl -sSL https://get.rvm.io | bash -s stable
-# XXX Need to log out and in again here for script to work on first run.
+
+# Enable RVM, which is less strict about letting commands fail, variables be
+# unset etc. than this script.
+set +euo pipefail
+# shellcheck disable=SC1091
+source /etc/profile.d/rvm.sh
+set -euo pipefail
+
 rvm rvmrc warning ignore allGemfiles
 
 # Required for rugged gem.
@@ -45,6 +52,7 @@ yum install libvirt-devel -y
 # Install Ruby and gems.
 rvm install ruby-2.4.1
 cd .. && cd -  # Let RVM automatically use correct Ruby for dir.
-# XXX Need to log out and in again here for script to work on first run.
 gem install bundler
 bundle install
+
+echo "You need to log out and in again and then \`cd $PWD && bin/metal\` should work!"

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -168,6 +168,14 @@ RSpec.describe Metalware::Namespaces::Node do
         it 'returns false when local? is called' do
           expect(node.local?).to eq(false)
         end
+
+        it 'uses correct build method class when build_method specified as a string' do
+          mock_build_method('uefi-kickstart')
+
+          expect(node.build_method.class).to eq(
+            Metalware::BuildMethods::Kickstarts::UEFI
+          )
+        end
       end
 
       context "with the 'local' node" do

--- a/src/namespaces/node.rb
+++ b/src/namespaces/node.rb
@@ -135,7 +135,7 @@ module Metalware
       end
 
       def build_method_class
-        case config.build_method
+        case config.build_method&.to_sym
         when :local
           msg = "node '#{name}' can not use the local build"
           raise InvalidLocalBuild, msg


### PR DESCRIPTION
This PR contains a fix for #439, which is also a fix for the the more general issue that all non-Pxelinux/Kickstart build methods were broken. Also included are some `setup` script tweaks to make this possible to work the first time it is run after syncing Metalware to a machine.

@ColonelPanicks can you try this out and let me know if this does/doesn't fix your original issue? @WilliamMcCumstie if this does fix #439 then I'll merge it unless there's some underlying reason why we thought we didn't need the original `to_sym`ing (and so this might need deeper investigation; see https://github.com/alces-software/metalware/commit/e01b30ef39ff9df3ef9c8032fba8e8e685757068#r30002376).