### PR TITLE
Make test helper functions available in all tests

### DIFF
--- a/spec/asset_builder_spec.rb
+++ b/spec/asset_builder_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Metalware::AssetBuilder do
 
   describe '#push_asset' do
     before do
-      SpecUtils.enable_output_to_stderr
+      enable_output_to_stderr
       push_test_asset
     end
 

--- a/spec/build_files_retrievers/cache_spec.rb
+++ b/spec/build_files_retrievers/cache_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Metalware::BuildFilesRetrievers::Cache do
   end
 
   before do
-    SpecUtils.use_mock_determine_hostip_script(self)
+    use_mock_determine_hostip_script
   end
 
   def hash_url(url)
@@ -42,7 +42,7 @@ RSpec.describe Metalware::BuildFilesRetrievers::Cache do
       FileSystem.root_setup do |fs|
         fs.with_clone_fixture('configs/unit-test.yaml')
       end
-      SpecUtils.use_unit_test_config(self)
+      use_unit_test_config
       allow(Metalware::Input).to receive(:download)
         .and_wrap_original do |_, _, to_path|
         FileUtils.touch(to_path)
@@ -136,7 +136,7 @@ RSpec.describe Metalware::BuildFilesRetrievers::Cache do
     end
 
     context 'when error retrieving URL file' do
-      let!(:http_error) { SpecUtils.fake_download_error(self) }
+      let!(:http_error) { fake_download_error }
 
       it 'adds error to file entry' do
         retrieved_files = subject.retrieve(test_node)

--- a/spec/command_helpers/configure_command_spec.rb
+++ b/spec/command_helpers/configure_command_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Metalware::CommandHelpers::ConfigureCommand do
 
   describe 'option handling' do
     before do
-      SpecUtils.use_mock_genders(self)
-      SpecUtils.mock_validate_genders_success(self)
+      use_mock_genders
+      mock_validate_genders_success
     end
 
     it 'passes answers through to configurator as hash' do

--- a/spec/commands/asset/add_spec.rb
+++ b/spec/commands/asset/add_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Metalware::Commands::Asset::Add do
   it_behaves_like 'record add command'
 
   it 'warns if the type does not exist' do
-    SpecUtils.enable_output_to_stderr
+    enable_output_to_stderr
     expect do
       Metalware::Utils.run_command(described_class,
                                    'missing-type',

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Metalware::Commands::Build do
   end
 
   before do
-    SpecUtils.use_mock_dependency(self)
+    use_mock_dependency
   end
 
   context 'when called without group argument' do

--- a/spec/commands/configure/domain_spec.rb
+++ b/spec/commands/configure/domain_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Metalware::Commands::Configure::Domain do
   end
 
   before do
-    SpecUtils.mock_validate_genders_success(self)
+    mock_validate_genders_success
   end
 
   it 'creates correct configurator' do

--- a/spec/commands/configure/group_spec.rb
+++ b/spec/commands/configure/group_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Metalware::Commands::Configure::Group do
   end
 
   before do
-    SpecUtils.mock_validate_genders_success(self)
+    mock_validate_genders_success
   end
 
   it 'creates correct configurator' do

--- a/spec/commands/configure/node_spec.rb
+++ b/spec/commands/configure/node_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Metalware::Commands::Configure::Node do
   end
 
   before do
-    SpecUtils.use_mock_genders(self)
-    SpecUtils.mock_validate_genders_success(self)
+    use_mock_genders
+    mock_validate_genders_success
     allow(Metalware::Namespaces::Alces).to receive(:new).and_return(alces)
   end
 

--- a/spec/commands/each_spec.rb
+++ b/spec/commands/each_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Metalware::Commands::Each do
       fs.with_genders_fixtures
       fs.with_clone_fixture('configs/unit-test.yaml')
     end
-    SpecUtils.use_unit_test_config(self)
+    use_unit_test_config
   end
 
   let(:groups) do

--- a/spec/commands/remove/group_spec.rb
+++ b/spec/commands/remove/group_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Metalware::Commands::Remove::Group do
   let(:deleted_files) { initial_files - answer_files }
 
   before do
-    SpecUtils.mock_validate_genders_success(self)
+    mock_validate_genders_success
     filesystem.test { initial_files }
   end
 

--- a/spec/dependency_specifications_spec.rb
+++ b/spec/dependency_specifications_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Metalware::DependencySpecifications do
   let(:alces) { Metalware::Namespaces::Alces.new }
 
   before do
-    SpecUtils.use_mock_genders(self)
+    use_mock_genders
     allow_any_instance_of(Metalware::Namespaces::Node).to \
       receive(:group).and_return(double('group', name: 'testnodes'))
   end

--- a/spec/namespaces/domain_spec.rb
+++ b/spec/namespaces/domain_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Metalware::Namespaces::Domain do
 
   include_examples Metalware::Namespaces::HashMergerNamespace
 
-  before { SpecUtils.use_mock_determine_hostip_script(self) }
+  before { use_mock_determine_hostip_script }
 
   it 'has a hostip' do
     expect(alces.domain.hostip).to eq('1.2.3.4')

--- a/spec/namespaces/node_spec.rb
+++ b/spec/namespaces/node_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Metalware::Namespaces::Node do
         receive(:all_nodes).and_return(node_array)
 
       # Spoofs the hostip
-      SpecUtils.use_mock_determine_hostip_script(self)
+      use_mock_determine_hostip_script
     end
 
     it 'can access the node name' do

--- a/spec/slow/status/job_spec.rb
+++ b/spec/slow/status/job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Metalware::Status::Job do
     described_class.send(:define_method, :bash_sleep, lambda {
       run_bash('sleep 100')
     })
-    SpecUtils.use_mock_genders(self)
+    use_mock_genders
   end
 
   after do

--- a/spec/slow/status/monitor_spec.rb
+++ b/spec/slow/status/monitor_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Metalware::Status::Monitor do
 
   before do
     FileSystem.root_setup(&:with_genders_fixtures)
-    SpecUtils.use_mock_genders(self)
+    use_mock_genders
     @cmds = [:ping, :power]
     @m_input = { nodes: nodes, cmds: @cmds, thread_limit: 10, time_limit: 20 }
     @monitor = described_class.new(@m_input)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,6 +56,8 @@ require 'filesystem'
 
 FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')
 
+require 'spec_utils'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -155,4 +157,7 @@ RSpec.configure do |config|
   config.after do
     FileSystem.root_file_system_config(reset: true)
   end
+
+  # Make our test helper functions available in all tests.
+  config.include SpecUtils
 end

--- a/spec/spec_utils.rb
+++ b/spec/spec_utils.rb
@@ -27,78 +27,62 @@ require 'constants'
 require 'dependency'
 
 module SpecUtils
-  # Use `instance_exec` in many functions in this module to execute blocks the
-  # context of the passed RSpec example group.
-  class << self
-    # Mocks.
+  # Mocks.
 
-    def mock_validate_genders_success(example_group)
-      mock_validate_genders(example_group, true, '')
-    end
+  def mock_validate_genders_success
+    mock_validate_genders(true, '')
+  end
 
-    def use_mock_genders(example_group, genders_file: 'genders/default')
-      genders_path = File.join(FIXTURES_PATH, genders_file)
+  def use_mock_genders(genders_file: 'genders/default')
+    genders_path = File.join(FIXTURES_PATH, genders_file)
 
-      example_group.instance_exec do
-        nodeattr_command = 'Metalware::Constants::NODEATTR_COMMAND'
-        stub_const(nodeattr_command, "nodeattr -f #{genders_path}")
-      end
-    end
+    nodeattr_command = 'Metalware::Constants::NODEATTR_COMMAND'
+    stub_const(nodeattr_command, "nodeattr -f #{genders_path}")
+  end
 
-    def use_unit_test_config(example_group)
-      example_group.instance_exec do
-        stub_const(
-          'Metalware::Constants::DEFAULT_CONFIG_PATH',
-          SpecUtils.fixtures_config('unit-test.yaml')
-        )
-      end
-    end
+  def use_unit_test_config
+    stub_const(
+      'Metalware::Constants::DEFAULT_CONFIG_PATH',
+      fixtures_config('unit-test.yaml')
+    )
+  end
 
-    def use_mock_determine_hostip_script(example_group)
-      example_group.instance_exec do
-        stub_const(
-          'Metalware::Constants::METALWARE_INSTALL_PATH',
-          FIXTURES_PATH
-        )
-      end
-    end
+  def use_mock_determine_hostip_script
+    stub_const(
+      'Metalware::Constants::METALWARE_INSTALL_PATH',
+      FIXTURES_PATH
+    )
+  end
 
-    def use_mock_dependency(example_group)
-      example_group.instance_exec do
-        allow_any_instance_of(
-          Metalware::Dependency
-        ).to receive(:enforce)
-      end
-    end
+  def use_mock_dependency
+    allow_any_instance_of(
+      Metalware::Dependency
+    ).to receive(:enforce)
+  end
 
-    def fake_download_error(example_group)
-      http_error = "418 I'm a teapot"
-      example_group.instance_exec do
-        allow(Metalware::Input).to receive(:download).and_raise(
-          OpenURI::HTTPError.new(http_error, nil)
-        )
-      end
-      http_error
-    end
+  def fake_download_error
+    http_error = "418 I'm a teapot"
+    allow(Metalware::Input).to receive(:download).and_raise(
+      OpenURI::HTTPError.new(http_error, nil)
+    )
+    http_error
+  end
 
-    # Other shared utils.
+  # Other shared utils.
 
-    def fixtures_config(config_file)
-      File.join(FIXTURES_PATH, 'configs', config_file)
-    end
+  def fixtures_config(config_file)
+    File.join(FIXTURES_PATH, 'configs', config_file)
+  end
 
-    def enable_output_to_stderr
-      $rspec_suppress_output_to_stderr = false
-    end
+  def enable_output_to_stderr
+    $rspec_suppress_output_to_stderr = false
+  end
 
-    private
+  private
 
-    def mock_validate_genders(example_group, valid, error)
-      example_group.instance_exec do
-        allow(Metalware::NodeattrInterface).to receive(
-          :validate_genders_file
-        ).and_return([valid, error])
-      end
-    end
+  def mock_validate_genders(valid, error)
+    allow(Metalware::NodeattrInterface).to receive(
+      :validate_genders_file
+    ).and_return([valid, error])
   end
 end


### PR DESCRIPTION
Use RSpec's `config.include` feature
(https://relishapp.com/rspec/rspec-core/docs/helper-methods/define-helper-methods-in-a-module#include-a-module-in-all-example-groups)
to make our SpecUtils helper functions be available in all tests.

This means calls to these functions no longer need to pass in the
current example group (when we want to use RSpec assertions etc. within
these), and makes defining these functions simpler; in turn this should
make it simpler to extract shared behaviour across test files.

Going to merge this straight through once CI passes, but feel free to comment.