### PR TITLE
Generic namespace data loading

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -85,6 +85,7 @@ mkdir -p /var/lib/metalware/plugins
 mkdir -p /var/lib/metalware/answers/{groups,nodes}
 mkdir -p /var/lib/metalware/assets
 mkdir -p /var/lib/metalware/build_hooks
+mkdir -p /var/lib/metalware/data
 mkdir -p /etc/named
 touch /etc/named/metalware.conf
 chmod a+rw /var/lib/metalware/events

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -197,6 +197,7 @@ class FileSystem
       '/var/lib/metalware/answers/groups',
       '/var/lib/metalware/answers/nodes',
       '/var/lib/metalware/assets',
+      '/var/lib/metalware/data',
       '/var/named',
       '/var/log/metalware',
       File.join(Metalware::Constants::METALWARE_INSTALL_PATH, 'templates'),

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -149,14 +149,6 @@ RSpec.describe Metalware::Namespaces::Alces do
     end
   end
 
-  describe '#hunter' do
-    context 'when no hunter cache file present' do
-      it 'loads a empty Hashie' do
-        expect(alces.hunter.to_h).to eq(Hashie::Mash.new)
-      end
-    end
-  end
-
   describe '#data' do
     it 'provides access to data in corresponding data directory file' do
       data_file_path = Metalware::FilePath.namespace_data_file('mydata')

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -157,6 +157,36 @@ RSpec.describe Metalware::Namespaces::Alces do
     end
   end
 
+  describe '#data' do
+    it 'provides access to data in corresponding data directory file' do
+      data_file_path = Metalware::FilePath.namespace_data_file('mydata')
+      Metalware::Data.dump(data_file_path, {foo: {bar: 'baz'}})
+
+      expect(alces.data.mydata.foo.bar).to eq('baz')
+      expect(alces.data.mydata.non_existent).to be nil
+      expect(alces.data.mydata).to be_a(Hashie::Mash)
+    end
+
+    it 'gives useful error when try to access data for non-existent file' do
+      data_file_path = Metalware::FilePath.namespace_data_file('non_existent')
+
+      expect do
+        alces.data.non_existent.foo
+      end.to raise_error(
+        Metalware::UserMetalwareError,
+        "Requested data file doesn't exist: #{data_file_path}"
+      )
+    end
+
+    it 'appropriately handles respond_to? as whether data file exists' do
+      existent_path = Metalware::FilePath.namespace_data_file('existent')
+      FileUtils.touch(existent_path)
+
+      expect(alces.data).to respond_to(:existent)
+      expect(alces.data).not_to respond_to(:non_existent)
+    end
+  end
+
   context 'when a template returns nil' do
     let(:metal_log) { instance_spy(Metalware::MetalLog) }
 

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Metalware::Namespaces::Alces do
   describe '#data' do
     it 'provides access to data in corresponding data directory file' do
       data_file_path = Metalware::FilePath.namespace_data_file('mydata')
-      Metalware::Data.dump(data_file_path, {foo: {bar: 'baz'}})
+      Metalware::Data.dump(data_file_path, foo: { bar: 'baz' })
 
       expect(alces.data.mydata.foo.bar).to eq('baz')
       expect(alces.data.mydata.non_existent).to be nil

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -36,7 +36,7 @@ module Metalware
     METALWARE_DATA_PATH = '/var/lib/metalware'
     CACHE_PATH = File.join(METALWARE_DATA_PATH, 'cache')
     NAMESPACE_DATA_PATH = File.join(METALWARE_DATA_PATH, 'data')
-    HUNTER_PATH = File.join(CACHE_PATH, 'hunter.yaml')
+    HUNTER_PATH = File.join(NAMESPACE_DATA_PATH, 'hunter.yaml')
     GROUP_CACHE_PATH = File.join(CACHE_PATH, 'groups.yaml')
     INVALID_RENDERED_GENDERS_PATH = File.join(CACHE_PATH, 'invalid.genders')
     RENDERED_DIR_PATH = File.join(METALWARE_DATA_PATH, 'rendered')

--- a/src/constants.rb
+++ b/src/constants.rb
@@ -35,6 +35,7 @@ module Metalware
 
     METALWARE_DATA_PATH = '/var/lib/metalware'
     CACHE_PATH = File.join(METALWARE_DATA_PATH, 'cache')
+    NAMESPACE_DATA_PATH = File.join(METALWARE_DATA_PATH, 'data')
     HUNTER_PATH = File.join(CACHE_PATH, 'hunter.yaml')
     GROUP_CACHE_PATH = File.join(CACHE_PATH, 'groups.yaml')
     INVALID_RENDERED_GENDERS_PATH = File.join(CACHE_PATH, 'invalid.genders')

--- a/src/file_path.rb
+++ b/src/file_path.rb
@@ -175,6 +175,13 @@ module Metalware
         File.join(metalware_data, 'build_hooks')
       end
 
+      def namespace_data_file(name)
+        File.join(
+          Constants::NAMESPACE_DATA_PATH,
+          "#{name}.yaml"
+        )
+      end
+
       private
 
       def record(record_dir, types_dir, name)

--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -103,11 +103,11 @@ module Metalware
               # error message if something else goes wrong in this class, so I
               # could eventually come to regret this.
               raise UserMetalwareError,
-                "Requested data file doesn't exist: #{data_file_path}"
+                    "Requested data file doesn't exist: #{data_file_path}"
             end
           end
 
-          def respond_to?(message)
+          def respond_to_missing?(message, _include_all = false)
             data_file_path = namespace_data_file(message)
             File.exist?(data_file_path)
           end

--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -39,21 +39,6 @@ module Metalware
           end
         end
 
-        def hunter
-          @hunter ||= begin
-            if File.exist? Constants::HUNTER_PATH
-              Hashie::Mash.load(Constants::HUNTER_PATH)
-            else
-              warning = \
-                "#{Constants::HUNTER_PATH} does not exist; need to run " \
-                "'metal hunter' first. Falling back to empty hash for" \
-                'alces.hunter.'
-              MetalLog.warn warning
-              Hashie::Mash.new
-            end
-          end
-        end
-
         def data
           DataFileNamespace.new
         end

--- a/src/namespaces/mixins/alces_static.rb
+++ b/src/namespaces/mixins/alces_static.rb
@@ -95,6 +95,13 @@ module Metalware
             if respond_to?(message)
               Hashie::Mash.load(data_file_path)
             else
+              # Normally `method_missing` should call `super` if it doesn't
+              # `respond_to?` a message. In this case this is a namespace
+              # designed to be used by users writing templates, so give them an
+              # informative error message for what they've probably missed
+              # instead. This does mean though that we could get a confusing
+              # error message if something else goes wrong in this class, so I
+              # could eventually come to regret this.
               raise UserMetalwareError,
                 "Requested data file doesn't exist: #{data_file_path}"
             end


### PR DESCRIPTION
Accessing `alces.data.foo` now provides access within the templating namespace to the YAML data stored in the file `/var/lib/metalware/data/foo.yaml`. This provides a way to make arbitrary new data available within the namespace, which will be useful both as part of the Metalware/Underware split, as well as a feature requested by @ColonelPanicks.

Also made the corresponding change to store the `hunter` data in this new namespace, which means Underware no longer needs to know about `hunter`.