### PR TITLE
Render and run hook scripts on build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development do
 end
 
 # Gems added for GUI app.
-gem 'bootstrap', '~> 4.0.0.beta'
+gem 'bootstrap'
 gem 'concurrent-ruby', require: 'concurrent'
 gem 'jquery-rails' # Required for Bootstrap.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,10 +60,10 @@ GEM
       tzinfo (~> 1.1)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.2.0)
+    autoprefixer-rails (9.1.4)
       execjs
     bindex (0.5.0)
-    bootstrap (4.0.0)
+    bootstrap (4.1.3)
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
@@ -105,7 +105,7 @@ GEM
     erubi (1.7.1)
     execjs (2.7.0)
     fakefs (0.13.3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashie (3.5.7)
@@ -144,7 +144,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
-    popper_js (1.12.9)
+    popper_js (1.14.3)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -210,7 +210,7 @@ GEM
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     rugged (0.27.0)
-    sass (3.5.6)
+    sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -267,7 +267,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bootstrap (~> 4.0.0.beta)
+  bootstrap
   byebug
   colorize
   commander!
@@ -308,4 +308,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/scripts/install
+++ b/scripts/install
@@ -84,6 +84,7 @@ mkdir -p /var/lib/metalware/repo
 mkdir -p /var/lib/metalware/plugins
 mkdir -p /var/lib/metalware/answers/{groups,nodes}
 mkdir -p /var/lib/metalware/assets
+mkdir -p /var/lib/metalware/build_hooks
 mkdir -p /etc/named
 touch /etc/named/metalware.conf
 chmod a+rw /var/lib/metalware/events

--- a/src/build_methods/build_method.rb
+++ b/src/build_methods/build_method.rb
@@ -22,7 +22,11 @@ module Metalware
         regex = File.join(FilePath.build_hooks, '*')
         Dir.glob(regex).each do |src|
           rendered_content = Templater.render(node, src)
-          puts rendered_content
+          temp_file = Tempfile.new("#{node.name}-#{File.basename(src)}")
+          temp_file.write rendered_content
+          temp_file.close
+          puts SystemCommand.run("bash #{temp_file.path}")
+          temp_file.unlink
         end
       end
 

--- a/src/build_methods/build_method.rb
+++ b/src/build_methods/build_method.rb
@@ -18,7 +18,11 @@ module Metalware
       end
 
       def start_hook
-        # Runs at the start of the build process
+        # Renders the build hook scripts and runs them
+        regex = File.join(FilePath.build_hooks, '*')
+        Dir.glob(regex).each do |file|
+          puts file
+        end
       end
 
       def complete_hook

--- a/src/build_methods/build_method.rb
+++ b/src/build_methods/build_method.rb
@@ -20,8 +20,9 @@ module Metalware
       def start_hook
         # Renders the build hook scripts and runs them
         regex = File.join(FilePath.build_hooks, '*')
-        Dir.glob(regex).each do |file|
-          puts file
+        Dir.glob(regex).each do |src|
+          rendered_content = Templater.render(node, src)
+          puts rendered_content
         end
       end
 

--- a/src/build_methods/kickstarts/kickstart.rb
+++ b/src/build_methods/kickstarts/kickstart.rb
@@ -8,10 +8,12 @@ module Metalware
     module Kickstarts
       class Kickstart < BuildMethod
         def start_hook
+          super
           render_pxelinux(firstboot: true)
         end
 
         def complete_hook
+          super
           render_pxelinux(firstboot: false)
         end
 

--- a/src/build_methods/local.rb
+++ b/src/build_methods/local.rb
@@ -8,6 +8,7 @@ module Metalware
   module BuildMethods
     class Local < BuildMethod
       def start_hook
+        super
         rendered_local_template =
           file_path.template_save_path(:local, node: node)
         FileUtils.chmod 'u+x', rendered_local_template

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -176,6 +176,10 @@ module Metalware
         File.join(cache, 'templates', name)
       end
 
+      def build_hooks
+        File.join(metalware_data, 'build_hooks')
+      end
+
       private
 
       def record(record_dir, types_dir, name)


### PR DESCRIPTION
This PR fixes #427. It will render all the scripts contained within `/v/l/m/build_hooks` for each node when the build starts. These scripts are than ran on the host machine using `bash`.

Also resolved https://nvd.nist.gov/vuln/detail/CVE-2018-14042 by updating the bootstrap gem.